### PR TITLE
Chore: Remove switch statement in balancer.sdk.ts

### DIFF
--- a/src/lib/balancer.sdk.ts
+++ b/src/lib/balancer.sdk.ts
@@ -4,20 +4,7 @@ import { ref } from 'vue';
 import { isTestMode } from '@/plugins/modes';
 
 const network = ((): Network => {
-  switch (configService.network.key) {
-    case '1':
-      return Network.MAINNET;
-    case '5':
-      return Network.GOERLI;
-    case '137':
-      return Network.POLYGON;
-    case '42161':
-      return Network.ARBITRUM;
-    case '100':
-      return Network.GNOSIS;
-    default:
-      return Network.MAINNET;
-  }
+  return configService.network.chainId;
 })();
 
 export const balancer = new BalancerSDK({


### PR DESCRIPTION
# Description

- This switch statement isn't needed as chainId is already of type `Network` 

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Ensure SDK functions such as fetching pools for SOR work correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
