### PR TITLE
Use new mainnet tokenlist

### DIFF
--- a/src/lib/config/mainnet/tokenlists.ts
+++ b/src/lib/config/mainnet/tokenlists.ts
@@ -3,7 +3,7 @@ import { TokenListURLMap } from '@/types/TokenList';
 const tokenlists: TokenListURLMap = {
   Balancer: {
     Default:
-      'https://raw.githubusercontent.com/balancer/tokenlists/main/generated/listed-old.tokenlist.json',
+      'https://raw.githubusercontent.com/balancer/tokenlists/main/generated/balancer.tokenlist.json',
     Vetted:
       'https://raw.githubusercontent.com/balancer/tokenlists/main/generated/balancer.tokenlist.json',
   },


### PR DESCRIPTION
# Description

Switching the main token list over to the new one that the API is using + fetching prices for. 

This fixes an issue where pools are injecting tokens that the frontend thinks are new and so the frontend is attempting to fetch prices + data for them which slows down single pool loading. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- Ensure that pools are loading as expected. 
- When swapping make sure the tokens list looks correct and tokens on the new list can be selected. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
