### PR TITLE
Change protocol rewards checks to config URLs instead of isL2

### DIFF
--- a/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.spec.ts
+++ b/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.spec.ts
@@ -20,7 +20,31 @@ vi.mock('@/composables/useTransactions');
 vi.mock('@/composables/useEthers');
 vi.mock('@/composables/queries/useGaugesQuery');
 vi.mock('@/composables/queries/useGaugesDecorationQuery');
+vi.mock('@/constants/pools.ts', () => {
+  return {
+    POOLS: {
+      IdsMap: {},
+    },
+  };
+});
 vi.mock('@/services/rpc-provider/rpc-provider.service');
+vi.mock('@/services/config/config.service', () => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    default: vi.fn().mockImplementation(() => {}),
+    configService: {
+      network: {
+        nativeAsset: {
+          address: '0x0000000000000000000000000000000000000000',
+        },
+        addresses: {
+          gaugeRewardsHelper: '',
+          vault: '0x0000000000000000000000000000000000000000',
+        },
+      },
+    },
+  };
+});
 vi.mock('@/services/balancer/contracts/contracts/liquidity-gauge');
 
 vi.mock('@/providers/tokens.provider');

--- a/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.spec.ts
+++ b/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.spec.ts
@@ -47,7 +47,6 @@ vi.mock('@/services/config/config.service', () => {
   };
 });
 vi.mock('@/services/balancer/contracts/contracts/liquidity-gauge');
-vi.mock('@/lib/balancer.sdk');
 
 vi.mock('@/providers/tokens.provider');
 

