### PR TITLE
feat: disable liquidity checks when querying a specific pool

### DIFF
--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -45,7 +45,12 @@ export default function usePoolQuery(
     const [pool] = await balancerSubgraph.pools.getDecorated(
       '24h',
       prices.value,
-      { where: { id } }
+      {
+        where: {
+          id: id.toLowerCase(),
+          totalShares_gt: -1 // Avoid the filtering for low liquidity pools
+        }
+      }
     );
     const tokens = pick(allTokens.value, pool.tokenAddresses) as Token[];
     const onchainData = await balancerContracts.vault.getPoolData(


### PR DESCRIPTION
We're currently filtering out any "dead" pools which have less than 0.01 BPT from any subgraph queries. A side effect of this is that we're unable to view any dead pools even when we're specifically looking for it.

I've disabled this minimum liquidity check for subgraph queries which are specific to a single pool. This can be tested by attempting to view the pool: 0x3A19030ED746BD1C3F2B0F996FF9479AF04C5F0A000100000000000000000005