### PR TITLE
Move APYVision details to config

### DIFF
--- a/src/components/links/ApyVisionPoolLink.vue
+++ b/src/components/links/ApyVisionPoolLink.vue
@@ -22,7 +22,7 @@ defineProps<Props>();
 const { poolPathSymbolSegment, apyVisionNetworkName } = useApyVisionHelpers();
 </script>
 
-<template>
+<template v-if="apyVisionNetworkName">
   <div class="group flex items-center mt-6 w-fit h-fit">
     <BalLink
       :href="

--- a/src/components/links/ApyVisionPoolLink.vue
+++ b/src/components/links/ApyVisionPoolLink.vue
@@ -22,8 +22,11 @@ defineProps<Props>();
 const { poolPathSymbolSegment, apyVisionNetworkName } = useApyVisionHelpers();
 </script>
 
-<template v-if="apyVisionNetworkName">
-  <div class="group flex items-center mt-6 w-fit h-fit">
+<template>
+  <div
+    v-if="apyVisionNetworkName"
+    class="group flex items-center mt-6 w-fit h-fit"
+  >
     <BalLink
       :href="
         'https://app.apy.vision/pools/balancerv2_' +

--- a/src/composables/external/useApyVisionHelpers.ts
+++ b/src/composables/external/useApyVisionHelpers.ts
@@ -10,7 +10,7 @@ export function poolPathSymbolSegment(tokens: PoolToken[]) {
 
 export function useApyVisionHelpers() {
   const apyVisionNetworkName = computed(() => {
-    return configService.network.apyVisionNetworkName;
+    return configService.network.thirdParty.apyVision?.networkName;
   });
 
   return {

--- a/src/composables/external/useApyVisionHelpers.ts
+++ b/src/composables/external/useApyVisionHelpers.ts
@@ -10,7 +10,7 @@ export function poolPathSymbolSegment(tokens: PoolToken[]) {
 
 export function useApyVisionHelpers() {
   const apyVisionNetworkName = computed(() => {
-    return configService.network.apyVisionNetworkName || 'eth';
+    return configService.network.apyVisionNetworkName;
   });
 
   return {

--- a/src/composables/external/useApyVisionHelpers.ts
+++ b/src/composables/external/useApyVisionHelpers.ts
@@ -2,7 +2,7 @@ import { computed } from 'vue';
 
 import { PoolToken } from '@balancer-labs/sdk';
 
-import { isArbitrum, isMainnet, isPolygon } from '../useNetwork';
+import { configService } from '@/services/config/config.service';
 
 export function poolPathSymbolSegment(tokens: PoolToken[]) {
   return tokens.map(token => token.symbol).join('-');
@@ -10,15 +10,7 @@ export function poolPathSymbolSegment(tokens: PoolToken[]) {
 
 export function useApyVisionHelpers() {
   const apyVisionNetworkName = computed(() => {
-    if (isMainnet.value) {
-      return 'eth';
-    } else if (isPolygon.value) {
-      return 'matic';
-    } else if (isArbitrum.value) {
-      return 'arbitrum';
-    } else {
-      return 'eth';
-    }
+    return configService.network.apyVisionNetworkName || 'eth';
   });
 
   return {

--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -51,6 +51,7 @@ const config: Config = {
     nativeAssetId: 'ethereum',
     platformId: 'arbitrum-one',
   },
+  apyVisionNetworkName: 'arbitrum',
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -47,11 +47,15 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
-  coingecko: {
-    nativeAssetId: 'ethereum',
-    platformId: 'arbitrum-one',
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: 'ethereum',
+      platformId: 'arbitrum-one',
+    },
+    apyVision: {
+      networkName: 'arbitrum',
+    },
   },
-  apyVisionNetworkName: 'arbitrum',
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/docker/index.ts
+++ b/src/lib/config/docker/index.ts
@@ -35,9 +35,11 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
-  coingecko: {
-    nativeAssetId: 'ethereum',
-    platformId: 'ethereum',
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: 'ethereum',
+      platformId: 'ethereum',
+    },
   },
   addresses: {
     ...contracts,

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -45,7 +45,6 @@ const config: Config = {
     logoURI: 'tokens/xdai.png',
     minTransactionBuffer: '0.05',
   },
-  apyVisionNetworkName: 'xdai',
   coingecko: {
     nativeAssetId: 'xdai',
     platformId: 'xdai',

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -45,9 +45,11 @@ const config: Config = {
     logoURI: 'tokens/xdai.png',
     minTransactionBuffer: '0.05',
   },
-  coingecko: {
-    nativeAssetId: 'xdai',
-    platformId: 'xdai',
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: 'xdai',
+      platformId: 'xdai',
+    },
   },
   addresses: {
     ...contracts,

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -45,6 +45,7 @@ const config: Config = {
     logoURI: 'tokens/xdai.png',
     minTransactionBuffer: '0.05',
   },
+  apyVisionNetworkName: 'xdai',
   coingecko: {
     nativeAssetId: 'xdai',
     platformId: 'xdai',

--- a/src/lib/config/goerli/index.ts
+++ b/src/lib/config/goerli/index.ts
@@ -44,9 +44,11 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
-  coingecko: {
-    nativeAssetId: 'ethereum',
-    platformId: 'ethereum',
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: 'ethereum',
+      platformId: 'ethereum',
+    },
   },
   addresses: {
     ...contracts,

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -51,6 +51,7 @@ const config: Config = {
     nativeAssetId: 'ethereum',
     platformId: 'ethereum',
   },
+  apyVisionNetworkName: 'eth',
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -47,11 +47,15 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
-  coingecko: {
-    nativeAssetId: 'ethereum',
-    platformId: 'ethereum',
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: 'ethereum',
+      platformId: 'ethereum',
+    },
+    apyVision: {
+      networkName: 'eth',
+    },
   },
-  apyVisionNetworkName: 'eth',
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -41,9 +41,11 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
-  coingecko: {
-    nativeAssetId: 'ethereum',
-    platformId: 'optimism',
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: 'ethereum',
+      platformId: 'optimism',
+    },
   },
   addresses: {
     ...contracts,

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -46,11 +46,15 @@ const config: Config = {
     logoURI: 'tokens/matic.svg',
     minTransactionBuffer: '0.1',
   },
-  coingecko: {
-    nativeAssetId: 'matic-network',
-    platformId: 'polygon-pos',
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: 'matic-network',
+      platformId: 'polygon-pos',
+    },
+    apyVision: {
+      networkName: 'matic',
+    },
   },
-  apyVisionNetworkName: 'matic',
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -50,6 +50,7 @@ const config: Config = {
     nativeAssetId: 'matic-network',
     platformId: 'polygon-pos',
   },
+  apyVisionNetworkName: 'matic',
   addresses: {
     ...contracts,
   },

--- a/src/lib/config/test/index.ts
+++ b/src/lib/config/test/index.ts
@@ -36,9 +36,11 @@ const config: Config = {
     logoURI: 'tokens/eth.png',
     minTransactionBuffer: '0.05',
   },
-  coingecko: {
-    nativeAssetId: 'ethereum',
-    platformId: 'ethereum',
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: 'ethereum',
+      platformId: 'ethereum',
+    },
   },
   addresses: {
     merkleRedeem: '0x6d19b2bF3A36A61530909Ae65445a906D98A2Fa8',

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -103,11 +103,15 @@ export interface Config {
     logoURI: string;
     minTransactionBuffer: string;
   };
-  coingecko: {
-    nativeAssetId: string;
-    platformId: string;
+  thirdParty: {
+    coingecko: {
+      nativeAssetId: string;
+      platformId: string;
+    };
+    apyVision?: {
+      networkName: string;
+    };
   };
-  apyVisionNetworkName?: string;
   addresses: Contracts;
   pools: Pools;
   tokens: TokenConstants;

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -107,6 +107,7 @@ export interface Config {
     nativeAssetId: string;
     platformId: string;
   };
+  apyVisionNetworkName?: string;
   addresses: Contracts;
   pools: Pools;
   tokens: TokenConstants;

--- a/src/services/coingecko/coingecko.service.ts
+++ b/src/services/coingecko/coingecko.service.ts
@@ -7,7 +7,7 @@ import config from '@/lib/config';
 export const getNativeAssetId = (chainId: string): string => {
   const mapping = Object.fromEntries(
     Object.values(config).map(c => {
-      return [c.chainId.toString(), c.coingecko.nativeAssetId];
+      return [c.chainId.toString(), c.thirdParty.coingecko.nativeAssetId];
     })
   );
 
@@ -17,7 +17,7 @@ export const getNativeAssetId = (chainId: string): string => {
 export const getPlatformId = (chainId: string): string => {
   const mapping = Object.fromEntries(
     Object.values(config).map(c => {
-      return [c.chainId.toString(), c.coingecko.platformId];
+      return [c.chainId.toString(), c.thirdParty.coingecko.platformId];
     })
   );
 


### PR DESCRIPTION
# Description

- Remove the switch statement from APY Vision and move it to config files instead
- Make the link not show on networks that APY Vision doesn't support yet (like Gnosis Chain)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor / cleanup

## How should this be tested?

- Ensure APY Vision link shows and works for pools on Ethereum/Arbitrum/Polygon
- Ensure APY Vision link doesn't show on Gnosis Chain as they don't support Balancer pools on it yet. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
