### PR TITLE
fix: enforce that tokens use checksummed addresses in useTokenLists

### DIFF
--- a/src/composables/useTokenLists.ts
+++ b/src/composables/useTokenLists.ts
@@ -1,4 +1,5 @@
 import { computed, reactive, ref } from 'vue';
+import { getAddress } from '@ethersproject/address';
 import { TOKEN_LISTS } from '@/constants/tokenlists';
 import { useQuery } from 'vue-query';
 import { loadTokenlist } from '@/utils/tokenlists';
@@ -74,6 +75,7 @@ export default function useTokenLists(request?: TokenListRequest) {
               const value24HChange = (value / 100) * price24HChange;
               return {
                 ...token,
+                address: getAddress(token.address), // Enforce that we use checksummed addresses
                 value,
                 price,
                 price24HChange,


### PR DESCRIPTION
Some tokenlists don't use checksummed addresses which causes duplicate entries. You can see this with the Zerion token list.

I've enforced that we convert all addresses to checksum addresses before we cull any duplicates to stop these from slipping though.
