### PR TITLE
Match network indicator color in SettingsPopover to MetaMask

### DIFF
--- a/src/components/SettingsPopover.vue
+++ b/src/components/SettingsPopover.vue
@@ -74,7 +74,7 @@
       </div>
       <div class="mt-4 px-4">
         <div class="flex items-baseline">
-          <h5 v-text="'Slippage tolerance'" />
+          <h5 v-text="'Slippage tolerance'" class="pr-1" />
           <BalTooltip>
             <template v-slot:activator>
               <BalIcon name="info" size="xs" class="text-gray-400 -mb-px" />
@@ -109,7 +109,12 @@
       <div class="network mt-4 px-4 pt-2 pb-4 text-sm border-t rounded-b-xl">
         <div v-text="t('network')" />
         <div class="flex items-baseline">
-          <div class="w-2 h-2 mr-1 bg-green-400 rounded-full"></div>
+          <div
+            :class="[
+              'w-2 h-2 mr-1 bg-green-400 rounded-full',
+              networkColorClass
+            ]"
+          ></div>
           {{ networkName }}
         </div>
       </div>
@@ -165,6 +170,9 @@ export default defineComponent({
     const account = computed(() => store.state.web3.account);
     const networkId = computed(() => store.state.web3.config.chainId);
     const networkName = computed(() => store.state.web3.config.name);
+    const networkColorClass = computed(
+      () => `network-${store.state.web3.config.shortName.toLowerCase()}`
+    );
     const appSlippage = computed(() => store.state.app.slippage);
     const appLocale = computed(() => store.state.app.locale);
     const appDarkMode = computed(() => store.state.app.darkMode);
@@ -222,6 +230,7 @@ export default defineComponent({
       account,
       networkId,
       networkName,
+      networkColorClass,
       appSlippage,
       appLocale,
       appDarkMode,
@@ -265,5 +274,21 @@ export default defineComponent({
 
 .slippage-input.active {
   @apply text-blue-500 border-blue-500 font-bold;
+}
+
+.network-kovan {
+  background: #9064ff;
+}
+
+.network-ropsten {
+  background: #ff4a8d;
+}
+
+.network-rinkeby {
+  background: #f6c343;
+}
+
+.network-goerli {
+  background: #3099f2;
 }
 </style>


### PR DESCRIPTION
I think it helps to see different colors for TestNets

Before:
<img width="322" alt="Screen Shot 2021-04-18 at 10 31 11 pm" src="https://user-images.githubusercontent.com/254095/115145750-7c8bb000-a096-11eb-80a9-49f6c06e5b40.png">

After:
<img width="322" alt="Screen Shot 2021-04-18 at 10 31 25 pm" src="https://user-images.githubusercontent.com/254095/115145756-81e8fa80-a096-11eb-899d-079d6612a1dc.png">
