### PR TITLE
Change excluded pool types to included

### DIFF
--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -53,7 +53,7 @@ export default function usePoolQuery(
       where: {
         id: { eq: id?.toLowerCase() },
         totalShares: { gt: -1 }, // Avoid the filtering for low liquidity pools
-        poolType: { not_in: POOLS.ExcludedPoolTypes },
+        poolType: { in: POOLS.IncludedPoolTypes },
       },
     };
     return queryArgs;

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -138,7 +138,7 @@ export default function usePoolsQuery(
       orderDirection: 'desc',
       where: {
         tokensList: { [tokensListFilterOperation]: tokenListFormatted },
-        poolType: { not_in: POOLS.ExcludedPoolTypes },
+        poolType: { in: POOLS.IncludedPoolTypes },
         totalShares: { gt: 0.00001 },
         id: { not_in: POOLS.BlockList },
       },

--- a/src/composables/queries/useUserPoolsQuery.ts
+++ b/src/composables/queries/useUserPoolsQuery.ts
@@ -61,7 +61,7 @@ export default function useUserPoolsQuery(options: QueryOptions = {}) {
     const pools = await balancerSubgraphService.pools.get({
       where: {
         id: { in: poolSharesIds },
-        poolType: { not_in: POOLS.ExcludedPoolTypes },
+        poolType: { in: POOLS.IncludedPoolTypes },
       },
     });
 

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -74,7 +74,7 @@ export type Pools = {
     Gauntlet: string[];
   };
   BlockList: string[];
-  ExcludedPoolTypes: string[];
+  IncludedPoolTypes: string[];
   Stable: {
     AllowList: string[];
   };
@@ -114,18 +114,14 @@ const POOLS_GOERLI: Pools = {
   BlockList: [
     '0x22d398c68030ef6b1c55321cca6e0cecc5c93b2f000200000000000000000678',
   ],
-  ExcludedPoolTypes: [
-    'Element',
-    'AaveLinear',
-    'EulerLinear',
-    'GearboxLinear',
-    'Linear',
-    'ERC4626Linear',
-    'FX',
-    'Gyro2',
-    'Gyro3',
-    'GyroE',
-    'HighAmpComposableStable',
+  IncludedPoolTypes: [
+    'Weighted',
+    'Stable',
+    'MetaStable',
+    'LiquidityBootstrapping',
+    'Investment',
+    'StablePhantom',
+    'ComposableStable',
   ],
   Stable: {
     AllowList: [
@@ -192,17 +188,14 @@ const POOLS_MAINNET: Pools = {
     Gauntlet: [],
   },
   BlockList: [''],
-  ExcludedPoolTypes: [
-    'Element',
-    'AaveLinear',
-    'EulerLinear',
-    'GearboxLinear',
-    'Linear',
-    'ERC4626Linear',
-    'Gyro2',
-    'Gyro3',
-    'GyroE',
-    'HighAmpComposableStable',
+  IncludedPoolTypes: [
+    'Weighted',
+    'Stable',
+    'MetaStable',
+    'LiquidityBootstrapping',
+    'Investment',
+    'StablePhantom',
+    'ComposableStable',
   ],
   Stable: {
     AllowList: [
@@ -510,17 +503,14 @@ const POOLS_POLYGON: Pools = {
     Gauntlet: [],
   },
   BlockList: [''],
-  ExcludedPoolTypes: [
-    'Element',
-    'AaveLinear',
-    'EulerLinear',
-    'GearboxLinear',
-    'Linear',
-    'ERC4626Linear',
-    'Gyro2',
-    'Gyro3',
-    'GyroE',
-    'HighAmpComposableStable',
+  IncludedPoolTypes: [
+    'Weighted',
+    'Stable',
+    'MetaStable',
+    'LiquidityBootstrapping',
+    'Investment',
+    'StablePhantom',
+    'ComposableStable',
   ],
   Stable: {
     AllowList: [
@@ -660,18 +650,14 @@ const POOLS_ARBITRUM: Pools = {
     Gauntlet: [],
   },
   BlockList: [''],
-  ExcludedPoolTypes: [
-    'Element',
-    'AaveLinear',
-    'EulerLinear',
-    'GearboxLinear',
-    'Linear',
-    'ERC4626Linear',
-    'FX',
-    'Gyro2',
-    'Gyro3',
-    'GyroE',
-    'HighAmpComposableStable',
+  IncludedPoolTypes: [
+    'Weighted',
+    'Stable',
+    'MetaStable',
+    'LiquidityBootstrapping',
+    'Investment',
+    'StablePhantom',
+    'ComposableStable',
   ],
   Stable: {
     AllowList: [
@@ -757,18 +743,14 @@ const POOLS_GNOSIS: Pools = {
     Gauntlet: [],
   },
   BlockList: [''],
-  ExcludedPoolTypes: [
-    'Element',
-    'AaveLinear',
-    'EulerLinear',
-    'GearboxLinear',
-    'Linear',
-    'ERC4626Linear',
-    'FX',
-    'Gyro2',
-    'Gyro3',
-    'GyroE',
-    'HighAmpComposableStable',
+  IncludedPoolTypes: [
+    'Weighted',
+    'Stable',
+    'MetaStable',
+    'LiquidityBootstrapping',
+    'Investment',
+    'StablePhantom',
+    'ComposableStable',
   ],
   Stable: {
     AllowList: [
@@ -824,18 +806,14 @@ const POOLS_GENERIC: Pools = {
     Gauntlet: [],
   },
   BlockList: [''],
-  ExcludedPoolTypes: [
-    'Element',
-    'AaveLinear',
-    'EulerLinear',
-    'GearboxLinear',
-    'Linear',
-    'ERC4626Linear',
-    'FX',
-    'Gyro2',
-    'Gyro3',
-    'GyroE',
-    'HighAmpComposableStable',
+  IncludedPoolTypes: [
+    'Weighted',
+    'Stable',
+    'MetaStable',
+    'LiquidityBootstrapping',
+    'Investment',
+    'StablePhantom',
+    'ComposableStable',
   ],
   Stable: {
     AllowList: [

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -196,6 +196,7 @@ const POOLS_MAINNET: Pools = {
     'Investment',
     'StablePhantom',
     'ComposableStable',
+    'FX',
   ],
   Stable: {
     AllowList: [
@@ -511,6 +512,7 @@ const POOLS_POLYGON: Pools = {
     'Investment',
     'StablePhantom',
     'ComposableStable',
+    'FX',
   ],
   Stable: {
     AllowList: [


### PR DESCRIPTION
# Description

There are many new Linear pools and different pool types being created (full list here: https://github.com/balancer/balancer-subgraph-v2/blob/master/src/mappings/helpers/pools.ts#L9-L33), almost all of which we don't want to show. Rather than constantly excluding new types it makes more sense to have an included pool types list. 

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Load each pools list on each network. Ensure the list of returned pools is the same as production. 
- Search for different tokens in the pools list, ensure the list of returned pools is the same. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
