### PR TITLE
Gnosis trade preview minor fix

### DIFF
--- a/src/components/modals/TradePreviewModalGP.vue
+++ b/src/components/modals/TradePreviewModalGP.vue
@@ -8,14 +8,12 @@
           >
             <span>
               {{ $t('effectivePrice') }}
-            </span>
-            <span
-              v-html="
+              {{
                 trading.exactIn.value
                   ? trading.effectivePriceMessage.value.tokenIn
                   : trading.effectivePriceMessage.value.tokenOut
-              "
-            />
+              }}
+            </span>
           </div>
         </template>
         <div>


### PR DESCRIPTION
# Description

This PR fixes a small bug @FernandoMartinelli noticed - missing space after: "Effective price"

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Switch to Gnosis interface, pick a pair to trade, and check the preview screen. The "effective price" should have a space after it.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
