### PR TITLE
fix: Ignore invalid JSON in link prefetch matches

### DIFF
--- a/src/lib/utils/prefetch.ts
+++ b/src/lib/utils/prefetch.ts
@@ -3,5 +3,14 @@ export function extractPrefetchAssets(input: string | undefined) {
   // Detect strings between brackets
   const matchArray = input.match(/\[(.*?)\]/);
   if (!matchArray) return [];
-  return JSON.parse(matchArray[0]).map(asset => asset.replace('"', ''));
+  return parse(matchArray[0]).map(asset => asset.replace('"', ''));
+}
+
+function parse(match): any {
+  try {
+    return JSON.parse(match);
+  } catch (e) {
+    // If the match is not a valid JSON, we just ignore it
+    return [];
+  }
 }


### PR DESCRIPTION
# Description

We discovered that in certain scenarios, the code that JSON.parses vite async import can be failing in local. This PR avoids that problem in local devserver while keeps working in production builds.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
