### PR TITLE
Move bridge information to config. Change check from isL2 to hasBridge

### DIFF
--- a/src/components/links/BridgeLink.vue
+++ b/src/components/links/BridgeLink.vue
@@ -2,22 +2,12 @@
 import useNetwork from '@/composables/useNetwork';
 import { buildNetworkIconURL } from '@/lib/utils/urls';
 import { configService } from '@/services/config/config.service';
-import { Network } from '@balancer-labs/sdk';
 import { computed } from 'vue';
 
 const { networkId } = useNetwork();
 
 const bridgeUrl = computed((): string => {
-  switch (networkId.value) {
-    case Network.POLYGON:
-      return 'https://wallet.polygon.technology/polygon/bridge';
-    case Network.ARBITRUM:
-      return 'https://bridge.arbitrum.io/';
-    case Network.GNOSIS:
-      return 'https://bridge.gnosischain.com/';
-    default:
-      return '';
-  }
+  return configService.network.bridgeUrl;
 });
 
 const label = computed((): string => {

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -51,6 +51,7 @@ export const isGoerli = computed(() => networkId.value === Network.GOERLI);
 export const isL2 = computed(
   () => isPolygon.value || isArbitrum.value || isGnosis.value
 );
+export const hasBridge = computed<boolean>(() => !!networkConfig.bridgeUrl);
 export const isTestnet = computed(() => isGoerli.value);
 
 /**

--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -34,6 +34,7 @@ const config: Config = {
     blocks:
       'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
   },
+  bridgeUrl: 'https://bridge.arbitrum.io/',
   supportsEIP1559: false,
   supportsElementPools: false,
   blockTime: 2,

--- a/src/lib/config/docker/index.ts
+++ b/src/lib/config/docker/index.ts
@@ -23,6 +23,7 @@ const config: Config = {
     gauge: '',
     blocks: '',
   },
+  bridgeUrl: '',
   supportsEIP1559: false,
   blockTime: 12,
   nativeAsset: {

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -32,6 +32,7 @@ const config: Config = {
       'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-gnosis-chain-b',
     blocks: '',
   },
+  bridgeUrl: 'https://bridge.gnosischain.com/',
   supportsEIP1559: true,
   supportsElementPools: true,
   blockTime: 5,

--- a/src/lib/config/goerli/index.ts
+++ b/src/lib/config/goerli/index.ts
@@ -31,6 +31,7 @@ const config: Config = {
       'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-goerli',
     blocks: 'https://api.thegraph.com/subgraphs/name/blocklytics/goerli-blocks',
   },
+  bridgeUrl: '',
   supportsEIP1559: true,
   supportsElementPools: true,
   blockTime: 12,

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -34,6 +34,7 @@ const config: Config = {
     blocks:
       'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
   },
+  bridgeUrl: '',
   supportsEIP1559: true,
   supportsElementPools: true,
   blockTime: 12,

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -29,6 +29,7 @@ const config: Config = {
       'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-optimism',
     blocks: '',
   },
+  bridgeUrl: '',
   supportsEIP1559: false,
   supportsElementPools: false,
   nativeAsset: {

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -33,6 +33,7 @@ const config: Config = {
       'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-polygon',
     blocks: 'https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks',
   },
+  bridgeUrl: 'https://wallet.polygon.technology/polygon/bridge',
   supportsEIP1559: true,
   supportsElementPools: false,
   blockTime: 4,

--- a/src/lib/config/test/index.ts
+++ b/src/lib/config/test/index.ts
@@ -23,6 +23,7 @@ const config: Config = {
     gauge: '',
     blocks: '',
   },
+  bridgeUrl: '',
   supportsEIP1559: true,
   supportsElementPools: true,
   blockTime: 12,

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -86,6 +86,7 @@ export interface Config {
     gauge: string;
     blocks: string;
   };
+  bridgeUrl: string;
   supportsEIP1559: boolean;
   supportsElementPools: boolean;
   blockTime: number;

--- a/src/pages/swap.vue
+++ b/src/pages/swap.vue
@@ -7,7 +7,7 @@ import Col3Layout from '@/components/layouts/Col3Layout.vue';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
 import useBreakpoints from '@/composables/useBreakpoints';
 import BridgeLink from '@/components/links/BridgeLink.vue';
-import { isL2 } from '@/composables/useNetwork';
+import { hasBridge } from '@/composables/useNetwork';
 
 /**
  * COMPOSABLES
@@ -23,7 +23,7 @@ const sections = computed(() => {
     { title: 'My wallet', id: 'my-wallet' },
     { title: 'Price chart', id: 'price-chart' },
   ];
-  if (isL2.value) sections.push({ title: 'Bridge assets', id: 'bridge' });
+  if (hasBridge.value) sections.push({ title: 'Bridge assets', id: 'bridge' });
   return sections;
 });
 
@@ -56,7 +56,7 @@ onMounted(() => {
           <template #price-chart>
             <PairPriceGraph />
           </template>
-          <template v-if="isL2" #bridge>
+          <template v-if="hasBridge" #bridge>
             <BridgeLink />
           </template>
         </BalAccordion>
@@ -64,7 +64,7 @@ onMounted(() => {
 
       <template #gutterRight>
         <PairPriceGraph />
-        <BridgeLink v-if="isL2" class="mt-4" />
+        <BridgeLink v-if="hasBridge" class="mt-4" />
       </template>
     </Col3Layout>
   </div>


### PR DESCRIPTION
# Description

- Move bridge URL's to config files. 
- Change check for showing bridge information to show if the bridge URL is set instead of using `isL2`

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Ensure that bridge information is shown on the swap screen for Polygon/Arbitrum/Gnosis Chain
- Ensure that bridge information is not shown on Ethereum / Goerli. 

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
