### PR TITLE
Hotfix: Lower min total shares

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.92.6",
+  "version": "1.92.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.92.6",
+      "version": "1.92.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.92.6",
+  "version": "1.92.7",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -139,7 +139,7 @@ export default function usePoolsQuery(
       where: {
         tokensList: { [tokensListFilterOperation]: tokenListFormatted },
         poolType: { not_in: POOLS.ExcludedPoolTypes },
-        totalShares: { gt: 0.01 },
+        totalShares: { gt: 0.00001 },
         id: { not_in: POOLS.BlockList },
       },
     };

--- a/src/services/balancer/api/entities/pools/query.ts
+++ b/src/services/balancer/api/entities/pools/query.ts
@@ -8,7 +8,7 @@ const defaultArgs: GraphQLArgs = {
   orderDirection: 'desc',
   where: {
     totalShares: {
-      gt: 0.01,
+      gt: 0.00001,
     },
     id: {
       not_in: POOLS.BlockList,

--- a/src/services/balancer/subgraph/entities/pools/query.ts
+++ b/src/services/balancer/subgraph/entities/pools/query.ts
@@ -9,7 +9,7 @@ const defaultArgs: GraphQLArgs = {
   orderDirection: 'desc',
   where: {
     totalShares: {
-      gt: 0.01,
+      gt: 0.00001,
     },
     id: {
       not_in: POOLS.BlockList,


### PR DESCRIPTION
- Some new pools on Gnosis aren't appearing because their totalShares is < 0.01. This will be a general problem with new pools on chains so changing the totalShares minimum to 0.00001 instead.
- This won't affect the main pools list on any other chains, but will affect the filtered pools if there is only a handful as more very low liquidity pools will show in searches.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Ensure that this pool shows in the main pool list on gnosis chain: https://app.balancer.fi/#/gnosis-chain/pool/0xf48f01dcb2cbb3ee1f6aab0e742c2d3941039d56000200000000000000000012

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
