### PR TITLE
Add extra context with full error info.

### DIFF
--- a/src/plugins/sentry.ts
+++ b/src/plugins/sentry.ts
@@ -21,7 +21,11 @@ export default function initSentry(app: App) {
     app.config.errorHandler = (error, _, info) => {
       try {
         setTag('info', info);
-        captureException(error);
+        captureException(error, {
+          extra: {
+            error: error
+          }
+        });
       } catch (error) {
         console.error('Failed to send error to Sentry', error);
       }


### PR DESCRIPTION
Fixes # UI-397.

Changes proposed in this pull request:
- Adds the 'extra' context and passes the error under an 'error' key which allows the full error to be seen under Additional Info.
- 
- 
