### PR TITLE
Fix Price Impact calculations

### DIFF
--- a/src/composables/swap/useSor.spec.ts
+++ b/src/composables/swap/useSor.spec.ts
@@ -7,6 +7,7 @@ import useSor, { calcPriceImpact } from '@/composables/swap/useSor';
 import { SorManager } from '@/lib/utils/balancer/helpers/sor/sorManager';
 import { configService } from '@/services/config/config.service';
 import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service';
+import { SwapType } from '@balancer-labs/sdk';
 
 vi.mock('@/lib/utils/balancer/helpers/sor/sorManager');
 
@@ -108,17 +109,10 @@ describe('setSwapCost', () => {
      *
      */
 
-    // expected slippage is 0.11111
-    // This is 10% less, but calculated as (expected / actual) = (1 / 0.9)
-    const expectedSlippageUnformatted = parseFixed('1', 36)
-      .div(parseFixed('0.9', 18))
-      .sub(parseFixed('1', 18));
-    const expectedSlippage = formatFixed(expectedSlippageUnformatted, 18).slice(
-      0,
-      10
-    );
-
     describe('USDC <> ETH', () => {
+      // The expected slippage for USDC <> ETH is 10%
+      const expectedSlippage = '0.1';
+
       /**
        * SwapExactIn USDC -> ETH
        * MarketSP = 2000
@@ -128,14 +122,14 @@ describe('setSwapCost', () => {
        */
       it('Should give 10% slippage when doing a swapExactIn from USDC -> ETH', () => {
         const priceImpact = calcPriceImpact(
-          18,
-          parseFixed('0.9', 18),
           parseFixed('2000', 6),
+          6,
+          parseFixed('0.9', 18),
+          18,
+          SwapType.SwapExactIn,
           '2000'
         );
-        expect(formatFixed(priceImpact, 18).slice(0, 10)).toBe(
-          expectedSlippage
-        );
+        expect(formatFixed(priceImpact, 18)).toBe(expectedSlippage);
       });
 
       /**
@@ -147,14 +141,14 @@ describe('setSwapCost', () => {
        */
       it('Should give 10% slippage when doing a swapExactOut from USDC -> ETH', () => {
         const priceImpact = calcPriceImpact(
-          6,
           parseFixed('1800', 6),
+          6,
           parseFixed('1', 18),
+          18,
+          SwapType.SwapExactOut,
           '2000'
         );
-        expect(formatFixed(priceImpact, 18).slice(0, 10)).toBe(
-          expectedSlippage
-        );
+        expect(formatFixed(priceImpact, 18)).toBe(expectedSlippage);
       });
 
       /**
@@ -166,14 +160,14 @@ describe('setSwapCost', () => {
        */
       it('Should give 10% slippage when doing a swapExactIn from ETH -> USDC', () => {
         const priceImpact = calcPriceImpact(
-          6,
-          parseFixed('1800', 6),
           parseFixed('1', 18),
+          18,
+          parseFixed('1800', 6),
+          6,
+          SwapType.SwapExactIn,
           '0.0005'
         );
-        expect(formatFixed(priceImpact, 18).slice(0, 10)).toBe(
-          expectedSlippage
-        );
+        expect(formatFixed(priceImpact, 18)).toBe(expectedSlippage);
       });
 
       /**
@@ -185,18 +179,21 @@ describe('setSwapCost', () => {
        */
       it('Should give 10% slippage when doing a swapExactOut from ETH -> USDC', () => {
         const priceImpact = calcPriceImpact(
-          18,
           parseFixed('0.9', 18),
+          18,
           parseFixed('2000', 6),
+          6,
+          SwapType.SwapExactOut,
           '0.0005'
         );
-        expect(formatFixed(priceImpact, 18).slice(0, 10)).toBe(
-          expectedSlippage
-        );
+        expect(formatFixed(priceImpact, 18)).toBe(expectedSlippage);
       });
     });
 
     describe('DAI <> ETH', () => {
+      // The expected slippage for DAI <> ETH is 10%
+      const expectedSlippage = '0.2';
+
       /**
        * SwapExactIn DAI -> ETH
        * MarketSP = 2000
@@ -204,16 +201,16 @@ describe('setSwapCost', () => {
        * Fixed Token = 2000 DAI
        * Variable Token = 0.9 ETH
        */
-      it('Should give 10% slippage when doing a swapExactIn from DAI -> ETH', () => {
+      it('Should give 20% slippage when doing a swapExactIn from DAI -> ETH', () => {
         const priceImpact = calcPriceImpact(
-          18,
-          parseFixed('0.9', 18),
           parseFixed('2000', 18),
+          18,
+          parseFixed('0.8', 18),
+          18,
+          SwapType.SwapExactIn,
           '2000'
         );
-        expect(formatFixed(priceImpact, 18).slice(0, 10)).toBe(
-          expectedSlippage
-        );
+        expect(formatFixed(priceImpact, 18)).toBe(expectedSlippage);
       });
 
       /**
@@ -223,16 +220,16 @@ describe('setSwapCost', () => {
        * Fixed Token = 1 ETH
        * Variable Token = 1800 DAI
        */
-      it('Should give 10% slippage when doing a swapExactOut from DAI -> ETH', () => {
+      it('Should give 20% slippage when doing a swapExactOut from DAI -> ETH', () => {
         const priceImpact = calcPriceImpact(
+          parseFixed('1600', 18),
           18,
-          parseFixed('1800', 18),
           parseFixed('1', 18),
+          18,
+          SwapType.SwapExactOut,
           '2000'
         );
-        expect(formatFixed(priceImpact, 18).slice(0, 10)).toBe(
-          expectedSlippage
-        );
+        expect(formatFixed(priceImpact, 18)).toBe(expectedSlippage);
       });
 
       /**
@@ -242,16 +239,16 @@ describe('setSwapCost', () => {
        * Fixed Token = 1 ETH
        * Variable Token = 1800 DAI
        */
-      it('Should give 10% slippage when doing a swapExactIn from ETH -> DAI', () => {
+      it('Should give 20% slippage when doing a swapExactIn from ETH -> DAI', () => {
         const priceImpact = calcPriceImpact(
-          18,
-          parseFixed('1800', 18),
           parseFixed('1', 18),
+          18,
+          parseFixed('1600', 18),
+          18,
+          SwapType.SwapExactIn,
           '0.0005'
         );
-        expect(formatFixed(priceImpact, 18).slice(0, 10)).toBe(
-          expectedSlippage
-        );
+        expect(formatFixed(priceImpact, 18)).toBe(expectedSlippage);
       });
 
       /**
@@ -261,16 +258,16 @@ describe('setSwapCost', () => {
        * Fixed Token = 2000 DAI
        * Variable Token = 0.9 ETH
        */
-      it('Should give 10% slippage when doing a swapExactOut from ETH -> DAI', () => {
+      it('Should give 20% slippage when doing a swapExactOut from ETH -> DAI', () => {
         const priceImpact = calcPriceImpact(
+          parseFixed('0.8', 18),
           18,
-          parseFixed('0.9', 18),
           parseFixed('2000', 18),
+          18,
+          SwapType.SwapExactOut,
           '0.0005'
         );
-        expect(formatFixed(priceImpact, 18).slice(0, 10)).toBe(
-          expectedSlippage
-        );
+        expect(formatFixed(priceImpact, 18)).toBe(expectedSlippage);
       });
     });
   });


### PR DESCRIPTION
# Description

Our price impact calculation function is currently quite broken (it was made years ago and never had tests and no one really knew how it worked). It previously only worked if the sell token was 18 decimals AND the swap type was SwapExactIn.

This PR adds many tests and documentation for this function so we can fix it once and for all. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Ensure that price impact looks correct for large swaps of USDC/USDT -> other tokens, or SwapExactOut swaps of any tokens. 

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
