### PR TITLE
set kovan addresses

### DIFF
--- a/src/utils/balancer/constants.ts
+++ b/src/utils/balancer/constants.ts
@@ -1,13 +1,13 @@
 // Config for a local node and subgraph
 const dockerParityAddresses = {
-  authorizer: '0x30Ca53e6e5bEc8B2513ddCfe45eE0F904900F096',
-  vault: '0xBFa16D136bAFEa5a54f581C491be040BA44AF98F',
-  constantProductPoolFactory: '0x26aC322aDa606bA5F3B3E23dB2955fA55d542115',
-  stablecoinPoolFactory: '0x9942784AEb3ECcF6013280A86f0F24dCd785D202',
-  oneToOneSwapValidator: '0x7bf43891B10ce66429d1a101FF0516e1Ab628C3B',
-  tokenFactory: '0xd7ce67992277d157abaB24cd610E1A4AD5292438',
-  weth: '0xB297057e60476438a280686415CBee9a4D949c6B',
-  MockFlashLoanReceiver: '0xD1C8625C3ECCD11d214A8760093959A8237dD710',
+  authorizer: '0x6Bff77238256fFF717e5Cc9A96640dC0D068b14D',
+  vault: '0x293f6758Fe4a4343E367Ac8E6A697eC6315fBEd7',
+  constantProductPoolFactory: '0xE48Aae4178612fdF77af25C83fa1099491A8AD1B',
+  stablecoinPoolFactory: '0xb4F97F452D71C3bba3c30c554305A7250c08b23A',
+  oneToOneSwapValidator: '0x2e7950e645CbA3eD9B376df081F2FA0fE53d30f0',
+  tokenFactory: '0xc9d340Bc37C57e70383b217De2c07FB252E36D55',
+  weth: '0x6c37Fa9557C135dF4323004D3f0549f3e94F112D',
+  MockFlashLoanReceiver: '',
 };
 
 // Config for latest core on Kovan


### PR DESCRIPTION
Changes proposed in this pull request:
- adds new kovan deployment addresses

We have a script that sets the current addresses in the subgraph.yml - we should think of something similar to maintain addresses in this repo across the kovan deploy and the dockerParity development environment. 