### PR TITLE
Hotfix: onchain updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.91.14",
+  "version": "1.91.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.91.14",
+      "version": "1.91.15",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.91.14",
+  "version": "1.91.15",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/queries/usePoolDecorationQuery.ts
+++ b/src/composables/queries/usePoolDecorationQuery.ts
@@ -4,6 +4,7 @@ import { Pool } from '@/services/pool/types';
 import QUERY_KEYS from '@/constants/queryKeys';
 import { PoolDecorator } from '@/services/pool/decorators/pool.decorator';
 import { useTokens } from '@/providers/tokens.provider';
+import { cloneDeep } from 'lodash';
 
 /**
  * TYPES
@@ -39,7 +40,8 @@ export default function usePoolDecorationQuery(
    */
   const queryFn = async () => {
     if (!pool.value) return undefined;
-    const poolDecorator = new PoolDecorator([pool.value]);
+    const _pool = cloneDeep(pool.value);
+    const poolDecorator = new PoolDecorator([_pool]);
     // Decorate pool updating only the onchain attributes.
     const [decoratedPool] = await poolDecorator.decorate(tokens.value, false);
     return decoratedPool;


### PR DESCRIPTION
# Description

The onchain data updater in the join/exit flow was trying to modify a readonly pool. This PR fixes that by deep cloning the initial pool before decoration.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test there are no console warnings about readonly mutations in the join/exit flows.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
