### PR TITLE
Hotfix: Fix BalActionSteps state injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.94.6",
+  "version": "1.94.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.94.6",
+      "version": "1.94.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.94.6",
+  "version": "1.94.7",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -67,12 +67,16 @@ const defaultActionState: TransactionActionState = {
  */
 const currentActionIndex = ref(0);
 const _actions = ref<TransactionActionInfo[]>(props.actions);
+const actionStates = ref<TransactionActionState[]>([]);
 
-const actionStates = ref(
-  _actions.value.map(() => ({
+/**
+ * LIFECYCLE
+ */
+onBeforeMount(() => {
+  actionStates.value = props.actions.map(() => ({
     ...defaultActionState,
-  }))
-);
+  }));
+});
 
 /**
  * WATCHERS
@@ -80,14 +84,16 @@ const actionStates = ref(
 watch(
   () => props.actions,
   newActions => {
-    // If new action has been injected reset all action states.
-    if (newActions.length !== _actions.value.length) {
-      _actions.value = props.actions;
-      actionStates.value = _actions.value.map(() => ({
-        ...defaultActionState,
-      }));
-    }
-  }
+    newActions.forEach((action, i) => {
+      _actions.value[i] = action;
+      if (!actionStates.value[i]) {
+        actionStates.value[i] = {
+          ...defaultActionState,
+        };
+      }
+    });
+  },
+  { deep: true }
 );
 
 watch(


### PR DESCRIPTION
# Description

Fix BalActionSteps so that action states are only injected if it doesn't exist already. We had a bug where the watcher wasn't injecting a state for new actions or it would overwrite existing states.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- [ ] Test staking approval flow, this was affected by the latest changes to BalActionSteps

## Visual context

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
