### PR TITLE
Fix dust being left after withdrawal

### DIFF
--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -480,9 +480,10 @@ export default defineComponent({
       const amount = bnum(balances.value[data.propToken])
         .times(fractionBasisPoints)
         .div(10000)
-        .precision(tokenDecimals(data.propToken));
+        .toFixed(tokenDecimals(data.propToken));
+
       const { send } = poolCalculator.propAmountsGiven(
-        amount.toString(),
+        amount,
         data.propToken,
         'send'
       );

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -458,13 +458,9 @@ export default defineComponent({
       const bpt = bnum(bptBalance.value)
         .times(fractionBasisPoints)
         .div(10000)
-        .precision(props.pool.onchain.decimals);
+        .toFixed(props.pool.onchain.decimals);
 
-      const { send, receive } = poolCalculator.propAmountsGiven(
-        bpt.toString(),
-        0,
-        'send'
-      );
+      const { send, receive } = poolCalculator.propAmountsGiven(bpt, 0, 'send');
       data.bptIn = send[0];
       data.amounts = receive;
     }


### PR DESCRIPTION
Using precision was limiting the whole number to the token decimal amount instead of just limiting the decimals.