### PR TITLE
Add breakdown of rewards to LM tooltip

### DIFF
--- a/src/components/tooltips/LiquidityMiningTooltip.vue
+++ b/src/components/tooltips/LiquidityMiningTooltip.vue
@@ -8,14 +8,14 @@
       />
     </template>
     <div class="text-sm divide-y dark:divide-gray-900">
-      <div class="mb-1 px-3 pt-3">
+      <div class="px-3 pt-3 pb-1 bg-gray-50 dark:bg-gray-800 rounded-t">
         <div class="text-gray-500">{{ $t('totalAPR') }}</div>
         <div class="text-lg">
           {{ fNum(pool.dynamic.apr.total, 'percent') }}
         </div>
       </div>
       <div class="p-3">
-        <div class="whitespace-nowrap flex items-center">
+        <div class="whitespace-nowrap flex items-center mb-1">
           {{ fNum(pool.dynamic.apr.pool, 'percent') }}
           <span class="ml-1 text-gray-500 text-xs">{{ $t('swapFeeAPR') }}</span>
         </div>
@@ -26,15 +26,33 @@
             <StarsIcon class="h-4 text-yellow-300" />
           </span>
         </div>
+        <div
+          v-if="multiRewardPool"
+          class="whitespace-nowrap flex flex-col mt-2 ml-px"
+        >
+          <div
+            v-for="(apr, address, index) in lmBreakdown"
+            :key="address"
+            class="flex items-center"
+          >
+            <div v-if="index === 0" class="init-vert-bar" />
+            <div v-else class="vert-bar" />
+            <div class="horiz-bar" />
+            {{ fNum(apr, 'percent') }}
+            <span class="text-gray-500 text-xs ml-2">
+              {{ lmTokens[address].symbol }} {{ $t('apr') }}
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </BalTooltip>
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
-
+import { defineComponent, PropType, computed } from 'vue';
 import useNumbers from '@/composables/useNumbers';
