### PR TITLE
fix: properly format token amounts and values in token selection

### DIFF
--- a/src/components/RowToken.vue
+++ b/src/components/RowToken.vue
@@ -12,12 +12,12 @@
     </div>
     <span class="text-right">
       <template v-if="token.balance > 0">
-        {{ fNum(token.balance, '0,0.[000]') }}
+        {{ fNum(token.balance, 'token') }}
       </template>
       <template v-else>-</template>
       <div class="text-gray text-sm">
         <template v-if="token.value > 0">
-          {{ fNum(token.value, '$0,0.[00]') }}
+          {{ fNum(token.value, 'usd') }}
         </template>
         <template v-else>-</template>
       </div>


### PR DESCRIPTION
`RowToken` isn't passing in a proper preset but the underlying format so it isn't being applied. I've changed it to pass in the correct presets.