### PR TITLE
fix dropdown behaviour of the settings popover

### DIFF
--- a/src/components/SettingsPopover.vue
+++ b/src/components/SettingsPopover.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="popover-wrapper hidden absolute right-6 top-14 z-10 mt-2">
-    <div class="w-full h-2"></div>
+  <div
+    class="popover-wrapper top-full invisible opacity-0 absolute z-10 pt-3 right-0"
+  >
     <BalCard class="popover pt-4" shadow="xl" noPad>
       <div class="px-4">
         <h5 v-text="t('account')" />
@@ -74,7 +75,7 @@
       </div>
       <div class="mt-4 px-4">
         <div class="flex items-baseline">
-          <h5 v-text="'Slippage tolerance'" class="pr-1" />
+          <h5 v-text="'Slippage tolerance'" />
           <BalTooltip>
             <template v-slot:activator>
               <BalIcon
@@ -256,8 +257,11 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.popover-wrapper {
+  transition: all 0.2s ease-in-out;
+}
 .popover-wrapper:hover {
-  display: initial;
+  @apply visible opacity-100;
 }
 
 .address {

--- a/src/components/navs/AppNav.vue
+++ b/src/components/navs/AppNav.vue
@@ -42,29 +42,33 @@
             >
               ✨ {{ _num(totalPending) }} BAL
             </BalBtn>
-            <BalBtn
-              class="auth-btn"
-              :loading="web3Loading"
-              :loading-label="['sm', 'md'].includes(bp) ? '' : 'Connecting...'"
-              color="gray"
-              outline
-              rounded
-              :size="['sm', 'md'].includes(bp) ? 'md' : 'sm'"
-              :circle="['sm', 'md'].includes(bp)"
-            >
-              <Avatar :address="account" :profile="profile" size="20" />
-              <span
-                v-if="profile.name || profile.ens"
-                v-text="profile.name || profile.ens"
-                class="pl-2 hidden md:inline-block"
-              />
-              <span
-                v-else
-                v-text="_shorten(account)"
-                class="pl-2 hidden md:inline-block"
-              />
-            </BalBtn>
-            <SettingsPopover v-if="!web3Loading" class="popover" />
+            <div class="relative">
+              <BalBtn
+                class="auth-btn"
+                :loading="web3Loading"
+                :loading-label="
+                  ['sm', 'md'].includes(bp) ? '' : 'Connecting...'
+                "
+                color="gray"
+                outline
+                rounded
+                :size="['sm', 'md'].includes(bp) ? 'md' : 'sm'"
+                :circle="['sm', 'md'].includes(bp)"
+              >
+                <Avatar :address="account" :profile="profile" size="20" />
+                <span
+                  v-if="profile.name || profile.ens"
+                  v-text="profile.name || profile.ens"
+                  class="pl-2 hidden md:inline-block"
+                />
+                <span
+                  v-else
+                  v-text="_shorten(account)"
+                  class="pl-2 hidden md:inline-block"
+                />
+              </BalBtn>
+              <SettingsPopover v-if="!web3Loading" class="popover" />
+            </div>
           </div>
           <BalBtn
             v-else
@@ -162,6 +166,6 @@ export default defineComponent({
 }
 
 .auth-btn:hover ~ .popover {
-  display: initial;
+  @apply visible opacity-100;
 }
 </style>


### PR DESCRIPTION
I noticed that when you hover the wallet address (auth button) and slightly go down, the popover would disappear - preventing the user from reaching it. This might be a regression because I recall it was working before.

I refactored the component by wrapping both the button and the popover inside a shared `div` container with a relative position.

I also added some transition - let me know if that's ok! (I could also switch back to using `display` as before)