### PR TITLE
Hotfix: Don't treat pools with joins disabled as deep pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.92.12",
+  "version": "1.92.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.92.12",
+      "version": "1.92.13",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.92.12",
+  "version": "1.92.13",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/usePool.ts
+++ b/src/composables/usePool.ts
@@ -118,7 +118,7 @@ export function isDeep(pool: Pool): boolean {
     '0x3f7a7fd7f214be45ec26820fd01ac3be4fc75aa70002000000000000000004c5', // stg/bbeusd
   ];
 
-  return treatAsDeep.includes(pool.id);
+  return treatAsDeep.includes(pool.id) && !isJoinsDisabled(pool.id);
 }
 
 /**


### PR DESCRIPTION
# Description

Changing isDeep to be false when a pool is disabled, so that if a parent pool has disabled joins users can still withdraw all linear tokens correctly. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
