### PR TITLE
Hotfix: Fix slippage converting numbers into scientific notation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.93.2",
+  "version": "1.93.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.93.2",
+      "version": "1.93.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.93.2",
+  "version": "1.93.3",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/__mocks__/useUserSettings.ts
+++ b/src/composables/__mocks__/useUserSettings.ts
@@ -1,7 +1,0 @@
-import { ref } from 'vue';
-
-export default function useUserSettings() {
-  return {
-    currency: ref('usd'),
-  };
-}

--- a/src/composables/useSlippage.spec.ts
+++ b/src/composables/useSlippage.spec.ts
@@ -1,0 +1,70 @@
+import useSlippage from './useSlippage';
+import { mountComposable } from '@tests/mount-helpers';
+
+vi.mock('@/providers/user-settings.provider');
+
+describe('useSlippage', () => {
+  const { result } = mountComposable(() => useSlippage());
+
+  it('Should load', () => {
+    expect(result).toBeTruthy();
+  });
+
+  describe('minusSlippage', () => {
+    it('Should minus slippage correctly', () => {
+      const value = result.minusSlippage('10000', 18);
+      expect(value).toBe('9900.0');
+    });
+
+    it('Should not convert large values to scientific notation', () => {
+      const value = result.minusSlippage(
+        '2773323395126403492447232848118078909179',
+        18
+      );
+      expect(value).toBe('2745590161175139457522760519636898120087.21');
+    });
+  });
+
+  describe('minusSlippageScaled', () => {
+    it('Should minus slippage correctly', () => {
+      const value = result.minusSlippageScaled('10000');
+      expect(value).toBe('9900');
+    });
+
+    it('Should not convert large values to scientific notation', () => {
+      const value = result.minusSlippageScaled(
+        '2773323395126403492447232848118078909179'
+      );
+      expect(value).toBe('2745590161175139457522760519636898120087');
+    });
+  });
+
+  describe('addSlippage', () => {
+    it('Should add slippage correctly', () => {
+      const value = result.addSlippage('4000', 18);
+      expect(value).toBe('4040.0');
+    });
+
+    it('Should not convert large values to scientific notation', () => {
+      const value = result.addSlippage(
+        '1234563395126403492447232848118078909179',
+        18
+      );
+      expect(value).toBe('1246909029077667527371705176599259698270.79');
+    });
+  });
+
+  describe('addSlippageScaled', () => {
+    it('Should add slippage correctly', () => {
+      const value = result.addSlippageScaled('5000');
+      expect(value).toBe('5050');
+    });
+
+    it('Should not convert large values to scientific notation', () => {
+      const value = result.addSlippageScaled(
+        '1234563395126403492447232848118078909179'
+      );
+      expect(value).toBe('1246909029077667527371705176599259698270');
+    });
+  });
+});

--- a/src/composables/useSlippage.ts
+++ b/src/composables/useSlippage.ts
@@ -26,7 +26,7 @@ export default function useSlippage() {
       .div(10000)
       .dp(0, BigNumber.ROUND_UP);
 
-    return bnum(amount).minus(delta).toString();
+    return bnum(amount).minus(delta).toFixed();
   }
 
   function addSlippage(_amount: string, decimals: number): string {
@@ -42,7 +42,7 @@ export default function useSlippage() {
       .div(10000)
       .dp(0, BigNumber.ROUND_DOWN);
 
-    return bnum(amount).plus(delta).toString();
+    return bnum(amount).plus(delta).toFixed();
   }
 
   return { minusSlippage, minusSlippageScaled, addSlippage, addSlippageScaled };

--- a/src/providers/__mocks__/user-settings.provider.ts
+++ b/src/providers/__mocks__/user-settings.provider.ts
@@ -1,0 +1,22 @@
+import { FiatCurrency } from '@/constants/currency';
+import { mock } from 'vitest-mock-extended';
+import { ref } from 'vue';
+import { UserSettingsResponse } from '../user-settings.provider';
+
+let slippage = '0.01';
+
+export const mockUserSettingsProvider = mock<UserSettingsResponse>();
+mockUserSettingsProvider.currency = ref(FiatCurrency.usd);
+mockUserSettingsProvider.slippage = ref(slippage);
+
+export function _setSlippage(value: string) {
+  slippage = value;
+}
+
+export function provideUserSettings(): UserSettingsResponse {
+  return mockUserSettingsProvider;
+}
+
+export function useUserSettings(): UserSettingsResponse {
+  return mockUserSettingsProvider;
+}


### PR DESCRIPTION
- Slippage adding and subtracting sometimes turns numbers into scientific notation with e+XX on the end which ethers cannot parse causing errors in the frontend. This fixes it by forcing the output to be fixed and also adds tests for this file.

Fixes https://balancer-labs.sentry.io/issues/4004085182/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Hard to test this because only certain withdraw values trigger it. If tests are passing it should be good as I did TDD on this bug. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
