### PR TITLE
Use Fleek storage directly to check claimable BAL

### DIFF
--- a/src/utils/balancer/claim/index.ts
+++ b/src/utils/balancer/claim/index.ts
@@ -9,18 +9,21 @@ const gateway = process.env.VUE_APP_IPFS_NODE || 'ipfs.io';
 export const constants = {
   1: {
     merkleRedeem: '0x6d19b2bF3A36A61530909Ae65445a906D98A2Fa8',
-    snapshot: 'balancer-team-bucket.storage.fleek.co/balancer-claim/snapshot'
+    snapshot:
+      'https://storageapi.fleek.co/balancer-team-bucket/balancer-claim/snapshot'
   },
   42: {
     merkleRedeem: '0x3bc73D276EEE8cA9424Ecb922375A0357c1833B3',
     snapshot:
-      'balancer-team-bucket.storage.fleek.co/balancer-claim-kovan/snapshot'
+      'https://storageapi.fleek.co/balancer-team-bucket/balancer-claim-kovan/snapshot'
   }
 };
 
 export async function getSnapshot(network) {
   if (constants[network]?.snapshot)
-    return (await ipfsGet(gateway, constants[network].snapshot, 'ipns')) || {};
+    return (
+      (await fetch(constants[network].snapshot).then(res => res.json())) || {}
+    );
   return {};
 }
 


### PR DESCRIPTION
Somehow the IPNS url don't give use the latest state of the document that list all the claim reports, this make the claim amount incorrect, on this PR is switch to Fleek storage directly. 

IPNS link showing 21 weeks
https://ipfs.fleek.co/ipns/balancer-team-bucket.storage.fleek.co/balancer-claim/snapshot

Direct link to Fleek show 22 weeks:
https://storageapi.fleek.co/balancer-team-bucket/balancer-claim/snapshot