### PR TITLE
fix: dark border styles in main page

### DIFF
--- a/src/components/_global/BalBtn/BalBtn.vue
+++ b/src/components/_global/BalBtn/BalBtn.vue
@@ -156,7 +156,7 @@ const bgColorClasses = computed(() => {
 const borderClasses = computed(() => {
   if (props.outline) {
     if (props.disabled) return `border border-gray-200 dark:border-gray-700`;
-    return `border ${border(props.color)} dark:border-${darkBorder(
+    return `border ${border(props.color)} ${darkBorder(
       props.color
     )} ${darkHoverBorder(props.color)} ${darkFocusBorder(
       props.color

--- a/src/components/_global/BalStack/BalStack.vue
+++ b/src/components/_global/BalStack/BalStack.vue
@@ -71,7 +71,7 @@ export default defineComponent({
     const borderType = this.vertical ? 'b' : 'r';
     const widthClass = this.expandChildren ? 'w-full' : '';
     const borderClass = this.withBorder ? `border-${borderType}` : '';
-    const stackNodeClass = `dark:border-gray-600 ${spacingType}-${
+    const stackNodeClass = `${spacingType}-${
       SpacingMap[this.spacing]
     } ${borderClass} ${widthClass}`;
 


### PR DESCRIPTION
# Description

Fix dark border styles of main pools table and `create a pool button` in main page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Visual context

![border-fix](https://user-images.githubusercontent.com/1316240/228197234-200e47fd-c437-4423-9ea1-3e9504356f00.png)



## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
