### PR TITLE
Reset SelectTokenModal to token search after being closed

### DIFF
--- a/src/components/modals/SelectTokenModal.vue
+++ b/src/components/modals/SelectTokenModal.vue
@@ -183,6 +183,7 @@ export default defineComponent({
     }
 
     function onClose() {
+      data.selectTokenList = false;
       data.query = '';
       emit('close');
     }


### PR DESCRIPTION
If a user navigates to the token list and closes the modal this would cause the modal to be in the "token list" instead of the "token search" view next time it is opened.