### PR TITLE
Hotfix: swap approval states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.94.5",
+  "version": "1.94.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.94.5",
+      "version": "1.94.6",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.94.5",
+  "version": "1.94.6",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -78,15 +78,15 @@ const actionStates = ref(
  * WATCHERS
  */
 watch(
-  () => [props.actions, props.isLoading],
-  () => {
-    _actions.value = props.actions;
-    actionStates.value = _actions.value.map(() => ({
-      ...defaultActionState,
-    }));
-  },
-  {
-    deep: true,
+  () => props.actions,
+  newActions => {
+    // If new action has been injected reset all action states.
+    if (newActions.length !== _actions.value.length) {
+      _actions.value = props.actions;
+      actionStates.value = _actions.value.map(() => ({
+        ...defaultActionState,
+      }));
+    }
   }
 );
 

--- a/src/components/modals/SwapPreviewModal.vue
+++ b/src/components/modals/SwapPreviewModal.vue
@@ -35,35 +35,31 @@ type Props = {
 /**
  * PROPS & EMITS
  */
-
 const props = defineProps<Props>();
-
 const emit = defineEmits(['swap', 'close']);
-// COMPOSABLES
+
+/**
+ * COMPOSABLES
+ */
 const { t } = useI18n();
 const { fNum, toFiat } = useNumbers();
 const { tokens, balanceFor, approvalRequired } = useTokens();
-const {
-  relayerSignature: batchRelayerSignature,
-  relayerApprovalAction: batchRelayerApprovalAction,
-} = useRelayerApproval(RelayerType.BATCH_V4);
-const { isUnlocked: batchRelayerIsUnlocked } = useRelayerApprovalTx(
-  RelayerType.BATCH_V4
-);
 const { blockNumber, account, startConnectWithInjectedProvider } = useWeb3();
 const { slippage } = useUserSettings();
 
-// state
+/**
+ * STATE
+ */
 const lastQuote = ref<SwapQuote | null>(
   props.swapping.isWrapUnwrapSwap.value ? null : props.swapping.getQuote()
 );
 const priceUpdated = ref(false);
 const priceUpdateAccepted = ref(false);
-
-// DATA
 const showSummaryInFiat = ref(false);
 
-// COMPUTED
+/**
+ * COMPUTED
+ */
 const slippageRatePercent = computed(() =>
   fNum(slippage.value, FNumFormats.percent)
 );
@@ -248,21 +244,6 @@ const labels = computed(() => {
   };
 });
 
-const tokenApproval = useTokenApproval(
-  addressIn,
-  props.swapping.tokenInAmountInput,
-  tokens
-);
-
-const cowswapRelayerApproval = useRelayerApprovalTx(
-  RelayerType.COWSWAP,
-  props.swapping.isCowswapSwap
-);
-
-const pools = computed<SubgraphPoolBase[]>(() => {
-  return props.swapping.sor.pools.value;
-});
-
 const wrapType = computed(() =>
   getWrapAction(
     props.swapping.tokenIn.value.address,
@@ -276,7 +257,29 @@ const isStETHSwap = computed(
     wrapType.value === WrapType.NonWrap
 );
 
+const tokenApproval = useTokenApproval(
+  addressIn,
+  props.swapping.tokenInAmountInput,
+  tokens
+);
+
+const {
+  relayerSignature: batchRelayerSignature,
+  relayerApprovalAction: batchRelayerApprovalAction,
+} = useRelayerApproval(RelayerType.BATCH_V4);
+
+const batchRelayerApproval = useRelayerApprovalTx(RelayerType.BATCH_V4);
+
+const cowswapRelayerApproval = useRelayerApprovalTx(
+  RelayerType.COWSWAP,
+  props.swapping.isCowswapSwap
+);
+
 const lidoRelayerApproval = useRelayerApprovalTx(RelayerType.LIDO, isStETHSwap);
+
+const pools = computed<SubgraphPoolBase[]>(() => {
+  return props.swapping.sor.pools.value;
+});
 
 const requiresTokenApproval = computed(() => {
   if (props.swapping.isWrap.value && !props.swapping.isEthSwap.value) {
@@ -294,7 +297,7 @@ const requiresTokenApproval = computed(() => {
 const requiresBatchRelayerApproval = computed(
   () =>
     props.swapping.isJoinExitSwap.value &&
-    !batchRelayerIsUnlocked.value &&
+    !batchRelayerApproval.isUnlocked.value &&
     !batchRelayerSignature.value
 );
 
@@ -318,7 +321,9 @@ const showTokenApprovalStep = computed(
 );
 
 const showBatchRelayerApprovalStep = computed(
-  () => props.swapping.isJoinExitSwap.value && !batchRelayerIsUnlocked.value
+  () =>
+    props.swapping.isJoinExitSwap.value &&
+    !batchRelayerApproval.isUnlocked.value
 );
 
 const showCowswapRelayerApprovalStep = computed(
@@ -351,52 +356,32 @@ const showPriceUpdateError = computed(
     !requiresApproval.value && priceUpdated.value && !priceUpdateAccepted.value
 );
 
-const actions = ref<TransactionActionInfo[]>([
-  ...(showCowswapRelayerApprovalStep.value
-    ? [
-        {
-          label: t('approveCowswapRelayer'),
-          loadingLabel: t('approvingCowswapRelayer'),
-          confirmingLabel: t('approveCowswapRelayer'),
-          action: cowswapRelayerApproval.approve,
-          stepTooltip: t(
-            'swapSummary.transactionTypesTooltips.cowswapRelayerApproval.content'
-          ),
-        },
-      ]
-    : []),
-  ...(showLidoRelayerApprovalStep.value
-    ? [
-        {
-          label: t('approveLidoRelayer'),
-          loadingLabel: t('approvingLidoRelayer'),
-          confirmingLabel: t('approveLidoRelayer'),
-          action: lidoRelayerApproval.approve,
-          stepTooltip: t(
-            'swapSummary.transactionTypesTooltips.lidoRelayerApproval.content'
-          ),
-        },
-      ]
-    : []),
-  ...(showBatchRelayerApprovalStep.value
-    ? [batchRelayerApprovalAction.value]
-    : []),
-  ...(showTokenApprovalStep.value
-    ? [
-        {
-          label: t('transactionSummary.approveForSwapping', [
-            props.swapping.tokenIn.value.symbol,
-          ]),
-          loadingLabel: t('actionSteps.approve.loadingLabel'),
-          confirmingLabel: t('confirming'),
-          action: approveToken,
-          stepTooltip: t(
-            'swapSummary.transactionTypesTooltips.tokenApproval.content'
-          ),
-        },
-      ]
-    : []),
-  {
+const actions = computed((): TransactionActionInfo[] => {
+  const actions: TransactionActionInfo[] = [];
+
+  if (showCowswapRelayerApprovalStep.value) {
+    actions.push(cowswapRelayerApproval.action.value);
+  } else if (showLidoRelayerApprovalStep.value) {
+    actions.push(lidoRelayerApproval.action.value);
+  } else if (showBatchRelayerApprovalStep.value) {
+    actions.push(batchRelayerApprovalAction.value);
+  }
+
+  if (showTokenApprovalStep.value) {
+    actions.push({
+      label: t('transactionSummary.approveForSwapping', [
+        props.swapping.tokenIn.value.symbol,
+      ]),
+      loadingLabel: t('actionSteps.approve.loadingLabel'),
+      confirmingLabel: t('confirming'),
+      action: approveToken,
+      stepTooltip: t(
+        'swapSummary.transactionTypesTooltips.tokenApproval.content'
+      ),
+    });
+  }
+
+  actions.push({
     label: labels.value.confirmSwap,
     loadingLabel: t('actionSteps.swap.loadingLabel'),
     confirmingLabel: t('confirming'),
@@ -405,10 +390,14 @@ const actions = ref<TransactionActionInfo[]>([
       props.swapping.isCowswapSwap.value && !props.swapping.isJoinExitSwap
         ? t('swapSummary.transactionTypesTooltips.sign.content')
         : t('swapSummary.transactionTypesTooltips.swap.content'),
-  },
-]);
+  });
 
-// METHODS
+  return actions;
+});
+
+/**
+ * METHODS
+ */
 async function swap() {
   return props.swapping.swap(() => {
     props.swapping.resetAmounts();
@@ -487,7 +476,9 @@ async function approveToken(): Promise<TransactionResponse> {
   }
 }
 
-// WATCHERS
+/**
+ * WATCHERS
+ */
 watch(blockNumber, () => {
   handlePriceUpdate();
 });

--- a/src/composables/approvals/useRelayerApprovalTx.ts
+++ b/src/composables/approvals/useRelayerApprovalTx.ts
@@ -51,10 +51,10 @@ export default function useRelayerApprovalTx(
 
   const action = computed(
     (): TransactionActionInfo => ({
-      label: t('approveBatchRelayer'),
-      loadingLabel: t('checkWallet'),
-      confirmingLabel: t('approvingBatchRelayer'),
-      stepTooltip: t('approveBatchRelayerTooltip'),
+      label: t('transactionSummary.approveRelayer', [relayer]),
+      loadingLabel: t('actionSteps.approve.loadingLabel'),
+      confirmingLabel: t('confirming'),
+      stepTooltip: t('approveRelayerTooltip'),
       action: approve,
     })
   );

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -75,6 +75,7 @@
   "approveBatchRelayer": "Approve Batch relayer",
   "approvingBatchRelayer": "Approving Batch relayer",
   "approveBatchRelayerTooltip": "Your permission is required to use the Batch relayer.",
+  "approveRelayerTooltip": "Your permission is required to use the relayer.",
   "approveTokens": "Approve tokens",
   "approving": "Approving",
   "approvingCowswapRelayer": "Approving Cowswap relayer",


### PR DESCRIPTION
# Description

Because actions steps in the swap preview is a computed property based on many other computed properties, it sometimes triggered a watcher of the actions prop in BalActionSteps despite the actions not actually changing. When that watcher was triggered it reset the state of all the BalActionStep actions, so any completed actions looked like they weren't. This PR ensures the action states are only reset if the length of actions passed via props changes. This is only usually the case once, after initial loading of approvals for example.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test swap approvals work as expected.

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
