### PR TITLE
Add new isVeBalSupported boolean using config data instead of isL2

### DIFF
--- a/src/components/heros/PortfolioPageHero.vue
+++ b/src/components/heros/PortfolioPageHero.vue
@@ -4,12 +4,13 @@ import { useRouter } from 'vue-router';
 
 import AppHero from '@/components/heros/AppHero.vue';
 import { useLock } from '@/composables/useLock';
-import useNetwork, { isL2 } from '@/composables/useNetwork';
+import useNetwork from '@/composables/useNetwork';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import useWeb3 from '@/services/web3/useWeb3';
 
 import HeroConnectWalletButton from './HeroConnectWalletButton.vue';
 import { useUserPools } from '@/providers/local/user-pools.provider';
+import { isVeBalSupported } from '@/composables/useVeBAL';
 
 /**
  * COMPOSABLES
@@ -56,7 +57,7 @@ const isLoadingTotalValue = computed((): boolean => isLoadingPools.value);
       <div v-else class="mb-1 text-3xl font-semibold text-white">
         {{ totalInvestedLabel }}
       </div>
-      <div v-if="!isL2" class="inline-block relative mt-2">
+      <div v-if="!isVeBalSupported" class="inline-block relative mt-2">
         <BalLoadingBlock
           v-if="isLoadingTotalValue"
           class="mx-auto w-40 h-8"

--- a/src/composables/useLock.ts
+++ b/src/composables/useLock.ts
@@ -4,9 +4,8 @@ import { TokenInfo } from '@/types/TokenList';
 import { useTokens } from '@/providers/tokens.provider';
 import { useUserData } from '@/providers/user-data.provider';
 import usePoolQuery from './queries/usePoolQuery';
-import { isL2 } from './useNetwork';
 import { fiatValueOf } from './usePool';
-import useVeBal from './useVeBAL';
+import useVeBal, { isVeBalSupported } from './useVeBAL';
 
 interface Options {
   enabled?: boolean;
@@ -21,7 +20,9 @@ export function useLock({ enabled = true }: Options = {}) {
   /**
    * QUERIES
    */
-  const shouldFetchLockPool = computed((): boolean => !isL2.value && enabled);
+  const shouldFetchLockPool = computed(
+    (): boolean => !isVeBalSupported.value && enabled
+  );
   const lockPoolQuery = usePoolQuery(
     lockablePoolId.value as string,
     shouldFetchLockPool

--- a/src/composables/useLock.ts
+++ b/src/composables/useLock.ts
@@ -21,7 +21,7 @@ export function useLock({ enabled = true }: Options = {}) {
    * QUERIES
    */
   const shouldFetchLockPool = computed(
-    (): boolean => !isVeBalSupported.value && enabled
+    (): boolean => isVeBalSupported.value && enabled
   );
   const lockPoolQuery = usePoolQuery(
     lockablePoolId.value as string,

--- a/src/composables/useVeBAL.ts
+++ b/src/composables/useVeBAL.ts
@@ -19,8 +19,7 @@ const showRedirectModal = ref(false);
  * COMPUTED
  */
 export const isVeBalSupported = computed<boolean>(
-  () =>
-    configService.network.addresses.veBAL !== '' && POOLS.IdsMap?.veBAL !== ''
+  () => configService.network.addresses.veBAL !== ''
 );
 
 /**

--- a/src/composables/useVeBAL.ts
+++ b/src/composables/useVeBAL.ts
@@ -1,7 +1,6 @@
 import { differenceInSeconds, formatDistanceToNow, sub } from 'date-fns';
 import { computed, ref } from 'vue';
 
-import { isGoerli, isMainnet } from '@/composables/useNetwork';
 import { POOLS } from '@/constants/pools';
 import { bnum } from '@/lib/utils';
 
@@ -9,6 +8,7 @@ import useConfig from './useConfig';
 import { getPreviousThursday, oneYearInSecs, toJsTimestamp } from './useTime';
 import { useTokens } from '@/providers/tokens.provider';
 import { WEIGHT_VOTE_DELAY } from '@/constants/gauge-controller';
+import { configService } from '@/services/config/config.service';
 
 /**
  * STATE
@@ -18,8 +18,8 @@ const showRedirectModal = ref(false);
 /**
  * COMPUTED
  */
-export const isVeBalSupported = computed(
-  () => isMainnet.value || isGoerli.value
+export const isVeBalSupported = computed<boolean>(
+  () => !!(configService.network.addresses.veBAL && POOLS.IdsMap?.veBAL)
 );
 
 /**

--- a/src/composables/useVeBAL.ts
+++ b/src/composables/useVeBAL.ts
@@ -19,7 +19,8 @@ const showRedirectModal = ref(false);
  * COMPUTED
  */
 export const isVeBalSupported = computed<boolean>(
-  () => !!(configService.network.addresses.veBAL && POOLS.IdsMap?.veBAL)
+  () =>
+    configService.network.addresses.veBAL !== '' && POOLS.IdsMap?.veBAL !== ''
 );
 
 /**


### PR DESCRIPTION
# Description

- Add a new boolean isVeBalSupported that is set based on if a veBal address is set in config.
- Wherever we have a veBAL related page (such as locking veBAL, or seeing rewards) use this boolean instead of `isL2`. 

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Ensure that the veBAL page works correctly on Mainnet and Goerli and redirects correctly on other networks.
- Ensure veBAL locked stats show on portfolio page on Mainnet and Goerli
- Ensure the veBAL locked stats do not show on other networks. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
