### PR TITLE
Fix: Weighted disable join conditional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.96.10",
+  "version": "1.96.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.96.10",
+      "version": "1.96.11",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.96.10",
+  "version": "1.96.11",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/useDisabledJoinPool.spec.ts
+++ b/src/composables/useDisabledJoinPool.spec.ts
@@ -48,6 +48,7 @@ it('disables joins for pools created after timestamp (2023-03-29) with non vette
 it('disables joins for weigthed pools created after timestamp (2023-03-29) that are not in the weighted allow list', async () => {
   const pool = BoostedPoolMock;
   pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
+  pool.poolType = PoolType.Weighted;
   const { disableJoinsReason, shouldDisableJoins } =
     await mountVettedTokensInPool(pool);
 

--- a/src/composables/useDisabledJoinPool.ts
+++ b/src/composables/useDisabledJoinPool.ts
@@ -4,6 +4,7 @@ import {
   isFx,
   isManaged,
   isStableLike,
+  isWeighted,
   noInitLiquidity,
 } from '@/composables/usePool';
 import { computed } from 'vue';
@@ -51,7 +52,9 @@ export function useDisabledJoinPool(pool: Pool) {
 
   const nonAllowedWeightedPoolAfterTimestamp = computed(() => {
     return (
-      createdAfterTimestamp(pool) && !POOLS.Weighted.AllowList.includes(pool.id)
+      isWeighted(pool.poolType) &&
+      createdAfterTimestamp(pool) &&
+      !POOLS.Weighted.AllowList.includes(pool.id)
     );
   });
 


### PR DESCRIPTION
# Description

Conditional to block joins in weighted pools created after timestamp didn't check if the pool was actually a weighted pool. This PR fixes the relevant conditional.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Check this pool is joinable on mainnet: 0x793f2d5cd52dfafe7a1a1b0b3988940ba2d6a63d0000000000000000000004f8

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
