### PR TITLE
Fix polygon native asset address

### DIFF
--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -41,7 +41,7 @@ const config: Config = {
   blockTime: 4,
   nativeAsset: {
     name: 'Matic',
-    address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+    address: '0x0000000000000000000000000000000000001010',
     symbol: 'MATIC',
     decimals: 18,
     deeplinkId: 'matic',

--- a/src/lib/config/polygon/tokens.ts
+++ b/src/lib/config/polygon/tokens.ts
@@ -5,11 +5,11 @@ const tokens: TokenConstants = {
     Symbols: ['WBTC', 'DAI', 'USDC', 'BAL', 'AAVE', 'WETH'],
   },
   InitialSwapTokens: {
-    input: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+    input: '0x0000000000000000000000000000000000001010',
     output: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
   },
   Addresses: {
-    nativeAsset: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+    nativeAsset: '0x0000000000000000000000000000000000001010',
     wNativeAsset: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
     WETH: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
     BAL: '0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3',


### PR DESCRIPTION
# Description

The native asset address on Polygon has always been wrong. This didn't matter previously as when fetching prices the SDK had a check for if it's a native asset and to pull from a different Coingecko API, and the balances code just calls `this.provider.getBalance` for the native asset. The default Coingecko API doesn't work with the 0xEee address:

```
> curl "https://api.coingecko.com/api/v3/simple/token_price/polygon-pos?contract_addresses=0x0000000000000000000000000000000000001010&vs_currencies=usd"
{"0x0000000000000000000000000000000000001010":{"usd":0.971639}}
> curl "https://api.coingecko.com/api/v3/simple/token_price/polygon-pos?contract_addresses=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE&vs_currencies=usd"
{}                                       
```

This is needed for switching to the Beets API.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Ensure prices in pools and on claim page for MATIC related things look correct. 
- Ensure useTokenPricesQuery is returning the correct price for this address. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
