### PR TITLE
feature: Add prefetch capability to desktop links

### DIFF
--- a/src/components/navs/AppNav/DesktopLinks/DesktopLinkItem.vue
+++ b/src/components/navs/AppNav/DesktopLinks/DesktopLinkItem.vue
@@ -1,13 +1,15 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
+import PrefetchLinks from './PrefetchLinks.vue';
 import { RouterLinkProps } from 'vue-router';
 
 interface Props extends RouterLinkProps {
   active: boolean;
+  prefetch?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   active: false,
+  prefetch: false,
 });
 
 const classes = computed(() => ({
@@ -20,6 +22,7 @@ const classes = computed(() => ({
 <template>
   <router-link v-bind="props" :class="['desktop-link-item', classes]">
     <slot />
+    <PrefetchLinks v-if="prefetch" :to="$attrs.to" />
   </router-link>
 </template>
 

--- a/src/components/navs/AppNav/DesktopLinks/DesktopLinks.vue
+++ b/src/components/navs/AppNav/DesktopLinks/DesktopLinks.vue
@@ -34,6 +34,7 @@ function isActive(page: string): boolean {
     <DesktopLinkItem
       :to="{ name: 'swap', params: { networkSlug } }"
       :active="isActive('swap')"
+      prefetch
       @click="trackGoal(Goals.ClickNavSwap)"
     >
       {{ $t('swap') }}
@@ -57,6 +58,7 @@ function isActive(page: string): boolean {
     <DesktopLinkItem
       :to="{ name: 'portfolio', params: { networkSlug } }"
       :active="isActive('portfolio')"
+      prefetch
       @click="trackGoal(Goals.ClickNavPortfolio)"
     >
       {{ $t('portfolio') }}

--- a/src/components/navs/AppNav/DesktopLinks/PrefetchLinks.vue
+++ b/src/components/navs/AppNav/DesktopLinks/PrefetchLinks.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import { extractPrefetchAssets } from '@/lib/utils/prefetch';
+import { RouteTo, resolveRoute } from '@/plugins/router/route-resolver';
+
+interface Props {
+  to: unknown;
+}
+
+const props = defineProps<Props>();
+
+// This only works in production builds (use npm run build & npm run preview to test this feature)
+// More details: https://github.com/vitejs/vite/issues/10600
+const stringifiedAssets = resolveRoute(props.to as RouteTo)?.toString();
+
+const assets = extractPrefetchAssets(stringifiedAssets);
+
+function assetType(asset: string) {
+  return asset.endsWith('.css') ? 'style' : 'script';
+}
+</script>
+
+<template>
+  <link
+    v-for="asset in assets"
+    :key="asset"
+    rel="prefetch"
+    :href="asset"
+    :as="assetType(asset)"
+  />
+</template>

--- a/src/lib/utils/prefetch.spec.ts
+++ b/src/lib/utils/prefetch.spec.ts
@@ -1,0 +1,18 @@
+import { extractPrefetchAssets } from './prefetch';
+
+// Example of string returned by vite's async import
+// More details: https://github.com/vitejs/vite/issues/10600
+const stringifiedViteImport = `import("./swap-e51e71cb.js"),["assets/swap-e51e71cb.js","assets/BalAccordion.vue_vue_type_script_setup_true_lang-c2dd96ca.js","assets/immutable-8725a18b.js","assets/connector-0989baba.js","assets/BalAsset-a8105779.css","assets/BalAssetSet-68519eb3.css"])`;
+
+test('Extracts hashed assets from assets string', async () => {
+  const assets = extractPrefetchAssets(stringifiedViteImport);
+
+  expect(assets).toEqual([
+    'assets/swap-e51e71cb.js',
+    'assets/BalAccordion.vue_vue_type_script_setup_true_lang-c2dd96ca.js',
+    'assets/immutable-8725a18b.js',
+    'assets/connector-0989baba.js',
+    'assets/BalAsset-a8105779.css',
+    'assets/BalAssetSet-68519eb3.css',
+  ]);
+});

--- a/src/lib/utils/prefetch.ts
+++ b/src/lib/utils/prefetch.ts
@@ -1,0 +1,7 @@
+export function extractPrefetchAssets(input: string | undefined) {
+  if (!input) return [];
+  // Detect strings between brackets
+  const matchArray = input.match(/\[(.*?)\]/);
+  if (!matchArray) return [];
+  return JSON.parse(matchArray[0]).map(asset => asset.replace('"', ''));
+}

--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -4,59 +4,31 @@ import { captureException } from '@sentry/browser';
 import { isGoerli } from '@/composables/useNetwork';
 import { applyNavGuards } from './nav-guards';
 
-const ClaimPage = () =>
-  import(/* webpackChunkName: "ClaimPage" */ '@/pages/claim/index.vue');
-const LegacyClaimPage = () =>
-  import(/* webpackChunkName: "LegacyClaimPage" */ '@/pages/claim/legacy.vue');
-const CookiesPolicyPage = () =>
-  import(
-    /* webpackChunkName: "CookiesPolicyPage" */ '@/pages/cookies-policy.vue'
-  );
-const GetVeBalPage = () =>
-  import(/* webpackChunkName: "GetVeBalPage" */ '@/pages/get-vebal.vue');
-const HomePage = () =>
-  import(
-    /* webpackChunkName: "HomePage" */ /* webpackPrefetch: true */ '@/pages/index.vue'
-  );
+const ClaimPage = () => import('@/pages/claim/index.vue');
+const LegacyClaimPage = () => import('@/pages/claim/legacy.vue');
+const CookiesPolicyPage = () => import('@/pages/cookies-policy.vue');
+const GetVeBalPage = () => import('@/pages/get-vebal.vue');
+const HomePage = () => import('@/pages/index.vue');
 const PoolPage = () =>
-  import(
-    /* webpackChunkName: "PoolPage" */ /* webpackPrefetch: true */ '@/pages/pool/_id.vue'
-  );
+  import(/* webpackPrefetch: true */ '@/pages/pool/_id.vue');
 // const CreatePoolPage = () =>
-//   import(/* webpackChunkName: "CreatePoolPage" */ '@/pages/pool/create.vue');
-const PoolAddLiquidityPage = () =>
-  import(
-    /* webpackChunkName: "PoolAddLiquidityPage" */ '@/pages/pool/add-liquidity.vue'
-  );
-const MigratePoolPage = () =>
-  import(/* webpackChunkName: "MigratePoolPage" */ '@/pages/pool/migrate.vue');
-const PoolWithdrawPage = () =>
-  import(
-    /* webpackChunkName: "PoolWithdrawPage" */ '@/pages/pool/withdraw.vue'
-  );
-const PrivacyPolicyPage = () =>
-  import(
-    /* webpackChunkName: "PrivacyPolicyPage" */ '@/pages/privacy-policy.vue'
-  );
-const TermsOfUsePage = () =>
-  import(/* webpackChunkName: "TermsOfUsePage" */ '@/pages/terms-of-use.vue');
-const RisksPage = () =>
-  import(/* webpackChunkName: "RisksPage" */ '@/pages/risks.vue');
-const SwapPage = () =>
-  import(
-    /* webpackChunkName: "SwapPage" */ /* webpackPrefetch: true */ '@/pages/swap.vue'
-  );
-const UnlockVeBalPage = () =>
-  import(/* webpackChunkName: "UnlockVeBalPage" */ '@/pages/unlock-vebal.vue');
-const VeBalPage = () =>
-  import(/* webpackChunkName: "VeBalPage" */ '@/pages/vebal.vue');
-const FaucetPage = () =>
-  import(/* webpackChunkName: "FaucetPage" */ '@/pages/faucet.vue');
+//   import('@/pages/pool/create.vue');
+const PoolAddLiquidityPage = () => import('@/pages/pool/add-liquidity.vue');
+const MigratePoolPage = () => import('@/pages/pool/migrate.vue');
+const PoolWithdrawPage = () => import('@/pages/pool/withdraw.vue');
+const PrivacyPolicyPage = () => import('@/pages/privacy-policy.vue');
+const TermsOfUsePage = () => import('@/pages/terms-of-use.vue');
+const RisksPage = () => import('@/pages/risks.vue');
+const SwapPage = () => import('@/pages/swap.vue');
 
-const PortfolioPage = () =>
-  import(
-    /* webpackChunkName: "PortfolioPage" */ /* webpackPrefetch: true */ '@/pages/portfolio.vue'
-  );
+export const SwapPagePrefetchLinks = async () =>
+  import('@/pages/swap.vue').toString();
+
+const UnlockVeBalPage = () => import('@/pages/unlock-vebal.vue');
+const VeBalPage = () => import('@/pages/vebal.vue');
+const FaucetPage = () => import('@/pages/faucet.vue');
+
+const PortfolioPage = () => import('@/pages/portfolio.vue');
 
 declare module 'vue-router' {
   interface RouteMeta {
@@ -210,7 +182,7 @@ if (isGoerli.value) {
 //   routes.push();
 // }
 
-const router = createRouter({
+export const router = createRouter({
   history: createWebHashHistory(),
   routes,
   scrollBehavior(to, from, savedPosition) {

--- a/src/plugins/router/route-resolver.spec.ts
+++ b/src/plugins/router/route-resolver.spec.ts
@@ -1,0 +1,11 @@
+import { resolveRoute } from './route-resolver';
+
+test('Resolves route by name', async () => {
+  expect(resolveRoute({ name: 'swap' })).toBeFunction();
+});
+
+test('Resolves route by name', async () => {
+  expect(() => resolveRoute({})).toThrowErrorMatchingInlineSnapshot(
+    '"Provided route ([object Object]) must have name"'
+  );
+});

--- a/src/plugins/router/route-resolver.ts
+++ b/src/plugins/router/route-resolver.ts
@@ -1,0 +1,11 @@
+import { router } from '.';
+
+export interface RouteTo {
+  name?: string;
+}
+
+export function resolveRoute(to: RouteTo) {
+  if (!to?.name) throw new Error(`Provided route (${to}) must have name`);
+  return router.resolve({ name: to.name, params: { networkSlug: 'ethereum' } })
+    .matched[0].components?.default;
+}


### PR DESCRIPTION
# Description

This PR adds a new prefetch mechanism that parses the result of vite's async imports (in build time) and uses them to add prefetch links. 

For now, we only added prefetch to `swap` and `portfolio` links. 

Adding prefetch to other links is as easy as adding `prefetch` prop to its markdown.

The feature only works in Desktop Links to prevent excessive bandwidth consumption in mobile devices (they don't use DesktopLinks).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

This feature only works after build process (it cannot be tested in local dev server) so it can be tested in the preview url. 

## Visual context

Tested that chrome and firefox both prefetch `css` and `js` assets for `swap` route:

**Chrome**: 

https://user-images.githubusercontent.com/1316240/231103975-292431d6-5043-4c8d-83d5-dbfc6f79e2f0.mp4

<img width="1450" alt="prefetch-css" src="https://user-images.githubusercontent.com/1316240/231104289-b48a4592-f386-4997-91a3-d526c811efe1.png">

**Firefox**:

<img width="1388" alt="prefetch-css-firefox" src="https://user-images.githubusercontent.com/1316240/231104332-ae97855f-fe65-4d47-a778-f2216b36c073.png">

![prefetch-js-firefox](https://user-images.githubusercontent.com/1316240/231104358-827bb868-9fc2-4ce6-bc08-f4f5f1f6019d.png)





## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
