### PR TITLE
Refactor/add tokens provider fake

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "worker-loader": "^3.0.8"
   },
   "lint-staged": {
-    "*.{js,ts,vue}": "eslint --cache --fix --max-warnings 1",
+    "*.{js,ts,vue}": "eslint --cache --fix --max-warnings 0",
     "*.{md,json,yaml,html}": "prettier --write",
     "*.{css,vue}": "stylelint --fix"
   },

--- a/src/components/btns/ClaimProtocolRewardsBtn.spec.ts
+++ b/src/components/btns/ClaimProtocolRewardsBtn.spec.ts
@@ -12,11 +12,6 @@ vi.mock('@/providers/tokens.provider');
 vi.mock('@/composables/queries/useProtocolRewardsQuery');
 vi.mock('@/services/rpc-provider/rpc-provider.service');
 
-vi.mock('@/services/balancer/contracts/contracts/fee-distributor');
-vi.mock('@/providers/tokens.provider');
-vi.mock('@/composables/queries/useProtocolRewardsQuery');
-vi.mock('@/services/rpc-provider/rpc-provider.service');
-
 const mockClaimBalance = vi.fn().mockResolvedValue(txResponseMock);
 const mockClaimBalances = vi.fn().mockResolvedValue(txResponseMock);
 

--- a/src/composables/swap/useJoinExit.spec.ts
+++ b/src/composables/swap/useJoinExit.spec.ts
@@ -4,18 +4,7 @@ import { computed, ref } from 'vue';
 import { initBalancerWithDefaultMocks } from '@/dependencies/balancer-sdk.mocks';
 import useJoinExit from '@/composables/swap/useJoinExit';
 import { noop } from 'lodash';
-import { mountComposable } from '@tests/mount-helpers';
-
-vi.mock('@/providers/tokens.provider', () => ({
-  useTokens: () => {
-    return {
-      injectTokens: vi.fn(noop),
-      priceFor: vi.fn(noop),
-      useTokens: vi.fn(noop),
-      getToken: vi.fn(noop),
-    };
-  },
-}));
+import { mountComposableWithFakeTokensProvider as mountComposable } from '@tests/mount-helpers';
 
 initBalancerWithDefaultMocks();
 

--- a/src/composables/swap/useSwapping.spec.ts
+++ b/src/composables/swap/useSwapping.spec.ts
@@ -9,7 +9,6 @@ import { UserSettingsProviderSymbol } from '@/providers/user-settings.provider';
 import { BalancerSDK, SwapInfo } from '@balancer-labs/sdk';
 import { BigNumber } from '@ethersproject/bignumber';
 import { mountComposableWithFakeTokensProvider as mountComposable } from '@tests/mount-helpers';
-import { noop } from 'lodash';
 import { mock, mockDeep } from 'vitest-mock-extended';
 import mockSorOutput from './__mocks__/mockSorOutput';
 import { TokensResponse } from '@/providers/tokens.provider';
