### PR TITLE
Display price impact tooltip in both states

### DIFF
--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -123,15 +123,16 @@
           <span
             >{{ $t('priceImpact') }}: {{ fNum(priceImpact, 'percent') }}</span
           >
-          <BalIcon
-            v-if="priceImpact >= 0.01"
-            name="alert-triangle"
-            size="xs"
-            class="ml-1"
-          />
-          <BalTooltip v-if="priceImpact < 0.0">
+          <BalTooltip>
             <template v-slot:activator>
               <BalIcon
+                v-if="priceImpact >= 0.01"
+                name="alert-triangle"
+                size="xs"
+                class="ml-1"
+              />
+              <BalIcon
+                v-else
                 name="info"
                 size="xs"
                 class="text-gray-400 -mb-px ml-2"

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -112,15 +112,16 @@
           <span
             >{{ $t('priceImpact') }}: {{ fNum(priceImpact, 'percent') }}</span
           >
-          <BalIcon
-            v-if="priceImpact >= 0.01"
-            name="alert-triangle"
-            size="xs"
-            class="ml-1"
-          />
-          <BalTooltip v-if="priceImpact < 0.01">
+          <BalTooltip>
             <template v-slot:activator>
               <BalIcon
+                v-if="priceImpact >= 0.01"
+                name="alert-triangle"
+                size="xs"
+                class="ml-1"
+              />
+              <BalIcon
+                v-else
                 name="info"
                 size="xs"
                 class="text-gray-400 -mb-px ml-2"


### PR DESCRIPTION
Changes proposed in this pull request:
- Display tooltip in both states, e.g. less than 1% and more than 1%
