### PR TITLE
feat: standardise user balance label formatting

### DIFF
--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -56,9 +56,9 @@
                 </span>
                 <span
                   class="text-xs text-gray-400 break-words"
-                  :title="`${balanceLabel(i)} balance`"
+                  :title="`${formatBalance(i)} balance`"
                 >
-                  {{ $t('balance') }}: {{ balanceLabel(i) }}
+                  {{ $t('balance') }}: {{ formatBalance(i) }}
                 </span>
               </div>
             </div>
@@ -109,7 +109,7 @@
             class="cursor-pointer"
             @click.prevent="amounts[i] = tokenBalance(i)"
           >
-            {{ $t('balance') }}: {{ balanceLabel(i) }}
+            {{ $t('balance') }}: {{ formatBalance(i) }}
           </div>
         </template>
         <template v-slot:append>
@@ -410,7 +410,7 @@ export default defineComponent({
       return toFiat(amount, token);
     }
 
-    function balanceLabel(index) {
+    function formatBalance(index) {
       return fNum(tokenBalance(index), 'token');
     }
 
@@ -537,7 +537,7 @@ export default defineComponent({
       fNum,
       isAuthenticated,
       connectWallet,
-      balanceLabel,
+      formatBalance,
       isProportional,
       propPercentage,
       priceImpact,

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -48,7 +48,7 @@
                   {{ fNum(amounts[i], 'token') }} {{ allTokens[token].symbol }}
                 </span>
                 <span class="text-xs text-gray-400 break-words">
-                  {{ $t('balance') }}: {{ propBalanceLabel(i) }}
+                  {{ $t('balance') }}: {{ formatPropBalance(i) }}
                 </span>
               </div>
             </div>
@@ -300,7 +300,7 @@ export default defineComponent({
       return allTokens.value[props.pool.address].balance;
     });
 
-    function propBalanceLabel(index) {
+    function formatPropBalance(index) {
       return fNum(data.propMax[index] || '0', 'token');
     }
 
@@ -569,7 +569,7 @@ export default defineComponent({
       priceImpactClasses,
       amountRules,
       formTypes,
-      propBalanceLabel,
+      formatPropBalance,
       amountUSD,
       singleAssetMaxLabel,
       singleAssetMaxes,

--- a/src/views/Trade.vue
+++ b/src/views/Trade.vue
@@ -57,7 +57,7 @@
           </template>
           <template v-slot:info>
             <div class="cursor-pointer" @click="handleMax">
-              {{ $t('balance') }}: {{ fNum(balanceLabel, 'token') }}
+              {{ $t('balance') }}: {{ formatBalance }}
             </div>
           </template>
           <template v-slot:append>
@@ -277,8 +277,8 @@ export default defineComponent({
         : !allowanceState.value.isUnlockedV2;
     });
 
-    const balanceLabel = computed(
-      () => tokens.value[tokenInAddressInput.value]?.balance
+    const formatBalance = computed(() =>
+      fNum(tokens.value[tokenInAddressInput.value]?.balance, 'token')
     );
 
     const title = computed(() => {
@@ -398,7 +398,7 @@ export default defineComponent({
       fNum,
       toFiat,
       tokens,
-      balanceLabel,
+      formatBalance,
       title,
       submitLabel,
       modalSelectTokenIsOpen,


### PR DESCRIPTION
We have a couple of different formats for showing the user's balance for tokens such as "Balance: 0", "balance: 0" and  "0 Balance" spread over the invest/withdraw/trade UIs. I've consolidated all to the first type.