### PR TITLE
Hotfix: Bump SDK version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sdk": "^1.0.1-beta.24",
+        "@balancer-labs/sdk": "^1.0.3-beta.0",
         "@balancer-labs/typechain": "^1.0.0",
         "@cowprotocol/contracts": "^1.3.1",
         "@ensdomains/content-hash": "^2.5.3",
@@ -805,12 +805,12 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.1-beta.24",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.24.tgz",
-      "integrity": "sha512-SbwtQzkE3dbHRX67HcF5BJkKG+qbK+l54ccQ86Dx1XMPRkTiGnsB8oFWoaBIhrfo7S2KltatBLWG4j6RNkT0Cg==",
+      "version": "1.0.3-beta.0",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.3-beta.0.tgz",
+      "integrity": "sha512-N59BTYg2vxPcE3bm+ENAepG6vyWdkzINTGuyUTOFEv/RAvU304FfIoQwgyltKRHOQnwTadzuVBxPi9ljlYfVnQ==",
       "dev": true,
       "dependencies": {
-        "@balancer-labs/sor": "^4.1.1-beta.3",
+        "@balancer-labs/sor": "^4.1.1-beta.6",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -856,9 +856,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.1.1-beta.5",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.5.tgz",
-      "integrity": "sha512-+sUwNWfvsYRFdcl+Pb5MMOnQSwOgNndvlh50s9T4i+13eIdfRw5jCMNvL8ahrzxrR06kJ1B4wlGrzhh/BuBqqA==",
+      "version": "4.1.1-beta.6",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.6.tgz",
+      "integrity": "sha512-Bfeqa2XZJowjSqLr0bv6ndKY4FOIR+upOWt0ILSzNNd2MLXiklWklg6TeAvTZXknOC+1zDCyiPUjEH+YfvA2Zw==",
       "dev": true,
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
@@ -19587,12 +19587,12 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.1-beta.24",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.24.tgz",
-      "integrity": "sha512-SbwtQzkE3dbHRX67HcF5BJkKG+qbK+l54ccQ86Dx1XMPRkTiGnsB8oFWoaBIhrfo7S2KltatBLWG4j6RNkT0Cg==",
+      "version": "1.0.3-beta.0",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.3-beta.0.tgz",
+      "integrity": "sha512-N59BTYg2vxPcE3bm+ENAepG6vyWdkzINTGuyUTOFEv/RAvU304FfIoQwgyltKRHOQnwTadzuVBxPi9ljlYfVnQ==",
       "dev": true,
       "requires": {
-        "@balancer-labs/sor": "^4.1.1-beta.3",
+        "@balancer-labs/sor": "^4.1.1-beta.6",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -19630,9 +19630,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.1.1-beta.5",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.5.tgz",
-      "integrity": "sha512-+sUwNWfvsYRFdcl+Pb5MMOnQSwOgNndvlh50s9T4i+13eIdfRw5jCMNvL8ahrzxrR06kJ1B4wlGrzhh/BuBqqA==",
+      "version": "4.1.1-beta.6",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.6.tgz",
+      "integrity": "sha512-Bfeqa2XZJowjSqLr0bv6ndKY4FOIR+upOWt0ILSzNNd2MLXiklWklg6TeAvTZXknOC+1zDCyiPUjEH+YfvA2Zw==",
       "dev": true,
       "requires": {
         "isomorphic-fetch": "^2.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.93.8",
+  "version": "1.93.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.93.8",
+      "version": "1.93.9",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@aave/protocol-js": "^4.3.0",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sdk": "^1.0.1-beta.24",
+    "@balancer-labs/sdk": "^1.0.3-beta.0",
     "@balancer-labs/typechain": "^1.0.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@ensdomains/content-hash": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.93.8",
+  "version": "1.93.9",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/lib/balancer.sdk.ts
+++ b/src/lib/balancer.sdk.ts
@@ -1,22 +1,38 @@
-import { BalancerSDK, Network } from '@balancer-labs/sdk';
+import {
+  BalancerSDK,
+  Network,
+  BALANCER_NETWORK_CONFIG,
+  BalancerNetworkConfig,
+} from '@balancer-labs/sdk';
 import { configService } from '@/services/config/config.service';
 import { ref } from 'vue';
 import { isTestMode } from '@/plugins/modes';
 
-const network = ((): Network => {
+const network = ((): BalancerNetworkConfig => {
   switch (configService.network.key) {
     case '1':
-      return Network.MAINNET;
+      return BALANCER_NETWORK_CONFIG[Network.MAINNET];
     case '5':
-      return Network.GOERLI;
-    case '137':
-      return Network.POLYGON;
+      return BALANCER_NETWORK_CONFIG[Network.GOERLI];
+    case '137': {
+      // StablePool with Convergence issues
+      let poolsToIgnore = ['0xc31a37105b94ab4efca1954a14f059af11fcd9bb'];
+      if (BALANCER_NETWORK_CONFIG[Network.POLYGON].poolsToIgnore)
+        poolsToIgnore = [
+          ...poolsToIgnore,
+          ...BALANCER_NETWORK_CONFIG[Network.POLYGON].poolsToIgnore,
+        ];
+      return {
+        ...BALANCER_NETWORK_CONFIG[Network.POLYGON],
+        poolsToIgnore,
+      };
+    }
     case '42161':
-      return Network.ARBITRUM;
+      return BALANCER_NETWORK_CONFIG[Network.ARBITRUM];
     case '100':
-      return Network.GNOSIS;
+      return BALANCER_NETWORK_CONFIG[Network.GNOSIS];
     default:
-      return Network.MAINNET;
+      return BALANCER_NETWORK_CONFIG[Network.MAINNET];
   }
 })();
 

--- a/src/lib/balancer.sdk.ts
+++ b/src/lib/balancer.sdk.ts
@@ -15,8 +15,10 @@ const network = ((): BalancerNetworkConfig => {
     case '5':
       return BALANCER_NETWORK_CONFIG[Network.GOERLI];
     case '137': {
-      // StablePool with Convergence issues
-      let poolsToIgnore = ['0xc31a37105b94ab4efca1954a14f059af11fcd9bb'];
+      let poolsToIgnore = [
+        '0xc31a37105b94ab4efca1954a14f059af11fcd9bb', // StablePool with Convergence issues
+      ];
+      // Make sure to include `poolsToIgnore` already defined in SDK package
       if (BALANCER_NETWORK_CONFIG[Network.POLYGON].poolsToIgnore)
         poolsToIgnore = [
           ...poolsToIgnore,


### PR DESCRIPTION
# Description

As reported by Tim, some swaps (on Polygon) were failing with `STABLE_GET_BALANCE_DIDNT_CONVERGE`. This was due to a broken Stable pool. PR makes it easy to filter SDK pools using `poolsToIgnore` config setting rather than having to wait for a new SDK package release.
Filters broken pool causing issue originally reported.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

You can try adding other pools to list and making sure they don't appear in swap route selected.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
