### PR TITLE
add subgraph url to env file

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,3 +3,4 @@ VUE_APP_IPFS_NODE=ipfs.fleek.co
 VUE_APP_NETWORK=42
 VUE_APP_BLOCKNATIVE_DAPP_ID=032e2fb8-6c66-46a5-bf1c-a049ac7eded2
 VUE_APP_INFURA_PROJECT_ID=daaa68ec242643719749dd1caba2fc66
+SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2


### PR DESCRIPTION
Bug was actually on mainnet, so added a env var in vercel to fix. This is just to explicitly list in the env file