### PR TITLE
Hotfix: Fix swap page crashing with invalid assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.98.0",
+  "version": "1.98.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.98.0",
+      "version": "1.98.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.98.0",
+  "version": "1.98.1",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/cards/SwapCard/SwapCard.vue
+++ b/src/components/cards/SwapCard/SwapCard.vue
@@ -367,21 +367,34 @@ export default defineComponent({
       );
     }
 
-    async function populateInitialTokens(): Promise<void> {
-      let assetIn = router.currentRoute.value.params.assetIn as string;
-      if (isNativeAssetIdentifier(assetIn)) {
-        assetIn = nativeAsset.address;
-      } else if (isAddress(assetIn)) {
-        assetIn = getAddress(assetIn);
+    function getFirstValidAddress(assets: string[]): string | undefined {
+      for (const asset of assets) {
+        if (isNativeAssetIdentifier(asset)) {
+          return nativeAsset.address;
+        }
+        if (isAddress(asset)) {
+          return getAddress(asset);
+        }
       }
-      let assetOut = router.currentRoute.value.params.assetOut as string;
-      if (isNativeAssetIdentifier(assetOut)) {
-        assetOut = nativeAsset.address;
-      } else if (isAddress(assetOut)) {
-        assetOut = getAddress(assetOut);
+    }
+
+    function populateInitialTokens(): void {
+      const assetIn = getFirstValidAddress([
+        router.currentRoute.value.params.assetIn,
+        inputAsset.value,
+        appNetworkConfig.tokens.InitialSwapTokens.input,
+      ]);
+      if (assetIn) {
+        setTokenInAddress(assetIn);
       }
-      setTokenInAddress(assetIn || inputAsset);
-      setTokenOutAddress(assetOut || outputAsset);
+      const assetOut = getFirstValidAddress([
+        router.currentRoute.value.params.assetOut,
+        outputAsset.value,
+        appNetworkConfig.tokens.InitialSwapTokens.output,
+      ]);
+      if (assetOut) {
+        setTokenOutAddress(assetOut);
+      }
 
       let assetInAmount = router.currentRoute.value.query?.inAmount as string;
       let assetOutAmount = router.currentRoute.value.query?.outAmount as string;


### PR DESCRIPTION
# Description

If an invalid asset or address is passed to the swap page it errors and stops working. This also caused the page to become permanently unavailable if a bad asset gets stored in  local storage.  

This PR fixes that bug ensuring that the swap assets are valid token addresses.

Example URL that currently crashes the swap page: http://app.balancer.fi/#/polygon/swap/eth/matic

Fixes: https://balancer-labs.sentry.io/issues/4147784240/?project=5725878

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Try adding different words or tokens to the URL of the swap page, or selecting bad assets, and ensure it doesn't throw errors in the console or fail to load. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
