### PR TITLE
Fix click-outside directive issue with settings popover

### DIFF
--- a/src/plugins/directives.ts
+++ b/src/plugins/directives.ts
@@ -3,20 +3,22 @@ import { App } from 'vue';
 export default function registerDirectives(app: App) {
   app.directive('click-outside', {
     beforeMount(el, binding) {
-      el.onClickOutside = function(event) {
+      el.__vueOnClickOutside = function(event) {
         const callback = binding.value;
+        const path = event.path || (event.composedPath && event.composedPath());
 
-        if (
-          typeof callback === 'function' &&
-          !(el === event.target || el.contains(event.target))
-        ) {
+        const isClickOutside = path
+          ? path.indexOf(el) < 0
+          : !el.contains(event.target);
+
+        if (typeof callback === 'function' && isClickOutside) {
           callback(event);
         }
       };
-      document.body.addEventListener('click', el.onClickOutside);
+      document.body.addEventListener('click', el.__vueOnClickOutside);
     },
     unmounted(el) {
-      document.body.removeEventListener('click', el.onClickOutside);
+      document.body.removeEventListener('click', el.__vueOnClickOutside);
     }
   });
 }


### PR DESCRIPTION
I noticed an issue with settings popover "clipboard" icon. If you click on it, and then move away from the popover, it will disappear (and it shouldn't because the trigger is "click").

After digging a bit it seems that its better to use https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath to detect outside click (if the browser supports it). That's what other vue-js for outside click are using.