### PR TITLE
Fix Dockerfile building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR ${APP_ROOT}
 
 FROM base AS dependencies
 
+COPY prepare.js ./
 COPY package*.json ./
 
 RUN npm install -g npm@7


### PR DESCRIPTION
# Description

- Add prepare.js to the Dockerfile before running npm install so it
builds correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How should this be tested?

Run `docker build .` in the root directory

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] My changes generate no new console warnings
- [x] The base of this PR is `master` if hotfix, `develop` if not
