### PR TITLE
Fix token image blink

### DIFF
--- a/src/components/Token.vue
+++ b/src/components/Token.vue
@@ -45,7 +45,7 @@ export default {
   },
   watch: {
     token(val, prev) {
-      if (val !== prev) this.error = false;
+      if (val.address !== prev.address) this.error = false;
     }
   }
 };


### PR DESCRIPTION
This fix an issue that was making token image blink when there is a change on the token data (balance etc).