### PR TITLE
Use .env for tokenlist generation on localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "npm": ">=7"
   },
   "scripts": {
-    "serve": "npm run generate:tokenlists && vue-cli-service serve",
+    "serve": "NODE_ENV=development npm run generate:tokenlists && vue-cli-service serve",
     "build": "npm run generate:tokenlists && vue-cli-service build",
     "test:unit": "NODE_ENV=test vue-cli-service test:unit --cache --detectOpenHandles",
     "lint": "vue-cli-service lint --no-fix --max-warnings 0",

--- a/src/lib/scripts/tokenlists.generator.ts
+++ b/src/lib/scripts/tokenlists.generator.ts
@@ -1,8 +1,17 @@
-require('dotenv').config();
-import { tokenListService } from '@/services/token-list/token-list.service';
+import TokenListService from '@/services/token-list/token-list.service';
 const fs = require('fs');
+const path = require('path');
+
+if (process.env.NODE_ENV === 'development') {
+  require('dotenv').config({
+    path: path.resolve(__dirname, '../../../.env.development')
+  });
+} else {
+  require('dotenv').config();
+}
 
 async function generate() {
+  const tokenListService = new TokenListService(process.env.VUE_APP_NETWORK);
   const tokenlists = await tokenListService.getAll();
   fs.writeFileSync(`./public/data/tokenlists.json`, JSON.stringify(tokenlists));
 }

--- a/src/services/token-list/token-list.service.ts
+++ b/src/services/token-list/token-list.service.ts
@@ -22,8 +22,7 @@ interface TokenListUris {
 
 export default class TokenListService {
   constructor(
-    private readonly config = configService,
-    private readonly appNetwork = config.network.key,
+    private readonly appNetwork = configService.network.key,
     private readonly provider = rpcProviderService.jsonProvider,
     private readonly ipfs = ipfsService
   ) {}


### PR DESCRIPTION
# Description

Tokenlists being generated in development were always mainnet tokenlists. We need to explicitly fetch and pass in the VUE_APP_NETWORK value from .env.development to the tokenlist generator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test /data/tokenlists.json contain kovan tokenlists when you run on network id 42 locally.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 2 reviews (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
