### PR TITLE
Disable using API on mainnet while pools aren't updating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.92.13",
+  "version": "1.92.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.92.13",
+      "version": "1.92.14",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.92.13",
+  "version": "1.92.14",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/lib/config/homestead.json
+++ b/src/lib/config/homestead.json
@@ -12,7 +12,7 @@
   "explorer": "https://etherscan.io",
   "explorerName": "Etherscan",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
-  "balancerApi": "https://api.balancer.fi",
+  "balancerApi": "",
   "poolsUrlV2": "https://storageapi.fleek.co/johngrantuk-team-bucket/poolsV2.json",
   "subgraphs": {
     "main": [


### PR DESCRIPTION
Disables using the Balancer API on mainnet as the update pools function is currently throwing errors. 