@@ -39,8 +38,6 @@ vi.spyOn(useSor, 'default').mockImplementation(() => {
 
 const mockTokensOutput = { value: {} };
 const tokensProviderOverride: DeepPartial<TokensResponse> = {
-  injectTokens: vi.fn(noop),
-  priceFor: vi.fn(noop),
   getToken: () => mockTokenInfoIn,
   tokens: mockTokensOutput,
 };

--- a/src/composables/swap/useSwapping.spec.ts
+++ b/src/composables/swap/useSwapping.spec.ts
@@ -8,10 +8,12 @@ import { provideTokenLists } from '@/providers/token-lists.provider';
 import { UserSettingsProviderSymbol } from '@/providers/user-settings.provider';
 import { BalancerSDK, SwapInfo } from '@balancer-labs/sdk';
 import { BigNumber } from '@ethersproject/bignumber';
-import { mountComposable } from '@tests/mount-helpers';
+import { mountComposableWithFakeTokensProvider as mountComposable } from '@tests/mount-helpers';
 import { noop } from 'lodash';
 import { mock, mockDeep } from 'vitest-mock-extended';
 import mockSorOutput from './__mocks__/mockSorOutput';
+import { TokensResponse } from '@/providers/tokens.provider';
+import { DeepPartial } from '@tests/unit/types';
 
 initOldMulticallerWithDefaultMocks();
 initEthersContractWithDefaultMocks();
@@ -35,21 +37,13 @@ vi.spyOn(useSor, 'default').mockImplementation(() => {
   return mockSorOutput;
 });
 
-vi.mock('@/providers/tokens.provider', () => {
-  const mockTokensOutput = { value: {} };
-
-  return {
-    useTokens: () => {
-      return {
-        injectTokens: vi.fn(noop),
-        priceFor: vi.fn(noop),
-        useTokens: vi.fn(noop),
-        getToken: vi.fn(() => ({ value: mockTokenInfoIn })),
-        tokens: mockTokensOutput,
-      };
-    },
-  };
-});
+const mockTokensOutput = { value: {} };
+const tokensProviderOverride: DeepPartial<TokensResponse> = {
+  injectTokens: vi.fn(noop),
+  priceFor: vi.fn(noop),
+  getToken: () => mockTokenInfoIn,
+  tokens: mockTokensOutput,
+};
 
 const swapInfoMock = mock<SwapInfo>();
 
@@ -103,14 +97,16 @@ const mockProps = {
 
 describe('useSwapping', () => {
   it('Should load', () => {
-    const { result } = mountComposable(() =>
-      useSwapping(
-        mockProps.exactIn,
-        mockProps.tokenInAddressInput,
-        mockProps.tokenInAmountInput,
-        mockProps.tokenOutAddressInput,
-        mockProps.tokenOutAmountInput
-      )
+    const { result } = mountComposable(
+      () =>
+        useSwapping(
+          mockProps.exactIn,
+          mockProps.tokenInAddressInput,
+          mockProps.tokenInAmountInput,
+          mockProps.tokenOutAddressInput,
+          mockProps.tokenOutAmountInput
+        ),
+      { tokensProviderOverride }
     );
     expect(result).toBeTruthy();
   });
@@ -135,6 +131,7 @@ describe('useSwapping', () => {
         provide(UserSettingsProviderSymbol, userSettingsResponse),
           provideTokenLists();
       },
+      tokensProviderOverride,
     });
     await result.joinExit.handleAmountChange();
 

--- a/src/composables/useLock.spec.ts
+++ b/src/composables/useLock.spec.ts
@@ -1,4 +1,4 @@
-import { mountComposable } from '@tests/mount-helpers';
+import { mountComposableWithFakeTokensProvider as mountComposable } from '@tests/mount-helpers';
 import waitForExpect from 'wait-for-expect';
 
 import { useLock } from '@/composables/useLock';
@@ -7,8 +7,6 @@ import { defaultLockedAmount } from '@/dependencies/Multicaller.mocks';
 import { provideUserData } from '@/providers/user-data.provider';
 import { poolsStoreService } from '@/services/pool/pools-store.service';
 import { aVeBalPool } from '@tests/unit/builders/pool.builders';
-
-vi.mock('@/providers/tokens.provider');
 
 initDependenciesWithDefaultMocks();
 

--- a/src/composables/useNumbers.spec.ts
+++ b/src/composables/useNumbers.spec.ts
@@ -1,8 +1,6 @@
-import { mountComposable } from '@tests/mount-helpers';
+import { mountComposableWithFakeTokensProvider as mountComposable } from '@tests/mount-helpers';
 import BigNumber from 'bignumber.js';
 import useNumbers, { bspToDec, FNumFormats } from './useNumbers';
-
-vi.mock('@/providers/tokens.provider');
 
 describe('useNumbers', () => {
   const { result } = mountComposable(() => useNumbers());

--- a/src/providers/__mocks__/tokens.provider.fake.spec.ts
+++ b/src/providers/__mocks__/tokens.provider.fake.spec.ts
@@ -1,0 +1,146 @@
+import { sleep } from '@/lib/utils';
+import { mount } from '@tests/mount-composable-tester';
+import {
+  customFakeTokensProvider,
+  defaultBalance,
+  defaultPrice,
+  fakeTokensProvider,
+} from './tokens.provider.fake';
+
+async function mountFakeTokensProvider() {
+  const { result } = mount(() => fakeTokensProvider());
+  // Wait for tokens list promise
+  await sleep(10);
+  return result;
+}
+
+test('Fakes provided state', async () => {
+  const {
+    nativeAsset,
+    tokens,
+    wrappedNativeAsset,
+    activeTokenListTokens,
+    balancerTokenListTokens,
+    prices,
+    balances,
+    allowances,
+  } = await mountFakeTokensProvider();
+
+  expect(nativeAsset.address).toBe(
+    '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+  );
+
+  expect(Object.keys(tokens.value)).toEqual([
+    '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+    '0xfA8449189744799aD2AcE7e0EBAC8BB7575eff47', //BAL
+    '0x8c9e6c40d3402480ACE624730524fACC5482798c', //DAI
+    '0x1f1f156E0317167c11Aa412E3d1435ea29Dc3cCE', //USDT
+    '0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb', //USDC
+    '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1', //WETH
+    '0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9', //WBTC
+    '0x398106564948fEeb1fEdeA0709AE7D969D62a391', //miMATIC
+  ]);
+
+  expect(wrappedNativeAsset.value.address).toBe(
+    '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1' //WETH
+  );
+
+  expect(Object.keys(activeTokenListTokens.value)).toEqual([
+    '0xfA8449189744799aD2AcE7e0EBAC8BB7575eff47',
+    '0x8c9e6c40d3402480ACE624730524fACC5482798c',
+    '0x1f1f156E0317167c11Aa412E3d1435ea29Dc3cCE',
+    '0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb',
+    '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+    '0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9',
+    '0x398106564948fEeb1fEdeA0709AE7D969D62a391',
+  ]);
+
+  expect(Object.keys(balancerTokenListTokens.value)).toEqual([
+    '0xfA8449189744799aD2AcE7e0EBAC8BB7575eff47',
+    '0x8c9e6c40d3402480ACE624730524fACC5482798c',
+    '0x1f1f156E0317167c11Aa412E3d1435ea29Dc3cCE',
+    '0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb',
+    '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+    '0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9',
+    '0x398106564948fEeb1fEdeA0709AE7D969D62a391',
+    '0x5cEA6A84eD13590ED14903925Fa1A73c36297d99',
+    '0x0595D1Df64279ddB51F1bdC405Fe2D0b4Cc86681',
+    '0xeFD681A82970AC5d980b9B2D40499735e7BF3F1F',
+    '0x13ACD41C585d7EbB4a9460f7C8f50BE60DC080Cd',
+    '0x829f35cEBBCd47d3c120793c12f7A232c903138B',
+    '0xFF386a3d08f80AC38c77930d173Fa56C6286Dc8B',
+    '0x89534a24450081Aa267c79B07411e9617D984052',
+    '0x811151066392fd641Fe74A9B55a712670572D161',
+    '0x4Cb1892FdDF14f772b2E39E299f44B2E5DA90d04',
+  ]);
+
+  expect(Object.keys(prices.value)).toEqual([]);
+  expect(Object.keys(balances.value)).toEqual([]);
+  expect(Object.keys(allowances.value)).toEqual([]);
+});
+
+const daiAddress = '0x8c9e6c40d3402480ACE624730524fACC5482798c';
+const wethAddress = '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1';
+
+test('Fakes provided methods', async () => {
+  const {
+    injectTokens,
+    searchTokens,
+    hasBalance,
+    approvalRequired,
+    approvalsRequired,
+    priceFor,
+    balanceFor,
+    getTokens,
+    getToken,
+    injectPrices,
+    injectedPrices,
+    getMaxBalanceFor,
+  } = await mountFakeTokensProvider();
+
+  // Does not fail
+  injectTokens(['0x811151066392fd641Fe74A9B55a712670572D161']);
+
+  const foundTokens = await searchTokens('WETH', {});
+  expect(Object.keys(foundTokens)).toEqual([
+    '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+  ]);
+
+  expect(hasBalance('any address')).toBeFalse();
+
+  expect(approvalRequired(daiAddress, '100')).toBeTrue();
+
+  const nativeAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+  expect(approvalRequired(nativeAddress, '100')).toBeFalse();
+
+  expect(approvalsRequired([daiAddress, wethAddress], ['50', '75'])).toEqual([
+    daiAddress,
+    wethAddress,
+  ]);
+
+  expect(priceFor('any address')).toBe(defaultPrice);
+  expect(balanceFor('any address')).toBe(defaultBalance);
+
+  const tokens = getTokens([daiAddress, wethAddress]);
+  expect(Object.keys(tokens)).toEqual([daiAddress, wethAddress]);
+  expect(tokens[daiAddress].name).toBe('Dai');
+  expect(tokens[wethAddress].name).toBe('WETH');
+
+  const token = getToken(daiAddress);
+  expect(token.name).toBe('Dai');
+
+  injectPrices({ [daiAddress]: { usd: 80 } });
+  expect(injectedPrices.value[daiAddress].usd).toBe(80);
+
+  expect(getMaxBalanceFor(daiAddress)).toBe(defaultBalance);
+});
+
+test('Can be customized with override parameter', async () => {
+  const { result } = mount(() =>
+    customFakeTokensProvider({ priceFor: () => 125, balanceFor: () => '0.19' })
+  );
+
+  const { priceFor, balanceFor } = result;
+  expect(priceFor(daiAddress)).toBe(125);
+  expect(balanceFor(daiAddress)).toBe('0.19');
+});

--- a/src/providers/__mocks__/tokens.provider.fake.ts
+++ b/src/providers/__mocks__/tokens.provider.fake.ts
@@ -1,0 +1,457 @@
+import { provideUserSettings } from '@/providers/user-settings.provider';
+import { UserSettingsResponse } from '@/providers/user-settings.provider';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { getAddress, isAddress } from '@ethersproject/address';
+import { compact, pick } from 'lodash';
+
+import useConfig from '@/composables/useConfig';
+import { TOKENS } from '@/constants/tokens';
+import {
+  bnum,
+  forChange,
+  getAddressFromPoolId,
+  includesAddress,
+  isSameAddress,
+} from '@/lib/utils';
+import { safeInject } from '@/providers/inject';
+import {
+  provideTokenLists,
+  TokenListsResponse,
+} from '@/providers/token-lists.provider';
+import { TokenPrices } from '@/services/coingecko/api/price.service';
+import { configService } from '@/services/config/config.service';
+import { ContractAllowancesMap } from '@/services/token/concerns/allowances.concern';
+import { BalanceMap } from '@/services/token/concerns/balances.concern';
+import {
+  NativeAsset,
+  TokenInfo,
+  TokenInfoMap,
+  TokenListMap,
+} from '@/types/TokenList';
+import {
+  tokensProvider,
+  TokensProviderSymbol,
+  TokensResponse,
+} from '../tokens.provider';
+
+/**
+ * TYPES
+ */
+type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
+
+export interface TokensProviderState {
+  loading: boolean;
+  injectedTokens: TokenInfoMap;
+  allowanceContracts: string[];
+  injectedPrices: TokenPrices;
+}
+
+export const defaultPrice = 2;
+export const defaultBalance = '10';
+
+/**
+ * Fake provider to be used by tests.
+ * It behaves like the original tokens provider but it avoids network calls
+ * It can be customized with override parameter
+ */
+export const customFakeTokensProvider = (
+  override: DeepPartial<TokensResponse>
+) => fakeTokensProvider(provideUserSettings(), provideTokenLists(), override);
+
+/**
+ * Fake provider to be used by tests.
+ * It behaves like the original tokens provider but it avoids network calls
+ * It can be customized with override parameter
+ */
+export const fakeTokensProvider = (
+  userSettings: UserSettingsResponse = provideUserSettings(),
+  tokenLists: TokenListsResponse = provideTokenLists(),
+  override: DeepPartial<TokensResponse> = {}
+): TokensResponse => {
+  /**
+   * COMPOSABLES
+   */
+  const { networkConfig } = useConfig();
+  const { currency } = userSettings;
+  const isWalletReady = ref(true);
+
+  const {
+    tokensListPromise,
+    allTokenLists,
+    activeTokenLists,
+    balancerTokenLists,
+  } = tokenLists;
+
+  /**
+   * STATE
+   */
+  const nativeAsset: NativeAsset = {
+    ...networkConfig.nativeAsset,
+    chainId: networkConfig.chainId,
+  };
+
+  const state: TokensProviderState = reactive({
+    loading: true,
+    injectedTokens: {},
+    allowanceContracts: compact([
+      networkConfig.addresses.vault,
+      networkConfig.addresses.wstETH,
+      configService.network.addresses.veBAL,
+    ]),
+    injectedPrices: {},
+  });
+
+  /**
+   * COMPUTED
+   */
+
+  /**
+   * All tokens from all token lists.
+   */
+  const allTokenListTokens = computed((): TokenInfoMap => {
+    return {
+      [networkConfig.nativeAsset.address]: nativeAsset,
+      ...mapTokenListTokens(allTokenLists.value),
+      ...state.injectedTokens,
+    };
+  });
+
+  /**
+   * All tokens from token lists that are toggled on.
+   */
+  const activeTokenListTokens = computed(
+    (): TokenInfoMap => mapTokenListTokens(activeTokenLists.value)
+  );
+
+  /**
+   * All tokens from Balancer token lists, e.g. 'listed' and 'vetted'.
+   */
+  const balancerTokenListTokens = computed(
+    (): TokenInfoMap => mapTokenListTokens(balancerTokenLists.value)
+  );
+
+  /**
+   * The main tokens map
+   * A combination of activated token list tokens
+   * and any injected tokens. Static and dynamic
+   * meta data should be available for these tokens.
+   */
+  const tokens = computed(
+    (): TokenInfoMap => ({
+      [networkConfig.nativeAsset.address]: nativeAsset,
+      ...activeTokenListTokens.value,
+      ...state.injectedTokens,
+    })
+  );
+
+  const tokenAddresses = computed((): string[] => Object.keys(tokens.value));
+
+  const wrappedNativeAsset = computed(
+    (): TokenInfo => getToken(TOKENS.Addresses.wNativeAsset)
+  );
+
+  const prices = computed((): TokenPrices => ({}));
+  const balances = computed((): BalanceMap => ({}));
+  const allowances = computed((): ContractAllowancesMap => ({}));
+
+  const dynamicDataLoaded = computed(() => true);
+
+  const dynamicDataLoading = computed(() => false);
+
+  /**
+   * METHODS
+   */
+  /**
+   * Create token map from a token list tokens array.const isEmpty = Object.keys(person).length === 0;
+   */
+  function mapTokenListTokens(tokenListMap: TokenListMap): TokenInfoMap {
+    const isEmpty = Object.keys(tokenListMap).length === 0;
+    if (isEmpty) return {};
+
+    const tokens = [...Object.values(tokenListMap)]
+      .map(list => list.tokens)
+      .flat();
+
+    const tokensMap = tokens.reduce<TokenInfoMap>((acc, token) => {
+      const address: string = getAddress(token.address);
+
+      // Don't include if already included
+      if (acc[address]) return acc;
+
+      // Don't include if not on app network
+      if (token.chainId !== networkConfig.chainId) return acc;
+
+      acc[address] = token;
+      return acc;
+    }, {});
+
+    return tokensMap;
+  }
+
+  /**
+   * Fetches static token metadata for given addresses and injects
+   * tokens into state tokens map.
+   */
+  async function injectTokens(addresses: string[]): Promise<void> {
+    addresses = addresses
+      .filter(a => a)
+      .map(getAddressFromPoolId)
+      .map(getAddress);
+
+    // Remove any duplicates
+    addresses = [...new Set(addresses)];
+
+    const existingAddresses = Object.keys(tokens.value);
+
+    await tokensListPromise;
+
+    // Only inject tokens that aren't already in tokens
+    const injectable = addresses.filter(
+      address => !includesAddress(existingAddresses, address)
+    );
+    if (injectable.length === 0) return;
+
+    // Wait for balances/allowances/prices to be fetched for newly injected tokens.
+    await nextTick();
+    await forChange(dynamicDataLoading, false);
+  }
+
+  /**
+   * Given query, filters tokens map by name, symbol or address.
+   * If address is provided, search for address in tokens or injectToken
+   */
+  async function searchTokens(
+    query: string,
+    {
+      excluded = [],
+      disableInjection = false,
+      subset = [],
+    }: { excluded?: string[]; disableInjection?: boolean; subset?: string[] }
+  ): Promise<TokenInfoMap> {
+    let tokensToSearch = subset.length > 0 ? getTokens(subset) : tokens.value;
+    if (!query) return removeExcluded(tokensToSearch, excluded);
+
+    tokensToSearch =
+      subset.length > 0 ? tokensToSearch : allTokenListTokens.value;
+
+    const potentialAddress = getAddressFromPoolId(query);
+
+    if (isAddress(potentialAddress)) {
+      const address = getAddress(potentialAddress);
+      const token = tokensToSearch[address];
+      if (token) {
+        return { [address]: token };
+      } else {
+        if (!disableInjection) {
+          await injectTokens([address]);
+          return pick(tokens.value, address);
+        } else {
+          return { [address]: token };
+        }
+      }
+    } else {
+      const tokensArray = Object.entries(tokensToSearch);
+      const results = tokensArray.filter(
+        ([, token]) =>
+          token.name.toLowerCase().includes(query.toLowerCase()) ||
+          token.symbol.toLowerCase().includes(query.toLowerCase())
+      );
+      return removeExcluded(Object.fromEntries(results), excluded);
+    }
+  }
+
+  /**
+   * Remove excluded tokens from given token map.
+   */
+  function removeExcluded(
+    tokens: TokenInfoMap,
+    excluded: string[]
+  ): TokenInfoMap {
+    return Object.keys(tokens)
+      .filter(address => !includesAddress(excluded, address))
+      .reduce((result, address) => {
+        result[address] = tokens[address];
+        return result;
+      }, {});
+  }
+
+  /**
+   * Check if approval is required for given contract address
+   * for a token and amount.
+   */
+  function approvalRequired(
+    tokenAddress: string,
+    amount: string,
+    contractAddress = networkConfig.addresses.vault
+  ): boolean {
+    if (!amount || bnum(amount).eq(0)) return false;
+    if (!contractAddress) return false;
+    if (isSameAddress(tokenAddress, nativeAsset.address)) return false;
+
+    const allowance = bnum(
+      (allowances.value[contractAddress] || {})[getAddress(tokenAddress)]
+    );
+    return allowance.lt(amount);
+  }
+
+  /**
+   * Check which tokens require approvals for given amounts
+   * @returns a subset of the token addresses passed in.
+   */
+  function approvalsRequired(
+    tokenAddresses: string[],
+    amounts: string[],
+    contractAddress: string = networkConfig.addresses.vault
+  ): string[] {
+    return tokenAddresses.filter((address, index) => {
+      if (!contractAddress) return false;
+
+      return approvalRequired(address, amounts[index], contractAddress);
+    });
+  }
+
+  /**
+   * Fetch price for a token
+   */
+  function priceFor(address: string): number {
+    return defaultPrice;
+  }
+
+  /**
+   * Fetch balance for a token
+   */
+  function balanceFor(address: string): string {
+    return defaultBalance;
+  }
+
+  /**
+   * Checks if token has a balance
+   */
+  function hasBalance(address: string): boolean {
+    return Number(balances.value[address]) > 0;
+  }
+
+  /**
+   * Get subset of tokens from state
+   */
+  function getTokens(addresses: string[]): TokenInfoMap {
+    return pick(tokens.value, addresses.map(getAddress));
+  }
+
+  /**
+   * Get single token from state
+   */
+  function getToken(address: string): TokenInfo {
+    address = getAddressFromPoolId(address); // In case pool ID has been passed
+    if (address) address = getAddress(address);
+    return tokens.value[address];
+  }
+
+  /**
+   * Injects prices for tokens where the pricing provider
+   * may have not found a valid price for provided tokens
+   * @param pricesToInject A map of <address, price> to inject
+   */
+  function injectPrices(pricesToInject: TokenPrices) {
+    state.injectedPrices = {
+      ...state.injectedPrices,
+      ...pricesToInject,
+    };
+  }
+
+  /**
+   * Get max balance of token
+   * @param tokenAddress
+   * @param disableNativeAssetBuffer Optionally disable native asset buffer
+   */
+  function getMaxBalanceFor(
+    tokenAddress,
+    disableNativeAssetBuffer = false
+  ): string {
+    let maxAmount;
+    const tokenBalance = balanceFor(tokenAddress) || '0';
+    const tokenBalanceBN = bnum(tokenBalance);
+
+    if (tokenAddress === nativeAsset.address && !disableNativeAssetBuffer) {
+      // Subtract buffer for gas
+      maxAmount = tokenBalanceBN.gt(nativeAsset.minTransactionBuffer)
+        ? tokenBalanceBN.minus(nativeAsset.minTransactionBuffer).toString()
+        : '0';
+    } else {
+      maxAmount = tokenBalance;
+    }
+    return maxAmount;
+  }
+
+  /**
+   * LIFECYCLE
+   */
+  onBeforeMount(async () => {
+    // Inject veBAL because it's not in tokenlists.
+    const { veBAL } = configService.network.addresses;
+    await injectTokens([veBAL]);
+    state.loading = false;
+  });
+
+  const balanceQueryLoading = ref(false);
+  const priceQueryLoading = ref(false);
+  const priceQueryError = ref(false);
+  const balancesQueryError = ref(false);
+  const allowancesQueryError = ref(false);
+  const refetchPrices = vi.fn();
+  const refetchBalances = vi.fn();
+  const refetchAllowances = vi.fn();
+
+  const defaultResponse = {
+    // state
+    ...toRefs(state),
+    nativeAsset,
+    // computed
+    tokens,
+    wrappedNativeAsset,
+    activeTokenListTokens,
+    balancerTokenListTokens,
+    prices,
+    balances,
+    allowances,
+    balanceQueryLoading,
+    dynamicDataLoaded,
+    dynamicDataLoading,
+    priceQueryError,
+    priceQueryLoading,
+    balancesQueryError,
+    allowancesQueryError,
+    // methods
+    refetchPrices,
+    refetchBalances,
+    refetchAllowances,
+    injectTokens,
+    searchTokens,
+    hasBalance,
+    approvalRequired,
+    approvalsRequired,
+    priceFor,
+    balanceFor,
+    getTokens,
+    getToken,
+    injectPrices,
+    getMaxBalanceFor,
+  };
+
+  return { ...defaultResponse, ...override } as TokensResponse;
+};
+
+export function provideTokens(
+  userSettings: UserSettingsResponse,
+  tokenLists: TokenListsResponse
+) {
+  const tokensResponse = tokensProvider(userSettings, tokenLists);
+  provide(TokensProviderSymbol, tokensResponse);
+  return tokensResponse;
+}
+
+export const useTokens = (): TokensResponse => {
+  return safeInject(TokensProviderSymbol);
+};

--- a/src/providers/__mocks__/tokens.provider.ts
+++ b/src/providers/__mocks__/tokens.provider.ts
@@ -43,9 +43,12 @@ export function useTokens() {
   return tokensProvider();
 }
 
+export const defaultPrice = 2;
+export const defaultBalance = '10';
+
 export const mockTokensProvider = mock<TokensResponse>();
-mockTokensProvider.priceFor.mockReturnValue(2);
-mockTokensProvider.balanceFor.mockReturnValue('10');
+mockTokensProvider.priceFor.mockReturnValue(defaultPrice);
+mockTokensProvider.balanceFor.mockReturnValue(defaultBalance);
 mockTokensProvider.getTokens.mockImplementation(addresses => {
   return Object.fromEntries(
     addresses.map(address => {

--- a/tests/mount-helpers.ts
+++ b/tests/mount-helpers.ts
@@ -6,13 +6,16 @@ import { provideTokenLists } from '@/providers/token-lists.provider';
 import {
   tokensProvider,
   TokensProviderSymbol,
+  TokensResponse,
 } from '@/providers/tokens.provider';
 import { provideUserSettings } from '@/providers/user-settings.provider';
 import { provideWallets } from '@/providers/wallet.provider';
+import { fakeTokensProvider } from '@/providers/__mocks__/tokens.provider.fake';
 import { computed, provide, Ref } from 'vue';
 import waitForExpect from 'wait-for-expect';
 import { mount, MountResult } from './mount-composable-tester';
 import { registerTestPlugins } from './registerTestPlugins';
+import { DeepPartial } from './unit/types';
 
 export const defaultStakedShares = '5';
 
@@ -48,6 +51,30 @@ export function mountComposableWithDefaultTokensProvider<R>(
       const userSettings = provideUserSettings();
       const tokenLists = provideTokenLists();
       provide(TokensProviderSymbol, tokensProvider(userSettings, tokenLists));
+      options?.extraProvidersCb?.();
+    },
+  });
+}
+
+export function mountComposableWithFakeTokensProvider<R>(
+  callback: () => R,
+  options?: {
+    extraProvidersCb?: () => void;
+    tokensProviderOverride?: DeepPartial<TokensResponse>;
+  }
+): MountResult<R> {
+  return mountComposable<R>(callback, {
+    extraProvidersCb: () => {
+      const userSettings = provideUserSettings();
+      const tokenLists = provideTokenLists();
+      provide(
+        TokensProviderSymbol,
+        fakeTokensProvider(
+          userSettings,
+          tokenLists,
+          options?.tokensProviderOverride
+        )
+      );
       options?.extraProvidersCb?.();
     },
   });

--- a/tests/unit/types.ts
+++ b/tests/unit/types.ts
@@ -1,0 +1,3 @@
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};


### PR DESCRIPTION
# Description

This PR introduces a new `mountComposableWithFakeTokensProvider`helper that allows testing composables with a tokens-provider fake, which is a double with a very similar but fast implementation of the real tokens provider (it is faster because it replaces the slow I/O dependencies).

The final goal is to replace every `vi.mock('@/providers/tokens.provider');` with this helper that will finally become `mountComposable`.  Instead of doing it in one go, we do it in in baby steps so that the PRs are easier to review and discuss. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