--- a/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.spec.ts
+++ b/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.spec.ts
@@ -34,6 +34,7 @@ vi.mock('@/services/config/config.service', () => {
     default: vi.fn().mockImplementation(() => {}),
     configService: {
       network: {
+        chainId: 5,
         nativeAsset: {
           address: '0x0000000000000000000000000000000000000000',
         },
@@ -46,6 +47,7 @@ vi.mock('@/services/config/config.service', () => {
   };
 });
 vi.mock('@/services/balancer/contracts/contracts/liquidity-gauge');
+vi.mock('@/lib/balancer.sdk');
 
 vi.mock('@/providers/tokens.provider');
 

--- a/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
+++ b/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
@@ -12,6 +12,7 @@ import { Gauge } from '@/services/balancer/gauges/types';
 import TxActionBtn from '../TxActionBtn/TxActionBtn.vue';
 import { configService } from '@/services/config/config.service';
 import useWeb3 from '@/services/web3/useWeb3';
+import { networkHasNativeGauges } from '@/composables/useNetwork';
 
 /**
  * TYPES
@@ -45,7 +46,7 @@ const liquidityGaugeContract = new LiquidityGauge(gaugeAddress);
  * METHODS
  */
 function claimTx() {
-  if (configService.network.addresses.gaugeRewardsHelper) {
+  if (!networkHasNativeGauges.value) {
     const liquidityGaugeRewardsHelperContract = new LiquidityGaugeRewardsHelper(
       configService.network.addresses.gaugeRewardsHelper || ''
     );

--- a/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
+++ b/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
@@ -11,7 +11,6 @@ import { Gauge } from '@/services/balancer/gauges/types';
 
 import TxActionBtn from '../TxActionBtn/TxActionBtn.vue';
 import { configService } from '@/services/config/config.service';
-import { isL2 } from '@/composables/useNetwork';
 import useWeb3 from '@/services/web3/useWeb3';
 
 /**
@@ -46,7 +45,7 @@ const liquidityGaugeContract = new LiquidityGauge(gaugeAddress);
  * METHODS
  */
 function claimTx() {
-  if (isL2.value) {
+  if (configService.network.addresses.gaugeRewardsHelper) {
     const liquidityGaugeRewardsHelperContract = new LiquidityGaugeRewardsHelper(
       configService.network.addresses.gaugeRewardsHelper || ''
     );

--- a/src/composables/queries/useProtocolRewardsQuery.ts
+++ b/src/composables/queries/useProtocolRewardsQuery.ts
@@ -7,7 +7,7 @@ import { configService } from '@/services/config/config.service';
 import { BalanceMap } from '@/services/token/concerns/balances.concern';
 import useWeb3 from '@/services/web3/useWeb3';
 
-import { isL2, isGoerli, networkId } from '../useNetwork';
+import { networkId } from '../useNetwork';
 
 /**
  * TYPES
@@ -29,6 +29,12 @@ const feeDistributorV2 = new FeeDistributor(
   configService.network.addresses.feeDistributor
 );
 
+export const networkHasProtocolRewards = computed<boolean>(
+  () =>
+    configService.network.addresses.feeDistributorDeprecated != '' ||
+    configService.network.addresses.feeDistributor != ''
+);
+
 /**
  * @summary Fetches claimable protocol reward balances.
  */
@@ -45,8 +51,7 @@ export default function useProtocolRewardsQuery(options: QueryOptions = {}) {
     () =>
       isWalletReady.value &&
       account.value != null &&
-      !isL2.value &&
-      !isGoerli.value
+      networkHasProtocolRewards.value
   );
 
   /**

--- a/src/composables/useClaimsData.ts
+++ b/src/composables/useClaimsData.ts
@@ -7,10 +7,10 @@ import useGaugesDecorationQuery from './queries/useGaugesDecorationQuery';
 import useGaugesQuery from './queries/useGaugesQuery';
 import useGraphQuery from './queries/useGraphQuery';
 import useProtocolRewardsQuery, {
+  networkHasProtocolRewards,
   ProtocolRewardsQueryResponse,
 } from './queries/useProtocolRewardsQuery';
 import { isQueryLoading } from './queries/useQueryHelpers';
-import { isGoerli, isL2 } from './useNetwork';
 import { subgraphFallbackService } from '@/services/balancer/subgraph/subgraph-fallback.service';
 import { PoolType } from '@balancer-labs/sdk';
 
@@ -81,12 +81,13 @@ export function useClaimsData() {
   const isLoading = computed(
     (): boolean =>
       isQueryLoading(gaugePoolQuery) ||
-      (!isL2.value && !isGoerli.value && isQueryLoading(protocolRewardsQuery))
+      (networkHasProtocolRewards.value && isQueryLoading(protocolRewardsQuery))
   );
 
   return {
     gauges,
     gaugePools,
+    networkHasProtocolRewards,
     protocolRewards,
     isLoading,
   };

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -57,6 +57,9 @@ export const isTestnet = computed(() => isGoerli.value);
 export const isPoolBoostsEnabled = computed<boolean>(
   () => configService.network.pools.BoostsEnabled
 );
+export const networkHasNativeGauges = computed<boolean>(() => {
+  return networkConfig.addresses.gaugeController !== '';
+});
 /**
  * METHODS
  */

--- a/src/lib/balancer.sdk.ts
+++ b/src/lib/balancer.sdk.ts
@@ -1,14 +1,10 @@
-import { BalancerSDK, Network } from '@balancer-labs/sdk';
+import { BalancerSDK } from '@balancer-labs/sdk';
 import { configService } from '@/services/config/config.service';
 import { ref } from 'vue';
 import { isTestMode } from '@/plugins/modes';
 
-const network = ((): Network => {
-  return configService.network.chainId;
-})();
-
 export const balancer = new BalancerSDK({
-  network,
+  network: configService.network.chainId,
   rpcUrl: configService.rpc,
   customSubgraphUrl: configService.network.subgraph,
 });

--- a/src/lib/config/goerli/tokens.ts
+++ b/src/lib/config/goerli/tokens.ts
@@ -14,6 +14,7 @@ const tokens: TokenConstants = {
     WETH: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
     BAL: '0xfA8449189744799aD2AcE7e0EBAC8BB7575eff47',
     bbaUSD: '0x13ACD41C585d7EbB4a9460f7C8f50BE60DC080Cd',
+    bbaUSDv2: '0x3d5981bdd8d3e49eb7bbdc1d2b156a3ee019c18e',
   },
   PriceChainMap: {
     /**

--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -46,6 +46,7 @@ const { isWalletReady } = useWeb3();
 const {
   gauges,
   gaugePools,
+  networkHasProtocolRewards,
   protocolRewards,
   isLoading: isClaimsLoading,
 } = useClaimsData();
@@ -263,6 +264,8 @@ onBeforeMount(async () => {
               :isLoading="loading"
             />
           </div>
+        </template>
+        <template v-if="networkHasProtocolRewards">
           <div class="mb-16">
             <h3 class="inline-block xl:px-0 pl-4 mt-8 mr-1.5 mb-3 text-xl">
               {{ $t('protocolIncentives') }}

--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -201,7 +201,7 @@ function formatRewardsData(data?: BalanceMap): ProtocolRewardRow[] {
  * @summary Fetches bb-a-USD rate as an appoximation of USD price.
  */
 async function getBBaUSDPrice() {
-  if (TOKENS.Addresses.bbaUSD) {
+  if (TOKENS.Addresses.bbaUSDv2) {
     const approxPrice = bnum(await bbAUSDToken.getRate()).toNumber();
     injectPrices({
       [TOKENS.Addresses.bbaUSD as string]: { [FiatCurrency.usd]: approxPrice },

--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -12,7 +12,7 @@ import ProtocolRewardsTable, {
   ProtocolRewardRow,
 } from '@/components/tables/ProtocolRewardsTable.vue';
 import { GaugePool, useClaimsData } from '@/composables/useClaimsData';
-import { isL2, isMainnet } from '@/composables/useNetwork';
+import { networkHasNativeGauges } from '@/composables/useNetwork';
 import useNumbers from '@/composables/useNumbers';
 import { isStableLike } from '@/composables/usePool';
 import { useTokenHelpers } from '@/composables/useTokenHelpers';
@@ -201,11 +201,13 @@ function formatRewardsData(data?: BalanceMap): ProtocolRewardRow[] {
  * @summary Fetches bb-a-USD rate as an appoximation of USD price.
  */
 async function getBBaUSDPrice() {
-  if (isMainnet.value) {
-    const appoxPrice = bnum(await bbAUSDToken.getRate()).toNumber();
+  if (TOKENS.Addresses.bbaUSD) {
+    const approxPrice = bnum(await bbAUSDToken.getRate()).toNumber();
     injectPrices({
-      [TOKENS.Addresses.bbaUSD as string]: { [FiatCurrency.usd]: appoxPrice },
-      [TOKENS.Addresses.bbaUSDv2 as string]: { [FiatCurrency.usd]: appoxPrice },
+      [TOKENS.Addresses.bbaUSD as string]: { [FiatCurrency.usd]: approxPrice },
+      [TOKENS.Addresses.bbaUSDv2 as string]: {
+        [FiatCurrency.usd]: approxPrice,
+      },
     });
   }
 }
@@ -225,7 +227,7 @@ watch(gaugePools, async newPools => {
  * LIFECYCLE
  */
 onBeforeMount(async () => {
-  if (!isL2.value) await getBBaUSDPrice();
+  await getBBaUSDPrice();
 });
 </script>
 
@@ -241,7 +243,7 @@ onBeforeMount(async () => {
           {{ configService.network.chainName }} {{ $t('liquidityIncentives') }}
         </h2>
 
-        <template v-if="!isL2">
+        <template v-if="networkHasNativeGauges">
           <div class="mb-16">
             <div class="px-4 xl:px-0">
               <div class="flex items-center mt-6 mb-2">
@@ -291,7 +293,7 @@ onBeforeMount(async () => {
             />
           </div>
         </template>
-        <div v-if="!isL2">
+        <div v-if="networkHasNativeGauges">
           <h3 class="inline-block px-4 xl:px-0 mt-8 mr-1.5 text-xl">
             {{ $t('otherTokenIncentives') }}
           </h3>

--- a/src/services/balancer/contracts/contracts/bb-a-usd-token.ts
+++ b/src/services/balancer/contracts/contracts/bb-a-usd-token.ts
@@ -8,7 +8,7 @@ import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service
 export class BBAUSDToken {
   constructor(
     private readonly abi = StablePhantomAbi,
-    public readonly address = TOKENS.Addresses.bbaUSD,
+    public readonly address = TOKENS.Addresses.bbaUSDv2,
     private readonly provider = rpcProviderService.jsonProvider
   ) {}
 


### PR DESCRIPTION
# Description

- Wherever protocol rewards are shown or the query is run, check if the network has a configured address for protocol rewards instead of the isL2 check. 

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Ensure that protocol rewards are shown on Ethereum 
- Ensure protocol rewards show on Goerli (Goerli didn't show before because there was an explicit !isGoerli check, but I thought they should show for this network as it has gauges and staking just like mainnet). 
- Ensure claim page loads correctly on L2's and no protocol rewards are shown. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
