### PR TITLE
feat: Allow for exits via internal balances

### DIFF
--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -57,6 +57,7 @@ import debounce from 'debounce-promise';
 import { captureException } from '@sentry/browser';
 import { safeInject } from '../inject';
 import { useApp } from '@/composables/useApp';
+import { POOLS } from '@/constants/pools';
 
 /**
  * TYPES
@@ -335,6 +336,13 @@ export const exitPoolProvider = (pool: Ref<Pool>) => {
 
   const fiatValueIn = computed(() => fiatValueOf(pool.value, bptIn.value));
 
+  // Should the exit be done via internal balances
+  const shouldUseInternalBalances = computed(
+    (): boolean =>
+      !!POOLS.ExitViaInternalBalance &&
+      POOLS.ExitViaInternalBalance.includes(pool.value.id)
+  );
+
   /**
    * METHODS
    */
@@ -366,6 +374,7 @@ export const exitPoolProvider = (pool: Ref<Pool>) => {
         bptInValid: bptInValid.value,
         relayerSignature: relayerSignature.value,
         transactionDeadline: transactionDeadline.value,
+        toInternalBalance: shouldUseInternalBalances.value,
       });
 
       priceImpact.value = output.priceImpact;
@@ -412,6 +421,7 @@ export const exitPoolProvider = (pool: Ref<Pool>) => {
         bptInValid: bptInValid.value,
         relayerSignature: relayerSignature.value,
         transactionDeadline: transactionDeadline.value,
+        toInternalBalance: shouldUseInternalBalances.value,
       });
       const newMax =
         selectByAddress(output.amountsOut, singleAmountOut.address) || '0';
@@ -444,6 +454,7 @@ export const exitPoolProvider = (pool: Ref<Pool>) => {
         bptInValid: bptInValid.value,
         relayerSignature: relayerSignature.value,
         transactionDeadline: transactionDeadline.value,
+        toInternalBalance: shouldUseInternalBalances.value,
       });
     } catch (error) {
       txError.value = (error as Error).message;

--- a/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exit-pool.handler.ts
@@ -26,6 +26,7 @@ export type ExitParams = {
   bptInValid: boolean;
   approvalActions: TransactionActionInfo[];
   transactionDeadline: number;
+  toInternalBalance?: boolean;
 };
 
 export type QueryOutput = {

--- a/src/services/balancer/pools/exits/handlers/recovery-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/recovery-exit.handler.ts
@@ -43,7 +43,7 @@ export class RecoveryExitHandler implements ExitPoolHandler {
   }
 
   async queryExit(params: ExitParams): Promise<QueryOutput> {
-    const { signer, bptIn, slippageBsp } = params;
+    const { signer, bptIn, slippageBsp, toInternalBalance } = params;
     const exiter = await signer.getAddress();
     const slippage = slippageBsp.toString();
     const sdkPool = await getBalancerSDK().pools.find(this.pool.value.id);
@@ -55,7 +55,8 @@ export class RecoveryExitHandler implements ExitPoolHandler {
     this.lastExitRes = await sdkPool.buildRecoveryExit(
       exiter,
       evmBptIn,
-      slippage
+      slippage,
+      toInternalBalance
     );
 
     if (!this.lastExitRes) throw new Error('Failed to construct exit.');

--- a/src/types/pools.ts
+++ b/src/types/pools.ts
@@ -93,6 +93,7 @@ export type Pools = {
   Deep: string[];
   BoostedApr: string[];
   DisabledJoins: string[];
+  ExitViaInternalBalance?: string[];
   BrandedRedirect?: Record<string, string>;
   Deprecated?: Record<string, DeprecatedDetails>;
   Migrations?: Record<string, PoolMigrationInfo>;


### PR DESCRIPTION
# Description

Allows for pools to be hardcoded to enable exits via internal balance.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

TBD

## Visual context

TBD

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