+import useTokens from '@/composables/useTokens';
 import { DecoratedPool } from '@/services/balancer/subgraph/types';
 
 export default defineComponent({
@@ -47,12 +65,46 @@ export default defineComponent({
     }
   },
 
-  setup() {
+  setup(props) {
+    /**
+     * COMPOSABLES
+     */
     const { fNum } = useNumbers();
+    const { getTokens } = useTokens();
+
+    /**
+     * COMPUTED
+     */
+    const lmBreakdown = computed(
+      () => props.pool.dynamic.apr.liquidityMiningBreakdown
+    );
+
+    const lmTokens = computed(() => getTokens(Object.keys(lmBreakdown.value)));
+
+    const multiRewardPool = computed(
+      () => Object.keys(lmTokens.value).length > 1
+    );
 
     return {
-      fNum
+      lmBreakdown,
+      fNum,
+      lmTokens,
+      multiRewardPool
     };
   }
 });
 </script>
+
+<style scoped>
+.horiz-bar {
+  @apply h-px w-3 bg-gray-200 dark:bg-gray-700 mr-2;
+}
+
+.init-vert-bar {
+  @apply w-px h-4 bg-gray-200 dark:bg-gray-700 -mt-4 -mr-px;
+}
+
+.vert-bar {
+  @apply w-px h-8 bg-gray-200 dark:bg-gray-700 -mt-8 -mr-px;
+}
+</style>

--- a/src/lib/utils/liquidityMining/index.ts
+++ b/src/lib/utils/liquidityMining/index.ts
@@ -49,6 +49,23 @@ export function computeAPRForPool(
     : '0';
 }
 
+export function computeAPRsForPool(
+  tokenRewards: LiquidityMiningTokenRewards[],
+  prices: TokenPrices,
+  currency: FiatCurrency,
+  totalLiquidity: string
+): { [address: string]: string } {
+  const rewardAPRs = tokenRewards.map(reward => [
+    getAddress(reward.tokenAddress),
+    computeAPRForPool(
+      reward.amount,
+      prices[getAddress(reward.tokenAddress)][currency],
+      totalLiquidity
+    )
+  ]);
+  return Object.fromEntries(rewardAPRs);
+}
+
 export function computeTotalAPRForPool(
   tokenRewards: LiquidityMiningTokenRewards[],
   prices: TokenPrices,

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -72,6 +72,7 @@ export interface TokensProviderResponse {
   priceFor: (address: string) => number;
   balanceFor: (address: string) => string;
   getTokens: (addresses: string[]) => TokenInfoMap;
+  getToken: (address: string) => TokenInfo;
 }
 
 /**
@@ -357,6 +358,13 @@ export default {
     }
 
     /**
+     * Get single token from state
+     */
+    function getToken(address: string): TokenInfo {
+      return tokens.value[address];
+    }
+
+    /**
      * CALLBACKS
      */
     onBeforeMount(async () => {
@@ -394,7 +402,8 @@ export default {
       approvalsRequired,
       priceFor,
       balanceFor,
-      getTokens
+      getTokens,
+      getToken
     });
 
     return () => slots.default();

--- a/src/services/balancer/subgraph/entities/pools/index.ts
+++ b/src/services/balancer/subgraph/entities/pools/index.ts
@@ -12,7 +12,8 @@ import {
 import { getAddress } from '@ethersproject/address';
 import {
   currentLiquidityMiningRewards,
-  computeTotalAPRForPool
+  computeTotalAPRForPool,
+  computeAPRsForPool
 } from '@/lib/utils/liquidityMining';
 import { NetworkId } from '@/constants/network';
 import { configService as _configService } from '@/services/config/config.service';
@@ -78,7 +79,8 @@ export default class Pools {
       const fees = this.calcFees(pool, pastPool);
       const {
         hasLiquidityMiningRewards,
-        liquidityMiningAPR
+        liquidityMiningAPR,
+        liquidityMiningBreakdown
       } = this.calcLiquidityMiningAPR(pool, prices, currency);
       const totalAPR = this.calcTotalAPR(poolAPR, liquidityMiningAPR);
 
@@ -92,6 +94,7 @@ export default class Pools {
           apr: {
             pool: poolAPR,
             liquidityMining: liquidityMiningAPR,
+            liquidityMiningBreakdown,
             total: totalAPR
           }
         }
@@ -138,6 +141,7 @@ export default class Pools {
     currency: FiatCurrency
   ) {
     let liquidityMiningAPR = '0';
+    let liquidityMiningBreakdown = {};
 
     const liquidityMiningRewards = currentLiquidityMiningRewards[pool.id];
 
@@ -152,15 +156,22 @@ export default class Pools {
         currency,
         pool.totalLiquidity
       );
+      liquidityMiningBreakdown = computeAPRsForPool(
+        liquidityMiningRewards,
+        prices,
+        currency,
+        pool.totalLiquidity
+      );
     }
 
     return {
       hasLiquidityMiningRewards,
-      liquidityMiningAPR
+      liquidityMiningAPR,
+      liquidityMiningBreakdown
     };
   }
 
-  private calcTotalAPR(poolAPR: string, liquidityMiningAPR: string) {
+  private calcTotalAPR(poolAPR: string, liquidityMiningAPR: string): string {
     return bnum(poolAPR)
       .plus(liquidityMiningAPR)
       .toString();

--- a/src/services/balancer/subgraph/types.ts
+++ b/src/services/balancer/subgraph/types.ts
@@ -43,6 +43,7 @@ export interface DecoratedPool extends Pool {
     apr: {
       pool: string;
       liquidityMining: string;
+      liquidityMiningBreakdown: { [address: string]: string };
       total: string;
     };
     fees: string;


### PR DESCRIPTION
# Description

For multi-token liquidity mining reward pools we currently do not show any information of where the APR is coming from. This PR breaks down the LM APR into the different reward tokens, if there is more than BAL.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [ ] Check breakdown appears on wstETH metastable pool, but not on other pools.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
