### PR TITLE
Chore: Make AppNavMenu dynamic and based on config

### DIFF
--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -38,13 +38,13 @@ function convertConfigToNetworkOption(config: Config): NetworkOption {
 }
 
 const prodNetworks: NetworkOption[] = Object.values(config)
-  .filter(config => config.inNetworkSelector && !config.testNetwork)
+  .filter(config => config.visibleInUI && !config.testNetwork)
   .map(convertConfigToNetworkOption);
 
 const networks = ref(prodNetworks);
 
 const testNetworks: NetworkOption[] = Object.values(config)
-  .filter(config => config.inNetworkSelector && config.testNetwork)
+  .filter(config => config.visibleInUI && config.testNetwork)
   .map(convertConfigToNetworkOption);
 
 const networksDev = ref(testNetworks);

--- a/src/components/navs/AppNav/AppNavNetworkSelect.vue
+++ b/src/components/navs/AppNav/AppNavNetworkSelect.vue
@@ -2,20 +2,20 @@
 import { computed, ref, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
-import i18n from '@/plugins/i18n';
-
+import { useI18n } from 'vue-i18n';
 import useBreakpoints from '@/composables/useBreakpoints';
 import useNetwork from '@/composables/useNetwork';
 import useNotifications from '@/composables/useNotifications';
 import useWeb3 from '@/services/web3/useWeb3';
 import { configService } from '@/services/config/config.service';
+import config from '@/lib/config';
+import { Config } from '@/lib/config/types';
 import { buildNetworkIconURL } from '@/lib/utils/urls';
 import { hardRedirectTo } from '@/plugins/router/nav-guards';
 
 export interface NetworkOption {
   id: string;
   name: string;
-  subdomain?: string;
   networkSlug?: string;
   key?: string;
 }
@@ -26,42 +26,28 @@ const { networkId, networkConfig } = useNetwork();
 const { chainId } = useWeb3();
 const router = useRouter();
 const { addNotification } = useNotifications();
+const { t } = useI18n();
 
-const networks = ref([
-  {
-    id: 'ethereum',
-    name: 'Ethereum',
-    networkSlug: 'ethereum',
-    key: '1',
-  },
-  {
-    id: 'polygon',
-    name: 'Polygon',
-    networkSlug: 'polygon',
-    key: '137',
-  },
-  {
-    id: 'arbitrum',
-    name: 'Arbitrum',
-    networkSlug: 'arbitrum',
-    key: '42161',
-  },
-  {
-    id: 'gnosis-chain',
-    name: 'Gnosis Chain',
-    networkSlug: 'gnosis-chain',
-    key: '100',
-  },
-]);
+function convertConfigToNetworkOption(config: Config): NetworkOption {
+  return {
+    id: config.slug,
+    name: config.chainName,
+    networkSlug: config.slug,
+    key: config.key,
+  };
+}
 
-const networksDev = ref([
-  {
-    id: 'goerli',
-    name: 'Goerli',
-    networkSlug: 'goerli',
-    key: '5',
-  },
-]);
+const prodNetworks: NetworkOption[] = Object.values(config)
+  .filter(config => config.inNetworkSelector && !config.testNetwork)
+  .map(convertConfigToNetworkOption);
+
+const networks = ref(prodNetworks);
+
+const testNetworks: NetworkOption[] = Object.values(config)
+  .filter(config => config.inNetworkSelector && config.testNetwork)
+  .map(convertConfigToNetworkOption);
+
+const networksDev = ref(testNetworks);
 
 // COMPUTED
 const allNetworks = computed(() => {
@@ -93,7 +79,7 @@ onMounted(async () => {
     addNotification({
       type: 'error',
       title: '',
-      message: `${i18n.global.t('poolDoesntExist')} ${networkConfig.chainName}`,
+      message: `${t('poolDoesntExist')} ${networkConfig.chainName}`,
     });
     router.replace({ query: {} });
   }

--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -15,6 +15,8 @@ const config: Config = {
   slug: 'arbitrum',
   network: 'arbitrum-one',
   unknown: false,
+  inNetworkSelector: true,
+  testNetwork: false,
   rpc: `https://arb-mainnet.g.alchemy.com/v2/${keys.alchemy}`,
   ws: `wss://arb-mainnet.g.alchemy.com/v2/${keys.alchemy}`,
   publicRpc: 'https://arb1.arbitrum.io/rpc',

--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -15,7 +15,7 @@ const config: Config = {
   slug: 'arbitrum',
   network: 'arbitrum-one',
   unknown: false,
-  inNetworkSelector: true,
+  visibleInUI: true,
   testNetwork: false,
   rpc: `https://arb-mainnet.g.alchemy.com/v2/${keys.alchemy}`,
   ws: `wss://arb-mainnet.g.alchemy.com/v2/${keys.alchemy}`,

--- a/src/lib/config/docker/index.ts
+++ b/src/lib/config/docker/index.ts
@@ -11,6 +11,8 @@ const config: Config = {
   slug: 'docker',
   network: 'docker localhost',
   unknown: false,
+  inNetworkSelector: false,
+  testNetwork: true,
   rpc: 'http://localhost:8545',
   ws: 'ws://localhost:8546',
   explorer: '',

--- a/src/lib/config/docker/index.ts
+++ b/src/lib/config/docker/index.ts
@@ -11,7 +11,7 @@ const config: Config = {
   slug: 'docker',
   network: 'docker localhost',
   unknown: false,
-  inNetworkSelector: false,
+  visibleInUI: false,
   testNetwork: true,
   rpc: 'http://localhost:8545',
   ws: 'ws://localhost:8546',

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -14,7 +14,7 @@ const config: Config = {
   slug: 'gnosis-chain',
   network: 'gnosis-chain',
   unknown: false,
-  inNetworkSelector: true,
+  visibleInUI: true,
   testNetwork: false,
   rpc: 'https://poa-xdai.gateway.pokt.network/v1/lb/91bc0e12a76e7a84dd76189d',
   ws: 'wss://rpc.gnosischain.com/wss',

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -14,6 +14,8 @@ const config: Config = {
   slug: 'gnosis-chain',
   network: 'gnosis-chain',
   unknown: false,
+  inNetworkSelector: true,
+  testNetwork: false,
   rpc: 'https://poa-xdai.gateway.pokt.network/v1/lb/91bc0e12a76e7a84dd76189d',
   ws: 'wss://rpc.gnosischain.com/wss',
   publicRpc: 'https://rpc.gnosis.gateway.fm',

--- a/src/lib/config/goerli/index.ts
+++ b/src/lib/config/goerli/index.ts
@@ -15,6 +15,8 @@ const config: Config = {
   slug: 'goerli',
   network: 'goerli',
   unknown: false,
+  inNetworkSelector: true,
+  testNetwork: true,
   rpc: `https://goerli.infura.io/v3/${keys.infura}`,
   ws: `wss://goerli.infura.io/ws/v3/${keys.infura}`,
   explorer: 'https://goerli.etherscan.io',

--- a/src/lib/config/goerli/index.ts
+++ b/src/lib/config/goerli/index.ts
@@ -15,7 +15,7 @@ const config: Config = {
   slug: 'goerli',
   network: 'goerli',
   unknown: false,
-  inNetworkSelector: true,
+  visibleInUI: true,
   testNetwork: true,
   rpc: `https://goerli.infura.io/v3/${keys.infura}`,
   ws: `wss://goerli.infura.io/ws/v3/${keys.infura}`,

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -15,6 +15,8 @@ const config: Config = {
   slug: 'ethereum',
   network: 'homestead',
   unknown: false,
+  inNetworkSelector: true,
+  testNetwork: false,
   rpc: `https://mainnet.infura.io/v3/${keys.infura}`,
   ws: `wss://mainnet.infura.io/ws/v3/${keys.infura}`,
   explorer: 'https://etherscan.io',

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -15,7 +15,7 @@ const config: Config = {
   slug: 'ethereum',
   network: 'homestead',
   unknown: false,
-  inNetworkSelector: true,
+  visibleInUI: true,
   testNetwork: false,
   rpc: `https://mainnet.infura.io/v3/${keys.infura}`,
   ws: `wss://mainnet.infura.io/ws/v3/${keys.infura}`,

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -12,6 +12,8 @@ const config: Config = {
   slug: 'optimism',
   network: 'optimism',
   unknown: false,
+  inNetworkSelector: false,
+  testNetwork: false,
   rpc: 'https://mainnet.optimism.io',
   ws: 'wss://ws-mainnet.optimism.io',
   blockTime: 13,

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -12,7 +12,7 @@ const config: Config = {
   slug: 'optimism',
   network: 'optimism',
   unknown: false,
-  inNetworkSelector: false,
+  visibleInUI: false,
   testNetwork: false,
   rpc: 'https://mainnet.optimism.io',
   ws: 'wss://ws-mainnet.optimism.io',

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -15,7 +15,7 @@ const config: Config = {
   slug: 'polygon',
   network: 'polygon',
   unknown: false,
-  inNetworkSelector: true,
+  visibleInUI: true,
   testNetwork: false,
   rpc: `https://polygon-mainnet.infura.io/v3/${keys.infura}`,
   ws: `wss://polygon-mainnet.g.alchemy.com/v2/${keys.alchemy}`,

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -15,6 +15,8 @@ const config: Config = {
   slug: 'polygon',
   network: 'polygon',
   unknown: false,
+  inNetworkSelector: true,
+  testNetwork: false,
   rpc: `https://polygon-mainnet.infura.io/v3/${keys.infura}`,
   ws: `wss://polygon-mainnet.g.alchemy.com/v2/${keys.alchemy}`,
   publicRpc: 'https://polygon-rpc.com',

--- a/src/lib/config/test/index.ts
+++ b/src/lib/config/test/index.ts
@@ -10,7 +10,7 @@ const config: Config = {
   slug: 'test',
   network: 'test',
   unknown: false,
-  inNetworkSelector: false,
+  visibleInUI: false,
   testNetwork: true,
   rpc: `https://mainnet.infura.io/v3/${keys.infura}`,
   ws: 'ws://balancer.fi:1234',

--- a/src/lib/config/test/index.ts
+++ b/src/lib/config/test/index.ts
@@ -10,6 +10,8 @@ const config: Config = {
   slug: 'test',
   network: 'test',
   unknown: false,
+  inNetworkSelector: false,
+  testNetwork: true,
   rpc: `https://mainnet.infura.io/v3/${keys.infura}`,
   ws: 'ws://balancer.fi:1234',
   explorer: 'https://etherscan.io',

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -72,6 +72,8 @@ export interface Config {
   slug: string;
   network: string;
   unknown: boolean;
+  inNetworkSelector: boolean;
+  testNetwork: boolean;
   rpc: string;
   publicRpc?: string;
   ws: string;

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -72,7 +72,7 @@ export interface Config {
   slug: string;
   network: string;
   unknown: boolean;
-  inNetworkSelector: boolean;
+  visibleInUI: boolean;
   testNetwork: boolean;
   rpc: string;
   publicRpc?: string;


### PR DESCRIPTION
# Description

- Change the AppNavMenu to be built based on configuration settings instead of hard coded. 

Question: The order of these buttons is now different. Do we want them in a specific order? 
 
## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Ensure that only Ethereum, Polygon, Arbitrum, and Gnosis Chain appear in the navigation menu
- Ensure that Goerli appears in the menu in dev mode
- Ensure that all button names look correct and clicking the buttons takes you to the right network. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
