### PR TITLE
fix: Set tokensList on fake Pool type

### DIFF
--- a/src/composables/useVotingGauges.ts
+++ b/src/composables/useVotingGauges.ts
@@ -12,10 +12,12 @@ import { isGoerli } from './useNetwork';
 import { orderedPoolTokens } from '@/composables/usePool';
 import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controller.decorator';
 import { Pool, PoolToken } from '@/services/pool/types';
+import { cloneDeep } from 'lodash';
 
 export function orderedTokenURIs(gauge: VotingGaugeWithVotes): string[] {
-  const gaugePool = gauge.pool as Pool;
+  const gaugePool = cloneDeep(gauge.pool as Pool);
   gaugePool.tokensList = gauge.pool.tokens.map(token => token.address);
+
   const sortedTokens = orderedPoolTokens(
     gaugePool,
     gaugePool.tokens as PoolToken[]

--- a/src/composables/useVotingGauges.ts
+++ b/src/composables/useVotingGauges.ts
@@ -14,9 +14,11 @@ import { VotingGaugeWithVotes } from '@/services/balancer/gauges/gauge-controlle
 import { Pool, PoolToken } from '@/services/pool/types';
 
 export function orderedTokenURIs(gauge: VotingGaugeWithVotes): string[] {
+  const gaugePool = gauge.pool as Pool;
+  gaugePool.tokensList = gauge.pool.tokens.map(token => token.address);
   const sortedTokens = orderedPoolTokens(
-    gauge.pool as Pool,
-    gauge.pool.tokens as PoolToken[]
+    gaugePool,
+    gaugePool.tokens as PoolToken[]
   );
   return sortedTokens.map(
     token => gauge.tokenLogoURIs[token?.address || ''] || ''


### PR DESCRIPTION
# Description

Changing the veBAL table to display only the underlying token icons for deep pools causes and error because the gauge pool object we pass in is not a real pool object and doesn't have a tokensList attribute. This caused an error in the underlying tokenTree parsing where we want to remove the pre-minted address from the tree.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test veBAL table works locally, this doesn't cause a render failure in production but it does on localhost.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
