### PR TITLE
Change isL2 check to networkHasNativeGauges, remove hard coded network switch

### DIFF
--- a/src/composables/useNetwork.spec.ts
+++ b/src/composables/useNetwork.spec.ts
@@ -1,7 +1,9 @@
+import { Network } from '@balancer-labs/sdk';
 import {
   getRedirectUrlFor,
   getSubdomain,
   handleNetworkSlug,
+  networkFor,
 } from './useNetwork';
 
 vi.mock('@/services/web3/useWeb3');
@@ -34,6 +36,19 @@ describe('useNetwork', () => {
       urls.forEach(url => {
         expect(getSubdomain(url.path)).toEqual(url.result);
       });
+    });
+  });
+
+  describe('neworkFor', () => {
+    it('should return networks that exists', () => {
+      expect(networkFor(1)).toEqual(Network.MAINNET);
+      expect(networkFor(137)).toEqual(Network.POLYGON);
+      expect(networkFor('42161')).toEqual(Network.ARBITRUM);
+      expect(networkFor('5')).toEqual(Network.GOERLI);
+    });
+
+    it('should throw an error for networks that dont exist', () => {
+      expect(() => networkFor(56)).toThrow('Network not supported');
     });
   });
 

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -4,6 +4,7 @@ import config from '@/lib/config';
 import { configService } from '@/services/config/config.service';
 import { Network } from '@balancer-labs/sdk';
 import { RouteParamsRaw } from 'vue-router';
+import { Config } from '@/lib/config/types';
 
 /**
  * STATE
@@ -62,20 +63,14 @@ export const networkHasNativeGauges = computed<boolean>(() => {
  */
 
 export function networkFor(key: string | number): Network {
-  switch (key.toString()) {
-    case '1':
-      return Network.MAINNET;
-    case '5':
-      return Network.GOERLI;
-    case '137':
-      return Network.POLYGON;
-    case '42161':
-      return Network.ARBITRUM;
-    case '100':
-      return Network.GNOSIS;
-    default:
-      throw new Error('Network not supported');
+  const network = Object.values(config).find((config: Config) => {
+    return config.key === key.toString();
+  });
+  if (!network) {
+    throw new Error('Network not supported');
   }
+
+  return network.chainId as Network;
 }
 
 export function getNetworkSlug(network: Network): string {
@@ -83,10 +78,10 @@ export function getNetworkSlug(network: Network): string {
 }
 
 export function networkFromSlug(networkSlug: string): Network | null {
-  const networkConf = Object.keys(config).find(
-    network => config[network].slug === networkSlug
-  );
-  return networkConf ? (Number(networkConf) as Network) : null;
+  const networkConf = Object.values(config).find((config: Config) => {
+    return config.slug === networkSlug;
+  });
+  return networkConf ? (networkConf.chainId as Network) : null;
 }
 
 export function appUrl(): string {

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -48,9 +48,6 @@ export const isArbitrum = computed(() => networkId.value === Network.ARBITRUM);
 export const isGnosis = computed(() => networkId.value === Network.GNOSIS);
 export const isGoerli = computed(() => networkId.value === Network.GOERLI);
 
-export const isL2 = computed(
-  () => isPolygon.value || isArbitrum.value || isGnosis.value
-);
 export const hasBridge = computed<boolean>(() => !!networkConfig.bridgeUrl);
 export const isTestnet = computed(() => isGoerli.value);
 

--- a/src/services/staking/staking-rewards.service.ts
+++ b/src/services/staking/staking-rewards.service.ts
@@ -4,7 +4,7 @@ import { getAddress } from '@ethersproject/address';
 import { formatUnits } from '@ethersproject/units';
 import { isNil, mapValues } from 'lodash';
 
-import { isL2 } from '@/composables/useNetwork';
+import { networkHasNativeGauges } from '@/composables/useNetwork';
 import { TOKENS } from '@/constants/tokens';
 import { bnum } from '@/lib/utils';
 import { configService } from '@/services/config/config.service';
@@ -101,7 +101,7 @@ export class StakingRewardsService {
     gauges: SubgraphGauge[];
     pools: Pool[];
   }): Promise<GaugeBalAprs> {
-    if (isL2.value) return {};
+    if (!networkHasNativeGauges.value) return {};
     const gaugeAddresses = gauges.map(gauge => gauge.id);
     const balAddress = TOKENS.Addresses.BAL;
     const [inflationRate, relativeWeights, workingSupplies, totalSupplies] =


### PR DESCRIPTION

# Description

- There were two places still using `isL2` for gauge checks, change these to `networkHasNativeGauges` to be more explicit about what we're searching for. All logical statements are reversed too. 
- Remove the `isL2` variable as it's no longer used.
- Refactor the `networkFor` function to use networks specified in config instead of its own list. 


## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Ensure gauge rewards are shown correctly on claim rewards pages for all networks. 
- Ensure boosted rewards are showing correctly for users that have boosts. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
