### PR TITLE
Hotfix: revert sdk config change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.94.2",
+  "version": "1.94.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.94.2",
+      "version": "1.94.3",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.94.2",
+  "version": "1.94.3",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/lib/balancer.sdk.ts
+++ b/src/lib/balancer.sdk.ts
@@ -1,40 +1,22 @@
-import {
-  BalancerSDK,
-  Network,
-  BALANCER_NETWORK_CONFIG,
-  BalancerNetworkConfig,
-} from '@balancer-labs/sdk';
+import { BalancerSDK, Network } from '@balancer-labs/sdk';
 import { configService } from '@/services/config/config.service';
 import { ref } from 'vue';
 import { isTestMode } from '@/plugins/modes';
 
-const network = ((): BalancerNetworkConfig => {
+const network = ((): Network => {
   switch (configService.network.key) {
     case '1':
-      return BALANCER_NETWORK_CONFIG[Network.MAINNET];
+      return Network.MAINNET;
     case '5':
-      return BALANCER_NETWORK_CONFIG[Network.GOERLI];
-    case '137': {
-      let poolsToIgnore = [
-        '0xc31a37105b94ab4efca1954a14f059af11fcd9bb', // StablePool with Convergence issues
-      ];
-      // Make sure to include `poolsToIgnore` already defined in SDK package
-      if (BALANCER_NETWORK_CONFIG[Network.POLYGON].poolsToIgnore)
-        poolsToIgnore = [
-          ...poolsToIgnore,
-          ...BALANCER_NETWORK_CONFIG[Network.POLYGON].poolsToIgnore,
-        ];
-      return {
-        ...BALANCER_NETWORK_CONFIG[Network.POLYGON],
-        poolsToIgnore,
-      };
-    }
+      return Network.GOERLI;
+    case '137':
+      return Network.POLYGON;
     case '42161':
-      return BALANCER_NETWORK_CONFIG[Network.ARBITRUM];
+      return Network.ARBITRUM;
     case '100':
-      return BALANCER_NETWORK_CONFIG[Network.GNOSIS];
+      return Network.GNOSIS;
     default:
-      return BALANCER_NETWORK_CONFIG[Network.MAINNET];
+      return Network.MAINNET;
   }
 })();
 


### PR DESCRIPTION
# Description

SDK config changes were causing swap exits to fail. The config changes were implemented to allow the frontend to more quickly added pool IDs to ignore for the SOR but the ID in question is now handled by default in the SDK so it is no longer required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test single asset exits from deep pools

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
