### PR TITLE
Improve token fetch speed

### DIFF
--- a/src/composables/queries/useTokenPricesQuery.ts
+++ b/src/composables/queries/useTokenPricesQuery.ts
@@ -5,11 +5,12 @@ import useNetwork from '../useNetwork';
 import { getApi } from '@/dependencies/balancer-api';
 import { GqlTokenPrice } from '@/services/api/graphql/generated/api-types';
 import { oneMinInMs } from '../useTime';
+import { CaseInsensitiveMap } from '@/types';
 
 /**
  * TYPES
  */
-export type TokenPrices = { [address: string]: number };
+export type TokenPrices = CaseInsensitiveMap<string, number>;
 type QueryResponse = TokenPrices;
 type QueryOptions = UseQueryOptions<QueryResponse>;
 
@@ -17,7 +18,9 @@ type QueryOptions = UseQueryOptions<QueryResponse>;
  * Fetches token prices for all provided addresses.
  */
 export default function useTokenPricesQuery(
-  pricesToInject: Ref<TokenPrices> = ref({}),
+  pricesToInject: Ref<TokenPrices> = ref(
+    new CaseInsensitiveMap<string, number>()
+  ),
   options: QueryOptions = {}
 ) {
   const { networkId } = useNetwork();
@@ -28,7 +31,7 @@ export default function useTokenPricesQuery(
   function priceArrayToMap(prices: GqlTokenPrice[]): TokenPrices {
     return prices.reduce(
       (obj, item) => ((obj[item.address] = item.price), obj),
-      {}
+      new CaseInsensitiveMap<string, number>()
     );
   }
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -7,6 +7,7 @@ import { Path } from 'vue-i18n';
 import pkg from '@/../package.json';
 import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
 import { POOLS } from '@/constants/pools';
+import { CaseInsensitiveMap } from '@/types';
 
 export function shorten(str = '') {
   return `${str.slice(0, 6)}...${str.slice(str.length - 4)}`;
@@ -156,15 +157,10 @@ export function indexOfAddress(addresses: string[], address: string): number {
 }
 
 export function selectByAddress<T>(
-  map: Record<string, T>,
+  map: CaseInsensitiveMap<string, T>,
   address: string
 ): T | undefined {
-  const foundAddress = Object.keys(map).find(itemAddress => {
-    if (isSameAddress(itemAddress, address)) {
-      return true;
-    }
-  });
-  if (foundAddress) return map[foundAddress];
+  return map[address];
 }
 
 export function findByAddress<T>(

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -42,6 +42,7 @@ import {
   TokenListMap,
 } from '@/types/TokenList';
 import useWeb3 from '@/services/web3/useWeb3';
+import { CaseInsensitiveMap } from '@/types';
 
 /**
  * TYPES
@@ -172,10 +173,16 @@ export const tokensProvider = (
   } = useAllowancesQuery(tokens, toRef(state, 'allowanceContracts'));
 
   const prices = computed(
-    (): TokenPrices => (priceData.value ? priceData.value : {})
+    (): TokenPrices =>
+      priceData.value
+        ? priceData.value
+        : new CaseInsensitiveMap<string, number>()
   );
   const balances = computed(
-    (): BalanceMap => (balanceData.value ? balanceData.value : {})
+    (): BalanceMap =>
+      balanceData.value
+        ? balanceData.value
+        : new CaseInsensitiveMap<string, number>()
   );
   const allowances = computed(
     (): ContractAllowancesMap =>

--- a/src/services/token/concerns/balances.concern.ts
+++ b/src/services/token/concerns/balances.concern.ts
@@ -10,9 +10,10 @@ import { getMulticall } from '@/dependencies/multicall';
 import { TokenInfoMap } from '@/types/TokenList';
 
 import TokenService from '../token.service';
+import { CaseInsensitiveMap } from '@/types';
 
 // TYPES
-export type BalanceMap = { [address: string]: string };
+export type BalanceMap = CaseInsensitiveMap<string, number>;
 
 export default class BalancesConcern {
   network: string;

--- a/src/types/TokenList.ts
+++ b/src/types/TokenList.ts
@@ -1,3 +1,5 @@
+import { CaseInsensitiveMap } from '.';
+
 export interface TokenInfo {
   readonly chainId: number;
   readonly address: string;
@@ -40,7 +42,7 @@ export interface TokenList {
 }
 
 export type TokenListMap = { [address: string]: TokenList };
-export type TokenInfoMap = Record<string, TokenInfo>;
+export type TokenInfoMap = CaseInsensitiveMap<string, TokenInfo>;
 
 export interface TokenListURLMap {
   Balancer: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,3 +79,28 @@ export interface BlockNumberResponse {
     ];
   };
 }
+
+export class CaseInsensitiveMap<T, U> extends Map<T, U> {
+  set(key: T, value: U): this {
+    if (typeof key === 'string') {
+      key = key.toLowerCase() as any as T;
+    }
+    return super.set(key, value);
+  }
+
+  get(key: T): U | undefined {
+    if (typeof key === 'string') {
+      key = key.toLowerCase() as any as T;
+    }
+
+    return super.get(key);
+  }
+
+  has(key: T): boolean {
+    if (typeof key === 'string') {
+      key = key.toLowerCase() as any as T;
+    }
+
+    return super.has(key);
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,4 +103,48 @@ export class CaseInsensitiveMap<T, U> extends Map<T, U> {
 
     return super.has(key);
   }
+
+  delete(key: T): boolean {
+    const keyLowerCase =
+      typeof key === 'string' ? (key.toLowerCase() as any as T) : key;
+    return super.delete(keyLowerCase);
+  }
+
+  clear(): void {
+    super.clear();
+  }
+
+  keys(): IterableIterator<T> {
+    return super.keys();
+  }
+
+  values(): IterableIterator<U> {
+    return super.values();
+  }
+
+  *entries(): IterableIterator<[T, U]> {
+    const keys = super.keys();
+    const values = super.values();
+    for (let i = 0; i < super.size; i++) {
+      yield [keys.next().value, values.next().value];
+    }
+  }
+
+  forEach(
+    callbackfn: (value: U, key: T, map: CaseInsensitiveMap<T, U>) => void
+  ): void {
+    const keys = super.keys();
+    const values = super.values();
+    for (let i = 0; i < super.size; i++) {
+      callbackfn(values.next().value, keys.next().value, this);
+    }
+  }
+
+  next(): IteratorResult<[T, U]> {
+    return super.entries().next();
+  }
+
+  [Symbol.iterator](): IterableIterator<[T, U]> {
+    return this;
+  }
 }


### PR DESCRIPTION
# Description

This is an alternate variation on #3243 where I've created a custom case insensitive map so that we don't have to worry about the case tokens are in. 

It doesn't currently work because the iterator is implemented incorrectly and so the page doesn't load. I haven't yet figured out how to implement the iterator type. This is needed so when adding objects via the spread operator it adds them correctly. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
