### PR TITLE
Hide pagination when not needed (Pools)

### DIFF
--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -64,7 +64,10 @@ export default function usePoolsQuery(
     return {
       pools,
       tokens,
-      skip: pools.length ? pageParam + POOLS.Pagination.PerPage : undefined
+      skip:
+        pools.length >= POOLS.Pagination.PerPage
+          ? pageParam + POOLS.Pagination.PerPage
+          : undefined
     };
   };
 


### PR DESCRIPTION
Currently `hasNextPage` will return true even if there are less than `POOLS.Pagination.PerPage` resulting in showing up a lot when filtering.