### PR TITLE
Fix: claims page infinite loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.96.3",
+  "version": "1.96.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.96.3",
+      "version": "1.96.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.96.3",
+  "version": "1.96.4",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -163,6 +163,11 @@ const QUERY_KEYS = {
       'protocol',
       { networkId, account },
     ],
+    GaugePools: (poolIds: Ref<string[]>) => [
+      CLAIMS_ROOT_KEY,
+      'gaugePools',
+      { poolIds },
+    ],
   },
   Tokens: {
     PairPriceData: (


### PR DESCRIPTION
# Description

A gauge in the gauges subgraph started returning a poolId of null which broken the gauges query on the claims page. This PR fixes that and cleans up the loading state of the claims page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test that the claims page loads as expected on mainnet.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
