### PR TITLE
SG snapshot timestamp to include current 24hr.

### DIFF
--- a/src/api/subgraph.ts
+++ b/src/api/subgraph.ts
@@ -152,7 +152,8 @@ export async function getPoolSnapshots(
   days: number
 ) {
   const currentTimestamp = Math.ceil(Date.now() / 1000);
-  const dayTimestamp = currentTimestamp - (currentTimestamp % DAY);
+  const dayTimestamp = currentTimestamp - (currentTimestamp % DAY) + DAY;
+
   const timestamps: number[] = [];
   for (let i = 0; i < days; i++) {
     timestamps.push(dayTimestamp - i * DAY);


### PR DESCRIPTION
Fixes #UI-239 .

Changes proposed in this pull request:
- Changes timestamp to match Subgraph (https://github.com/balancer-labs/balancer-subgraph-v2/blob/master/src/mappings/helpers.ts#L148). This should include todays swap data correctly.
- 
- 
