### PR TITLE
Chore: Move coingecko settings from the service to config files

### DIFF
--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -47,6 +47,10 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
+  coingecko: {
+    nativeAssetId: 'ethereum',
+    platformId: 'arbitrum-one',
+  },
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/docker/index.ts
+++ b/src/lib/config/docker/index.ts
@@ -35,6 +35,10 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
+  coingecko: {
+    nativeAssetId: 'ethereum',
+    platformId: 'ethereum',
+  },
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -45,6 +45,10 @@ const config: Config = {
     logoURI: 'tokens/xdai.png',
     minTransactionBuffer: '0.05',
   },
+  coingecko: {
+    nativeAssetId: 'xdai',
+    platformId: 'xdai',
+  },
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/goerli/index.ts
+++ b/src/lib/config/goerli/index.ts
@@ -44,6 +44,10 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
+  coingecko: {
+    nativeAssetId: 'ethereum',
+    platformId: 'ethereum',
+  },
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -47,6 +47,10 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
+  coingecko: {
+    nativeAssetId: 'ethereum',
+    platformId: 'ethereum',
+  },
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -41,6 +41,10 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
+  coingecko: {
+    nativeAssetId: 'ethereum',
+    platformId: 'optimism',
+  },
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -46,6 +46,10 @@ const config: Config = {
     logoURI: 'tokens/matic.svg',
     minTransactionBuffer: '0.1',
   },
+  coingecko: {
+    nativeAssetId: 'matic-network',
+    platformId: 'polygon-pos',
+  },
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/test/index.ts
+++ b/src/lib/config/test/index.ts
@@ -2,8 +2,8 @@ import { Config } from '../types';
 import keys from './keys';
 
 const config: Config = {
-  key: '1',
-  chainId: 1,
+  key: '12345',
+  chainId: 12345,
   chainName: 'test',
   name: 'test',
   shortName: 'test',

--- a/src/lib/config/test/index.ts
+++ b/src/lib/config/test/index.ts
@@ -36,6 +36,10 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
+  coingecko: {
+    nativeAssetId: 'ethereum',
+    platformId: 'ethereum',
+  },
   addresses: {
     merkleRedeem: '0x6d19b2bF3A36A61530909Ae65445a906D98A2Fa8',
     merkleOrchard: '',

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -99,6 +99,10 @@ export interface Config {
     logoURI: string;
     minTransactionBuffer: string;
   };
+  coingecko: {
+    nativeAssetId: string;
+    platformId: string;
+  };
   addresses: Contracts;
   pools: Pools;
   tokens: TokenConstants;

--- a/src/services/coingecko/coingecko.service.ts
+++ b/src/services/coingecko/coingecko.service.ts
@@ -2,29 +2,24 @@ import { SUPPORTED_FIAT } from '@/constants/currency';
 
 import { PriceService } from './api/price.service';
 import { coingeckoClient } from './coingecko.client';
+import config from '@/lib/config';
 
 export const getNativeAssetId = (chainId: string): string => {
-  const mapping = {
-    '1': 'ethereum',
-    '5': 'ethereum',
-    '42': 'ethereum',
-    '137': 'matic-network',
-    '100': 'xdai',
-    '42161': 'ethereum',
-  };
+  const mapping = Object.fromEntries(
+    Object.values(config).map(c => {
+      return [c.chainId.toString(), c.coingecko.nativeAssetId];
+    })
+  );
 
   return mapping[chainId] || 'ethereum';
 };
 
 export const getPlatformId = (chainId: string): string => {
-  const mapping = {
-    '1': 'ethereum',
-    '5': 'ethereum',
-    '42': 'ethereum',
-    '137': 'polygon-pos',
-    '100': 'xdai',
-    '42161': 'arbitrum-one',
-  };
+  const mapping = Object.fromEntries(
+    Object.values(config).map(c => {
+      return [c.chainId.toString(), c.coingecko.platformId];
+    })
+  );
 
   return mapping[chainId] || 'ethereum';
 };


### PR DESCRIPTION
# Description

- Move coingecko native asset and platformId settings to config files
- Tested by inspecting in browser and comparing the new list to the old one. They are the same except for the inclusion of networks 10 & 17 and removal of network 42. 

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Ensure that tokens load from Coingecko on each network
- Can inspect `coingecko.service` in browser tools to see the list is the same. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
