### PR TITLE
Exit "Approving" state when user rejects approval transaction

### DIFF
--- a/src/composables/pools/useTokenApprovals.ts
+++ b/src/composables/pools/useTokenApprovals.ts
@@ -59,6 +59,7 @@ export default function useTokenApprovals(tokens, shortAmounts) {
       console.log(txs);
       handleTransactions(txs);
     } catch (error) {
+      approving.value = false;
       console.error(error);
     }
   }


### PR DESCRIPTION
If `approveTokens` throws due to user rejecting a transaction (or any other reason) then we get stuck in the state of waiting for the transaction to confirm until the user refreshes.