### PR TITLE
Update swaps whenever new pools/balances fetched.

### DIFF
--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -67,9 +67,7 @@ export default function useSor(
 
   useIntervalFn(async () => {
     if (sorManager) {
-      console.time('[SOR] fetchPools');
-      await sorManager.fetchPools();
-      console.timeEnd('[SOR] fetchPools');
+      fetchPools();
     }
   }, 30 * 1e3);
 
@@ -95,10 +93,7 @@ export default function useSor(
       subgraphUrl
     );
 
-    console.time('[SOR] fetchPools');
-    await sorManager.fetchPools();
-    console.timeEnd('[SOR] fetchPools');
-    pools.value = sorManager.selectedPools.pools;
+    fetchPools();
   }
 
   async function fetchPools(): Promise<void> {
@@ -110,6 +105,8 @@ export default function useSor(
     await sorManager.fetchPools();
     console.timeEnd('[SOR] fetchPools');
     pools.value = sorManager.selectedPools.pools;
+    // Updates any swaps with up to date pools/balances
+    handleAmountChange();
   }
 
   async function handleAmountChange(): Promise<void> {


### PR DESCRIPTION
Fixes #UI-363 .

Changes proposed in this pull request:
- After every pools/balances fetch update swap/SOR amounts.
- Should fix issue that causes failed tx due to SOR using wrong balances after a trade.
- Also updates Swap amounts after initial page load.
