### PR TITLE
Adds new AGVE GNO pool to AllowList 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.97.13",
+  "version": "1.97.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.97.13",
+      "version": "1.97.14",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.97.13",
+  "version": "1.97.14",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/lib/config/gnosis-chain/pools.ts
+++ b/src/lib/config/gnosis-chain/pools.ts
@@ -37,6 +37,7 @@ const pools: Pools = {
     // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
     AllowList: [
       '0xa99fd9950b5d5dceeaf4939e221dca8ca9b938ab000100000000000000000025', // 25WETH-25BAL-25GNO-25wxDAI
+      '0x388CAE2F7D3704C937313D990298BA67D70A3709000200000000000000000026', // 50AGVE-50GNO
     ],
   },
   Factories: {


### PR DESCRIPTION
Description
Adds the newly created AGVE GNO pool on Gnosis Chain to the AllowList. See pool: https://app.balancer.fi/#/gnosis-chain/pool/0x388CAE2F7D3704C937313D990298BA67D70A3709000200000000000000000026