### PR TITLE
Round weight display

### DIFF
--- a/src/components/tables/PoolsTable.vue
+++ b/src/components/tables/PoolsTable.vue
@@ -39,7 +39,7 @@
             class="inline-block mr-1"
           >
             <span class="dot">•</span>
-            {{ fNum(token.weight * 100, 'percent') }}
+            {{ fNum(token.weight, 'percent') }}
             {{ allTokens[getAddress(token.address)].symbol }}
           </span>
         </div>


### PR DESCRIPTION
Changes proposed in this pull request:
- Percentages were displayed unrounded:
- 70.0000000000000001
- 33.333333333333333
