### PR TITLE
Fix single asset max withdrawal dust bug

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -364,6 +364,7 @@ export default defineComponent({
       if (isProportional.value) return data.bptIn;
       if (!exactOut.value) return bptBalance.value; // Single asset max withdrawal
 
+      // Else single asset exact amount case
       const poolDecimals = allTokens.value[props.pool.address].decimals;
       let bptIn = poolCalculator
         .bptInForExactTokenOut(data.amounts[data.singleAsset], data.singleAsset)


### PR DESCRIPTION
For the case where the user wants to withdraw the maximum amount possible of a single token, the bptIn amount should be their balance.