### PR TITLE
Hotfix: Recovery exits from old composable stable pools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.93.3",
+  "version": "1.93.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.93.3",
+      "version": "1.93.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.93.3",
+  "version": "1.93.4",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawalTokenSelect.vue
@@ -47,7 +47,7 @@ const tokenAddresses = computed(() => {
 });
 
 const options = computed(() => {
-  return ['all', ...tokenAddresses.value];
+  return ['all', ...(props.pool.isInRecoveryMode ? [] : tokenAddresses.value)];
 });
 
 const selectedToken = computed((): TokenInfo => getToken(selectedOption.value));

--- a/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
+++ b/src/components/forms/pool_actions/WithdrawForm/composables/useWithdrawMath.ts
@@ -180,7 +180,10 @@ export default function useWithdrawMath(
 
   // To account for exact maths required in BPTInForExactTokensOut cases.
   const shouldUseBptBuffer = computed(
-    (): boolean => isProportional.value && isShallowComposableStablePool.value
+    (): boolean =>
+      isProportional.value &&
+      isShallowComposableStablePool.value &&
+      !pool.value.isInRecoveryMode
   );
 
   const bptBuffer = computed((): number =>
@@ -260,7 +263,11 @@ export default function useWithdrawMath(
   const amountsOut = computed(() => {
     return fullAmounts.value.map((amount, i) => {
       if (amount === '0' || exactOut.value) return amount;
-      if (isProportional.value && isShallowComposableStablePool.value)
+      if (
+        isProportional.value &&
+        isShallowComposableStablePool.value &&
+        !pool.value.isInRecoveryMode
+      )
         return amount;
 
       return minusSlippage(amount, withdrawalTokens.value[i].decimals);
@@ -287,7 +294,11 @@ export default function useWithdrawMath(
         return batchRelayerSwap.value?.outputs?.amountsIn || '0';
       }
       return batchSwap.value?.returnAmounts?.[0]?.toString() || '0';
-    } else if (isShallowComposableStablePool.value) return queryBptIn.value;
+    } else if (
+      isShallowComposableStablePool.value &&
+      !pool.value.isInRecoveryMode
+    )
+      return queryBptIn.value;
 
     return poolCalculator
       .bptInForExactTokenOut(tokenOutAmount.value, tokenOutIndex.value)
@@ -302,7 +313,11 @@ export default function useWithdrawMath(
    */
   const bptIn = computed((): string => {
     if (exactOut.value) return addSlippageScaled(fullBPTIn.value);
-    if (isShallowComposableStablePool.value && !singleAssetMaxed.value) {
+    if (
+      isShallowComposableStablePool.value &&
+      !pool.value.isInRecoveryMode &&
+      !singleAssetMaxed.value
+    ) {
       return addSlippageScaled(fullBPTIn.value);
     }
 

--- a/src/services/pool/exchange/exchange.service.ts
+++ b/src/services/pool/exchange/exchange.service.ts
@@ -154,28 +154,19 @@ function queryRecoveryExit(
 ): { bptIn: BigNumber; amountsOut: BigNumber[] } {
   const evmBptIn = parseUnits(bptIn);
   const evmTotalSupply = parseUnits(pool?.onchain?.totalSupply || '0');
-  const balances = Object.values(pool?.onchain?.tokens || []).map(
-    t => t.balance
-  );
-  const evmBalances = balances.map(balance =>
-    parseUnits(balance, pool.onchain?.decimals || 18)
+  const balances = Object.values(pool?.onchain?.tokens || []).map(t => ({
+    balance: t.balance,
+    decimals: t.decimals,
+  }));
+  const evmBalances = balances.map(({ balance, decimals }) =>
+    parseUnits(balance, decimals || 18)
   );
   const bptRatio = evmBptIn.div(evmTotalSupply);
 
-  console.log('balances', balances);
-  console.log('parsedBptIn', evmBptIn.toString());
-  console.log('totalSupply', evmTotalSupply.toString());
-  console.log('bptRatio', bptRatio.toString());
-
-  const output = {
+  return {
     bptIn: evmBptIn,
     amountsOut: evmBalances.map(balance => {
       return balance.mul(bptRatio);
     }),
   };
-  console.log(
-    'amountsOut',
-    output.amountsOut.map(a => a.toString())
-  );
-  return output;
 }

--- a/src/services/pool/exchange/exchange.service.ts
+++ b/src/services/pool/exchange/exchange.service.ts
@@ -13,6 +13,7 @@ import ExitParams from './serializers/ExitParams';
 import JoinParams from './serializers/JoinParams';
 import { TransactionBuilder } from '@/services/web3/transactions/transaction.builder';
 import { BigNumber } from 'ethers';
+import { parseUnits } from '@ethersproject/units';
 
 export default class ExchangeService {
   pool: Ref<Pool>;
@@ -97,13 +98,17 @@ export default class ExchangeService {
       exactOut
     );
 
-    const txBuilder = new TransactionBuilder(signer);
-    return await txBuilder.contract.callStatic({
-      contractAddress: this.helpersAddress,
-      abi: BalancerHelpers__factory.abi,
-      action: 'queryExit',
-      params,
-    });
+    if (this.pool.value.isInRecoveryMode) {
+      return queryRecoveryExit(bptIn, this.pool.value);
+    } else {
+      const txBuilder = new TransactionBuilder(signer);
+      return await txBuilder.contract.callStatic({
+        contractAddress: this.helpersAddress,
+        abi: BalancerHelpers__factory.abi,
+        action: 'queryExit',
+        params,
+      });
+    }
   }
 
   public async exit(
@@ -141,4 +146,35 @@ export default class ExchangeService {
   private get exitParams() {
     return new ExitParams(this);
   }
+}
+
+function queryRecoveryExit(
+  bptIn: string,
+  pool: Pool
+): { bptIn: BigNumber; amountsOut: BigNumber[] } {
+  const evmBptIn = parseUnits(bptIn);
+  const evmTotalSupply = parseUnits(pool?.onchain?.totalSupply || '0');
+  const balances = Object.values(pool?.onchain?.tokens || []).map(
+    t => t.balance
+  );
+  const evmBalances = balances.map(balance =>
+    parseUnits(balance, pool.onchain?.decimals || 18)
+  );
+  console.log('balances', balances);
+  console.log('parsedBptIn', evmBptIn.toString());
+  console.log('totalSupply', evmTotalSupply.toString());
+  const bptRatio = evmBptIn.div(evmTotalSupply);
+  console.log('bptRatio', bptRatio.toString());
+
+  const output = {
+    bptIn: evmBptIn,
+    amountsOut: evmBalances.map(balance => {
+      return balance.mul(bptRatio);
+    }),
+  };
+  console.log(
+    'amountsOut',
+    output.amountsOut.map(a => a.toString())
+  );
+  return output;
 }

--- a/src/services/pool/exchange/exchange.service.ts
+++ b/src/services/pool/exchange/exchange.service.ts
@@ -160,10 +160,11 @@ function queryRecoveryExit(
   const evmBalances = balances.map(balance =>
     parseUnits(balance, pool.onchain?.decimals || 18)
   );
+  const bptRatio = evmBptIn.div(evmTotalSupply);
+
   console.log('balances', balances);
   console.log('parsedBptIn', evmBptIn.toString());
   console.log('totalSupply', evmTotalSupply.toString());
-  const bptRatio = evmBptIn.div(evmTotalSupply);
   console.log('bptRatio', bptRatio.toString());
 
   const output = {


### PR DESCRIPTION
# Description

We originally built in a hack to make proportional exits work for ComposableStable pool types that didn't support the exit type needed for proportional exits. This hack breaks proportional exits from these pools when they go into recovery mode and proportional exits are possible. This PR adds `isInRecoveryMode` to all withdrawal math conditionals relevant to this hack.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test withdrawals from this pool `0x8e85e97ed19c0fa13b2549309965291fbbc0048b0000000000000000000003ba`

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
