### PR TITLE
hide horizontal scroll from token modal

### DIFF
--- a/src/components/modals/SelectTokenModal.vue
+++ b/src/components/modals/SelectTokenModal.vue
@@ -63,7 +63,10 @@
         </a>
       </div>
       <div>
-        <div v-if="Object.keys(tokens).length > 0" class="h-96 overflow-scroll">
+        <div
+          v-if="Object.keys(tokens).length > 0"
+          class="h-96 overflow-y-scroll"
+        >
           <a
             v-for="(token, key) in tokens"
             :key="key"


### PR DESCRIPTION
Before:
<img width="567" alt="Screen Shot 2021-04-24 at 10 29 34 pm" src="https://user-images.githubusercontent.com/254095/115958990-38dcee80-a54d-11eb-9319-a548b92b7716.png">

After:
<img width="537" alt="Screen Shot 2021-04-24 at 10 31 29 pm" src="https://user-images.githubusercontent.com/254095/115958995-3f6b6600-a54d-11eb-89c9-c7fa99604d8a.png">
