### PR TITLE
Disable swap button if values are invalid

### DIFF
--- a/src/views/Trade.vue
+++ b/src/views/Trade.vue
@@ -163,6 +163,7 @@
           :label="`${$t(submitLabel)}`"
           :loading="trading"
           :loading-label="$t('confirming')"
+          :disabled="zeroAmounts"
           color="gradient"
           block
           @click.prevent="trade"
@@ -326,6 +327,15 @@ export default defineComponent({
       return message;
     });
 
+    const zeroAmounts = computed(() => {
+      return (
+        (!tokenInAmountInput.value ||
+          parseFloat(tokenInAmountInput.value) === 0) &&
+        (!tokenOutAmountInput.value ||
+          parseFloat(tokenOutAmountInput.value) === 0)
+      );
+    });
+
     function toggleRate(): void {
       isInRate.value = !isInRate.value;
     }
@@ -431,7 +441,8 @@ export default defineComponent({
       approve,
       trading,
       trade,
-      priceImpact
+      priceImpact,
+      zeroAmounts
     };
   }
 });


### PR DESCRIPTION
Changes proposed in this pull request:
- Invest/Withdraw disable the button if input is invalid
- Swap button still tries to do a swap, which fails if 0
- Disable button unless there are valid numeric inputs
