### PR TITLE
fix: make entire row clickable in PoolsTable

### DIFF
--- a/src/components/tables/PoolsTable.vue
+++ b/src/components/tables/PoolsTable.vue
@@ -20,6 +20,7 @@
         class="cursor-default hover:bg-gray-50"
         v-for="pool in filteredPools"
         :key="pool.address"
+        @click="openPool(pool)"
       >
         <td class="p-2 pl-5 py-5 flex">
           <div class="w-20 relative">
@@ -80,6 +81,12 @@ export default defineComponent({
       required: true
     },
     selectedTokens: { type: Array as PropType<string[]>, default: () => [] }
+  },
+
+  methods: {
+    openPool(pool: Pool) {
+      this.$router.push({ name: 'pool', params: { id: pool.id } });
+    }
   },
 
   setup(props) {


### PR DESCRIPTION
Closes UI-228

Changes proposed in this pull request:
- Adds similar logic to in `Table/PortfolioPools` to make the entire row clickable.
