### PR TITLE
Use new SOR packages that reuturn amt with fees.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sor": "^1.0.0",
+        "@balancer-labs/sor": "github:balancer-labs/balancer-sor#john/v1-consideringFees-package",
         "@balancer-labs/sor2": "github:balancer-labs/balancer-sor#john/rc03-package",
         "@ensdomains/content-hash": "^2.5.3",
         "@ethersproject/abi": "^5.0.1",
@@ -1433,9 +1433,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-1.0.0.tgz",
-      "integrity": "sha512-EF4RvwCHGIa3gqRKMBlrq19FS4X+4g3NAJkJf9k21oIUp1XAhdV3/aMlAoJ25OigafCjPFEHn7wOHrtZNKHc3A==",
+      "version": "1.0.1",
+      "resolved": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#9b813756ee3ff0a8f9eb13f05246023da2afa9a0",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "@ethersproject/address": "^5.0.5",
         "@ethersproject/constants": "^5.0.5",
@@ -1475,7 +1475,7 @@
     },
     "node_modules/@balancer-labs/sor2": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#be2970e3e32ee6aa06ff522916c6edee5bbb48f9",
+      "resolved": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#6e8e1dd546538ace0775ee68fb8bff6c179d2d20",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@ethersproject/address": "^5.0.5",
@@ -32403,9 +32403,8 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-1.0.0.tgz",
-      "integrity": "sha512-EF4RvwCHGIa3gqRKMBlrq19FS4X+4g3NAJkJf9k21oIUp1XAhdV3/aMlAoJ25OigafCjPFEHn7wOHrtZNKHc3A==",
+      "version": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#9b813756ee3ff0a8f9eb13f05246023da2afa9a0",
+      "from": "@balancer-labs/sor@github:balancer-labs/balancer-sor#john/v1-consideringFees-package",
       "requires": {
         "@ethersproject/address": "^5.0.5",
         "@ethersproject/constants": "^5.0.5",
@@ -32446,7 +32445,7 @@
       }
     },
     "@balancer-labs/sor2": {
-      "version": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#be2970e3e32ee6aa06ff522916c6edee5bbb48f9",
+      "version": "git+ssh://git@github.com/balancer-labs/balancer-sor.git#6e8e1dd546538ace0775ee68fb8bff6c179d2d20",
       "from": "@balancer-labs/sor2@github:balancer-labs/balancer-sor#john/rc03-package",
       "requires": {
         "@ethersproject/address": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sor": "^1.0.0",
+    "@balancer-labs/sor": "github:balancer-labs/balancer-sor#john/v1-consideringFees-package",
     "@balancer-labs/sor2": "github:balancer-labs/balancer-sor#john/rc03-package",
     "@ensdomains/content-hash": "^2.5.3",
     "@ethersproject/abi": "^5.0.1",

--- a/src/composables/trade/useSor.ts
+++ b/src/composables/trade/useSor.ts
@@ -45,6 +45,7 @@ export default function useSor(
       swaps: [],
       swapAmount: new BigNumber(0),
       returnAmount: new BigNumber(0),
+      returnAmountConsideringFees: new BigNumber(0),
       tokenIn: '',
       tokenOut: '',
       marketSp: new BigNumber(0)


### PR DESCRIPTION
Fixes #UI-392 .

Changes proposed in this pull request:
- Uses new SOR packaged for V1 and V2 that return amtConsideringFees
- Use amtConsideringFees value to select best liqudity source
- Require npm install to be run
