### PR TITLE
Change Investment Pool terminology to Managed Pool

### DIFF
--- a/src/components/forms/pool_actions/InvestForm.vue
+++ b/src/components/forms/pool_actions/InvestForm.vue
@@ -332,7 +332,7 @@ export default defineComponent({
       isStableLikePool,
       isWethPool,
       isWstETHPool,
-      investmentPoolWithTradingHalted
+      managedPoolWithTradingHalted
     } = usePool(toRef(props, 'pool'));
 
     const { amounts } = toRefs(data);
@@ -485,8 +485,8 @@ export default defineComponent({
         }
       ];
 
-      // Investment pools with trading halted only allow proportional joins/exits
-      if (!investmentPoolWithTradingHalted.value) {
+      // Managed pools with trading halted only allow proportional joins/exits
+      if (!managedPoolWithTradingHalted.value) {
         validTypes.push({
           label: t('customAmounts'),
           max: balanceMaxUSD.value,
@@ -585,7 +585,7 @@ export default defineComponent({
       try {
         data.loading = true;
         await calcMinBptOut();
-        const _bptOut = investmentPoolWithTradingHalted.value
+        const _bptOut = managedPoolWithTradingHalted.value
           ? bptOut.value
           : minBptOut.value;
 

--- a/src/components/forms/pool_actions/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm.vue
@@ -232,7 +232,7 @@ export default defineComponent({
     const { trackGoal, Goals } = useFathom();
     const { txListener } = useEthers();
     const { addTransaction } = useTransactions();
-    const { isStableLikePool, isInvestmentPool } = usePool(
+    const { isStableLikePool, managedPoolWithTradingHalted } = usePool(
       toRef(props, 'pool')
     );
 
@@ -408,8 +408,8 @@ export default defineComponent({
         }
       ];
 
-      // Investment pools with trading halted only allow proportional joins/exits
-      if (isInvestmentPool.value || props.pool.onchain.swapEnabled) {
+      // Managed pools with trading halted only allow proportional joins/exits
+      if (!managedPoolWithTradingHalted.value) {
         validTypes.push({
           label: t('singleToken'),
           max: singleMaxUSD.value,

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -10,7 +10,7 @@ import { POOLS } from '@/constants/pools';
 import useApp from '../useApp';
 import useUserSettings from '../useUserSettings';
 import { forChange } from '@/lib/utils';
-import { isInvestment, isStableLike } from '../usePool';
+import { isManaged, isStableLike } from '../usePool';
 import { getAddress } from '@ethersproject/address';
 
 export default function usePoolQuery(
@@ -46,7 +46,7 @@ export default function usePoolQuery(
 
     if (
       (isStableLike(pool.poolType) && !POOLS.Stable.AllowList.includes(id)) ||
-      (isInvestment(pool.poolType) && !POOLS.Investment.AllowList.includes(id))
+      (isManaged(pool.poolType) && !POOLS.Investment.AllowList.includes(id))
     ) {
       throw new Error('Pool not allowed');
     }

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -23,20 +23,21 @@ export function isWeighted(poolType: PoolType): boolean {
   return poolType === PoolType.Weighted;
 }
 
-export function isInvestment(poolType: PoolType): boolean {
+export function isManaged(poolType: PoolType): boolean {
+  // Correct terminology is managed pools but subgraph still returns poolType = "Investment"
   return poolType === PoolType.Investment;
 }
 
 export function isWeightedLike(poolType: PoolType): boolean {
   return (
     isWeighted(poolType) ||
-    isInvestment(poolType) ||
+    isManaged(poolType) ||
     isLiquidityBootstrapping(poolType)
   );
 }
 
 export function isTradingHaltable(poolType: PoolType): boolean {
-  return isInvestment(poolType) || isLiquidityBootstrapping(poolType);
+  return isManaged(poolType) || isLiquidityBootstrapping(poolType);
 }
 
 export function isWeth(pool: AnyPool): boolean {
@@ -67,16 +68,15 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
   const isWeightedLikePool = computed(
     () => pool.value && isWeightedLike(pool.value.poolType)
   );
-  const isInvestmentPool = computed(
-    () => pool.value && isInvestment(pool.value.poolType)
+  const isManagedPool = computed(
+    () => pool.value && isManaged(pool.value.poolType)
   );
   const isLiquidityBootstrappingPool = computed(
     () => pool.value && isLiquidityBootstrapping(pool.value.poolType)
   );
 
-  const investmentPoolWithTradingHalted = computed(
-    () =>
-      pool.value && isInvestmentPool.value && pool.value.onchain?.swapEnabled
+  const managedPoolWithTradingHalted = computed(
+    () => pool.value && isManagedPool.value && pool.value.onchain?.swapEnabled
   );
 
   const isWethPool = computed(() => pool.value && isWeth(pool.value));
@@ -89,9 +89,9 @@ export function usePool(pool: Ref<AnyPool> | Ref<undefined>) {
     isStableLikePool,
     isWeightedPool,
     isWeightedLikePool,
-    isInvestmentPool,
+    isManagedPool,
     isLiquidityBootstrappingPool,
-    investmentPoolWithTradingHalted,
+    managedPoolWithTradingHalted,
     isWethPool,
     isWstETHPool,
     // methods

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -76,14 +76,14 @@ export const POOLS = {
     '0x67d27634e44793fe63c467035e31ea8635117cd4': 'stablePool', // Metastable
     '0x751dfdace1ad995ff13c927f6f761c6604532c79': 'stablePool', // Kovan
     '0x590e544e7ca956bb878f8c873e82e65550d67d2f': 'stablePool', // Kovan Metastable
-    '0xb08e16cfc07c684daa2f93c70323badb2a6cbfd2': 'investmentPool', // Kovan Investment
+    '0xb08e16cfc07c684daa2f93c70323badb2a6cbfd2': 'managedPool', // Kovan Managed
     '0x7dfdef5f355096603419239ce743bfaf1120312b': 'weightedPool', // Arbitrum Weighted
     '0xcf0a32bbef8f064969f21f7e02328fb577382018': 'weightedPool', // Arbitrum WeightedOracle
     '0x2433477a10fc5d31b9513c638f19ee85caed53fd': 'stablePool', // Arbitrum Stable
     '0xebfd5681977e38af65a7487dc70b8221d089ccad': 'stablePool', // Arbitrum MetaStable
     '0x751a0bc0e3f75b38e01cf25bfce7ff36de1c87de': 'liquidityBootstrappingPool', // Mainnet LBP
-    '0x48767f9f868a4a7b86a90736632f6e44c2df7fa9': 'investmentPool', // Mainnet Investment
-    '0x0f7bb7ce7b6ed9366f9b6b910adefe72dc538193': 'investmentPool', // Polygon Investment
-    '0xacd615b3705b9c880e4e7293f1030b34e57b4c1c': 'investmentPool' // Arbitrum Investment
+    '0x48767f9f868a4a7b86a90736632f6e44c2df7fa9': 'managedPool', // Mainnet Managed
+    '0x0f7bb7ce7b6ed9366f9b6b910adefe72dc538193': 'managedPool', // Polygon Managed
+    '0xacd615b3705b9c880e4e7293f1030b34e57b4c1c': 'managedPool' // Arbitrum Managed
   }
 };

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -153,6 +153,7 @@
     "logOut": "Log out",
     "lpsEarnFee": "<span>LPs earn <b>{0}</b> in fees</span>",
     "manageLists": "Manage lists",
+    "managedPool": "Managed pool",
     "marketConditionsWarning": "Market conditions may change between the time your order is submitted and the time it gets executed on Ethereum. Slippage tolerance is the maximum change in price you are willing to accept. This protects you from front-running bots and miner extractable value (MEV).",
     "max": "Max",
     "maxed": "Maxed",


### PR DESCRIPTION
# Description

Investment Pool is a terrible name for a pool type considering all pools are listed under the title "Investment pools". The general consensus is to relabel these pools "Managed Pools". This PR changes the terminology throughout the app to Managed Pools.

Note: Unfortunately the subgraph will still return the `poolType` "Investment".

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test production pool `0xe7b1d394f3b40abeaa0b64a545dbcf89da1ecb3f00010000000000000000009a` is labeled "Managed Pool"

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] My changes generate no new console warnings
- [ ] The base of this PR is `master` if hotfix, `develop` if not
