### PR TITLE
Update Arbitrum block time

### DIFF
--- a/src/services/balancer/subgraph/balancer-subgraph.service.ts
+++ b/src/services/balancer/subgraph/balancer-subgraph.service.ts
@@ -30,8 +30,7 @@ export default class BalancerSubgraphService {
       case Network.POLYGON:
         return 2;
       case Network.ARBITRUM:
-        // TODO: Replace this with a more realistic number once activity picks up
-        return 13;
+        return 3;
       case Network.KOVAN:
         // Should be ~4s but this causes subgraph to return with unindexed block error.
         return 1;


### PR DESCRIPTION
# Description

24h volume on arbitrum is significantly underestimated. This updates the block time heuristic to something more reasonable (based on the past 4 days, where it's varied between 2.5s and 3.5s) until we can implement https://linear.app/balancer/issue/UI-768/accurately-compute-24h-volume

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

- [x] 24h volume on the UI should be more in line with what you get from a time travel query pointing to the block number from exactly 24h ago

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
