### PR TITLE
Keep height stable, change on mouseover, add annotations

### DIFF
--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -37,9 +37,6 @@ export default {
           events: {
             click: (event, chartContext, config) => {
               this.$emit('click', config);
-            },
-            mouseMove: (event, chartContext, config) => {
-              this.$emit('click', config);
             }
           }
         },


### PR DESCRIPTION
* This keeps the mim and max stable just so we can see the line keep stable. I don't think it should be actually hard coded, but we should be basing them on within x% of max and mins of the BPT, not the other graphs
* graph redesigns on mouseover. Performance is now a bit worst, is this because apex charts is truly performance heavy or something else? I suppose computers in 2020 can handle drawing lines in javascript.
* Added some annotations. The vertical line should, of course, follow the reference date. The colored dots would represent when the user had bought or sold tokens. We can make them more discreet.