### PR TITLE
Fix: duplicate pools issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.92.15",
+  "version": "1.92.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.92.15",
+      "version": "1.92.16",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.92.15",
+  "version": "1.92.16",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -132,9 +132,14 @@ export default function usePoolsQuery(
     const tokenListFormatted = filterTokens.value.map(address =>
       address.toLowerCase()
     );
+
+    const orderBy = isBalancerApiDefined
+      ? poolsSortField?.value
+      : 'totalLiquidity';
+
     const queryArgs: GraphQLArgs = {
       chainId: configService.network.chainId,
-      orderBy: poolsSortField?.value || 'totalLiquidity',
+      orderBy,
       orderDirection: 'desc',
       where: {
         tokensList: { [tokensListFilterOperation]: tokenListFormatted },

--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -106,8 +106,8 @@ export default function usePoolsQuery(
 
         return decoratedPools;
       },
-      get skip(): number {
-        return balancerSubgraphService.pools.skip;
+      get skip(): undefined {
+        return undefined;
       },
     };
   }
@@ -205,11 +205,11 @@ export default function usePoolsQuery(
     try {
       const pools: Pool[] = await poolsRepository.fetch(fetchOptions);
 
+      poolsStoreService.addPools(pools);
+
       skip = poolsRepository.currentProvider?.skip
         ? poolsRepository.currentProvider.skip
-        : 0;
-
-      poolsStoreService.setPools(pools);
+        : poolsStoreService.pools.value?.length || 0;
 
       return {
         pools,
@@ -224,7 +224,8 @@ export default function usePoolsQuery(
     }
   };
 
-  options.getNextPageParam = (lastPage: PoolsQueryResponse) => lastPage.skip;
+  options.getNextPageParam = (lastPage: PoolsQueryResponse) =>
+    lastPage.skip || 0;
 
   return useInfiniteQuery<PoolsQueryResponse>(queryKey, queryFn, options);
 }

--- a/src/services/pool/pools-store.service.ts
+++ b/src/services/pool/pools-store.service.ts
@@ -15,6 +15,10 @@ export class PoolsStoreService implements IPoolsStoreService {
     this.pools.value = pools;
   }
 
+  public addPools(pools: Pool[]): void {
+    this.pools.value = [...(this.pools.value ?? []), ...pools];
+  }
+
   public findPool(id: string): Pool | void {
     return this.pools.value?.find(pool => pool.id === id);
   }


### PR DESCRIPTION
# Description

Fixes issue when fetching pools list from subgraph and clicking load more causes duplicate pools in list.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test loading more pools in pools list, there should no longer be any duplicate pools.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
