### PR TITLE
Remove duplicated network functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,12 @@ module.exports = {
             message:
               'Please import from src/dependencies to make this dependency more testable',
           },
+          {
+            group: ['@balancer-labs/sdk'],
+            importNames: ['Network'],
+            message:
+              'Please import Network from @/lib/config to avoid adding SDK to bundle',
+          },
         ],
       },
     ],

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesFilters.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesFilters.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { networkLabelMap } from '@/composables/useNetwork';
-import { Network } from '@balancer-labs/sdk';
-import { ref, computed } from 'vue';
+import { Network } from '@/lib/config';
 
 /**
  * TYPES

--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
-
 import useExpiredGaugesQuery from '@/composables/queries/useExpiredGaugesQuery';
 import useVeBalLockInfoQuery from '@/composables/queries/useVeBalLockInfoQuery';
 import useVotingEscrowLocks from '@/composables/useVotingEscrowLocks';
@@ -15,7 +13,7 @@ import GaugesTable from './GaugesTable.vue';
 import GaugeVoteModal from './GaugeVoteModal.vue';
 import ResubmitVotesAlert from './ResubmitVotes/ResubmitVotesAlert.vue';
 import { orderedTokenURIs } from '@/composables/useVotingGauges';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import GaugesFilters from './GaugesFilters.vue';
 
 /**

--- a/src/components/contextual/pages/vebal/LMVoting/types.ts
+++ b/src/components/contextual/pages/vebal/LMVoting/types.ts
@@ -1,5 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
-
+import { Network } from '@/lib/config';
 import { PoolType } from '@/services/pool/types';
 
 export type Pool = {

--- a/src/components/modals/VeBalRedirectModal.vue
+++ b/src/components/modals/VeBalRedirectModal.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
-import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 
 import BalModal from '@/components/_global/BalModal/BalModal.vue';
 import useVeBAL from '@/composables/useVeBAL';

--- a/src/components/navs/AppNav/AppNavSettings.vue
+++ b/src/components/navs/AppNav/AppNavSettings.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { Network } from '@balancer-labs/sdk';
-
 import AppSlippageForm from '@/components/forms/AppSlippageForm.vue';
 import Avatar from '@/components/images/Avatar.vue';
 import useEthereumTxType from '@/composables/useEthereumTxType';
@@ -11,6 +9,7 @@ import useDarkMode from '@/composables/useDarkMode';
 import { getConnectorLogo } from '@/services/web3/wallet-logos';
 import { getConnectorName } from '@/services/web3/wallet-names';
 import { useUserSettings } from '@/providers/user-settings.provider';
+import { Network, isEIP1559SupportedNetwork } from '@/composables/useNetwork';
 
 // COMPOSABLES
 const { darkMode, setDarkMode } = useDarkMode();
@@ -22,7 +21,6 @@ const {
   toggleWalletSelectModal,
   connector,
   provider,
-  isEIP1559SupportedNetwork,
   userNetworkConfig,
   isUnsupportedNetwork,
   explorerLinks,
@@ -44,7 +42,7 @@ const networkColorClass = computed(() => {
     color = 'red';
   } else {
     switch (userNetworkConfig.value?.chainId) {
-      case Network.GÖRLI:
+      case Network.GOERLI:
         color = 'blue';
         break;
     }

--- a/src/components/navs/AppNav/AppNavSettings.vue
+++ b/src/components/navs/AppNav/AppNavSettings.vue
@@ -9,7 +9,8 @@ import useDarkMode from '@/composables/useDarkMode';
 import { getConnectorLogo } from '@/services/web3/wallet-logos';
 import { getConnectorName } from '@/services/web3/wallet-names';
 import { useUserSettings } from '@/providers/user-settings.provider';
-import { Network, isEIP1559SupportedNetwork } from '@/composables/useNetwork';
+import { isEIP1559SupportedNetwork } from '@/composables/useNetwork';
+import { Network } from '@/lib/config';
 
 // COMPOSABLES
 const { darkMode, setDarkMode } = useDarkMode();

--- a/src/components/navs/AppNav/DesktopLinks/DesktopLinks.vue
+++ b/src/components/navs/AppNav/DesktopLinks/DesktopLinks.vue
@@ -1,11 +1,8 @@
 <script lang="ts" setup>
 import { useRoute } from 'vue-router';
-import useWeb3 from '@/services/web3/useWeb3';
 import DesktopLinkItem from './DesktopLinkItem.vue';
-import useNetwork from '@/composables/useNetwork';
+import useNetwork, { isGoerli } from '@/composables/useNetwork';
 import { Goals, trackGoal } from '@/composables/useFathom';
-
-const { isGoerli } = useWeb3();
 
 /**
  * COMPOSABLES

--- a/src/components/popovers/SwapSettingsPopover.vue
+++ b/src/components/popovers/SwapSettingsPopover.vue
@@ -12,7 +12,7 @@ import useEthereumTxType from '@/composables/useEthereumTxType';
 import useFathom from '@/composables/useFathom';
 import { ethereumTxTypeOptions } from '@/constants/options';
 import { useUserSettings } from '@/providers/user-settings.provider';
-import useWeb3 from '@/services/web3/useWeb3';
+import { isEIP1559SupportedNetwork } from '@/composables/useNetwork';
 
 type Props = {
   context: SwapSettingsContext;
@@ -29,7 +29,6 @@ const { context } = toRefs(props);
 // COMPOSABLES
 const { transactionDeadline, setTransactionDeadline } = useApp();
 
-const { isEIP1559SupportedNetwork } = useWeb3();
 const { trackGoal, Goals } = useFathom();
 const { ethereumTxType, setEthereumTxType } = useEthereumTxType();
 const { supportSignatures, setSupportSignatures } = useUserSettings();

--- a/src/composables/useBlocknative.ts
+++ b/src/composables/useBlocknative.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import BlocknativeSdk from 'bnc-sdk';
 import { computed, inject } from 'vue';
 

--- a/src/composables/useNetwork.spec.ts
+++ b/src/composables/useNetwork.spec.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import {
   getRedirectUrlFor,
   getSubdomain,

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -1,22 +1,7 @@
-import config from '@/lib/config';
+import config, { Network } from '@/lib/config';
 import { configService } from '@/services/config/config.service';
 import { RouteParamsRaw } from 'vue-router';
 import { Config } from '@/lib/config/types';
-
-// We don't import Network from sdk to avoid extra bundle size when loading app (while the SDK is not tree-shakable)
-export enum Network {
-  MAINNET = 1,
-  ROPSTEN = 3,
-  RINKEBY = 4,
-  GOERLI = 5,
-  GÖRLI = 5,
-  OPTIMISM = 10,
-  KOVAN = 42,
-  GNOSIS = 100,
-  POLYGON = 137,
-  ARBITRUM = 42161,
-  FANTOM = 250,
-}
 
 /**
  * STATE

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -1,10 +1,22 @@
-import { computed, ref } from 'vue';
-
 import config from '@/lib/config';
 import { configService } from '@/services/config/config.service';
-import { Network } from '@balancer-labs/sdk';
 import { RouteParamsRaw } from 'vue-router';
 import { Config } from '@/lib/config/types';
+
+// We don't import Network from sdk to avoid extra bundle size when loading app (while the SDK is not tree-shakable)
+export enum Network {
+  MAINNET = 1,
+  ROPSTEN = 3,
+  RINKEBY = 4,
+  GOERLI = 5,
+  GÖRLI = 5,
+  OPTIMISM = 10,
+  KOVAN = 42,
+  GNOSIS = 100,
+  POLYGON = 137,
+  ARBITRUM = 42161,
+  FANTOM = 250,
+}
 
 /**
  * STATE
@@ -51,6 +63,10 @@ export const isGoerli = computed(() => networkId.value === Network.GOERLI);
 
 export const hasBridge = computed<boolean>(() => !!networkConfig.bridgeUrl);
 export const isTestnet = computed(() => isGoerli.value);
+
+export const isEIP1559SupportedNetwork = computed(
+  () => configService.network.supportsEIP1559
+);
 
 export const isPoolBoostsEnabled = computed<boolean>(
   () => configService.network.pools.BoostsEnabled
@@ -162,6 +178,7 @@ export function getRedirectUrlFor(
 }
 
 export default function useNetwork() {
+  const appNetworkConfig = configService.network;
   return {
     appUrl,
     networkId,
@@ -171,5 +188,6 @@ export default function useNetwork() {
     getSubdomain,
     handleNetworkSlug,
     networkLabelMap,
+    appNetworkConfig,
   };
 }

--- a/src/composables/usePoolHelpers.spec.ts
+++ b/src/composables/usePoolHelpers.spec.ts
@@ -3,7 +3,7 @@ import { initDependenciesWithDefaultMocks } from '@/dependencies/default-mocks';
 import { Pool, PoolToken, PoolType, SubPool } from '@/services/pool/types';
 import { BoostedPoolMock } from '@/__mocks__/pool';
 import { aWeightedPool } from '@/__mocks__/weighted-pool';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { mountComposableWithDefaultTokensProvider as mountComposable } from '@tests/mount-helpers';
 
 import {

--- a/src/composables/usePoolHelpers.ts
+++ b/src/composables/usePoolHelpers.ts
@@ -1,8 +1,8 @@
-import { AprBreakdown, Network, PoolType } from '@balancer-labs/sdk';
+import { AprBreakdown, PoolType } from '@balancer-labs/sdk';
 import { getAddress } from '@ethersproject/address';
 
 import { APR_THRESHOLD } from '@/constants/pools';
-import configs from '@/lib/config';
+import configs, { Network } from '@/lib/config';
 import {
   bnum,
   includesAddress,

--- a/src/composables/usePoolWarning.ts
+++ b/src/composables/usePoolWarning.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { computed, Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { networkId } from './useNetwork';

--- a/src/composables/useSupportsBlocknative.ts
+++ b/src/composables/useSupportsBlocknative.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { computed } from 'vue';
 
 import useWeb3 from '@/services/web3/useWeb3';

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { TransactionReceipt } from '@ethersproject/abstract-provider';
 import { Ref } from 'vue';
 

--- a/src/constants/voting-gauges.ts
+++ b/src/constants/voting-gauges.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { PoolToken, PoolType } from '@/services/pool/types';
 
 // voting-gauges.json is inside src

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,4 +1,3 @@
-import { Network } from '@balancer-labs/sdk';
 import { Config } from './types';
 
 import arbitrum from './arbitrum';
@@ -9,6 +8,21 @@ import optimism from './optimism';
 import polygon from './polygon';
 import gnosisChain from './gnosis-chain';
 import test from './test';
+
+// We don't import Network from sdk to avoid extra bundle size when loading app (while the SDK is not tree-shakable)
+export enum Network {
+  MAINNET = 1,
+  ROPSTEN = 3,
+  RINKEBY = 4,
+  GOERLI = 5,
+  GÖRLI = 5,
+  OPTIMISM = 10,
+  KOVAN = 42,
+  GNOSIS = 100,
+  POLYGON = 137,
+  ARBITRUM = 42161,
+  FANTOM = 250,
+}
 
 const config: Record<Network | number, Config> = {
   [Network.MAINNET]: mainnet,

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { Pools } from '@/types/pools';
 import { TokenListURLMap } from '@/types/TokenList';
 

--- a/src/lib/scripts/tokenlists.generator.ts
+++ b/src/lib/scripts/tokenlists.generator.ts
@@ -1,6 +1,6 @@
 import TokenListService from '@/services/token-list/token-list.service';
 import config from '@/lib/config';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 
 const fs = require('fs');
 const path = require('path');

--- a/src/lib/scripts/voting-gauge.generator.ts
+++ b/src/lib/scripts/voting-gauge.generator.ts
@@ -4,7 +4,7 @@
  * To run, ensure you have your own .env.development file with the following:
  * VITE_RPC_URL_1=YOUR_MAINNET_RPC_URL
  */
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { getAddress } from '@ethersproject/address';
 import debug from 'debug';
 import fs from 'fs';

--- a/src/lib/utils/urls.ts
+++ b/src/lib/utils/urls.ts
@@ -1,5 +1,5 @@
 import { networkMap, Wallet } from '@/providers/wallet.provider';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 
 function getNetworkIconName(network: Network) {
   return networkMap[Number(network)].toLowerCase();

--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -25,7 +25,7 @@ import { BalanceMap } from '@/services/token/concerns/balances.concern';
 import useWeb3 from '@/services/web3/useWeb3';
 import { TOKENS } from '@/constants/tokens';
 import { buildNetworkIconURL } from '@/lib/utils/urls';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 
 /**
  * TYPES

--- a/src/pages/claim/legacy.vue
+++ b/src/pages/claim/legacy.vue
@@ -3,12 +3,17 @@ import HeroClaim from '@/components/contextual/pages/claim/HeroClaim.vue';
 import LegacyClaims from '@/components/contextual/pages/claim/LegacyClaims.vue';
 import { MerkleOrchardVersion } from '@/services/claim/claim.service';
 import useWeb3 from '@/services/web3/useWeb3';
+import {
+  isArbitrum,
+  isMainnet,
+  isGoerli,
+  isPolygon,
+} from '@/composables/useNetwork';
 
 /**
  * COMPOSABLES
  */
-const { isWalletReady, account, isArbitrum, isMainnet, isGoerli, isPolygon } =
-  useWeb3();
+const { isWalletReady, account } = useWeb3();
 
 /**
  * COMPUTED

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -9,12 +9,11 @@ import PoolsTable from '@/components/tables/PoolsTable/PoolsTable.vue';
 import usePoolFilters from '@/composables/pools/usePoolFilters';
 import useBreakpoints from '@/composables/useBreakpoints';
 import useNetwork from '@/composables/useNetwork';
-import useWeb3 from '@/services/web3/useWeb3';
 import usePools from '@/composables/pools/usePools';
 
 // COMPOSABLES
 const router = useRouter();
-const { appNetworkConfig } = useWeb3();
+const { appNetworkConfig } = useNetwork();
 const isElementSupported = appNetworkConfig.supportsElementPools;
 const { selectedTokens, addSelectedToken, removeSelectedToken } =
   usePoolFilters();

--- a/src/plugins/router/nav-guards.ts
+++ b/src/plugins/router/nav-guards.ts
@@ -7,7 +7,7 @@ import {
 } from '@/composables/useNetwork';
 import { isJoinsDisabled } from '@/composables/usePoolHelpers';
 import config from '@/lib/config';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { Router } from 'vue-router';
 import metaService from '@/services/meta/meta.service';
 

--- a/src/providers/wallet.provider.ts
+++ b/src/providers/wallet.provider.ts
@@ -20,7 +20,7 @@ import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service
 import { Connector } from '@/services/web3/connectors/connector';
 import { walletService } from '@/services/web3/wallet.service';
 import { getWeb3Provider } from '@/dependencies/wallets/Web3Provider';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import {
   getSafeConnector,
   initSafeConnector,

--- a/src/services/balancer/gauges/gauge-controller.decorator.ts
+++ b/src/services/balancer/gauges/gauge-controller.decorator.ts
@@ -13,7 +13,8 @@ import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service
 import { getOldMulticaller } from '@/dependencies/OldMulticaller';
 // eslint-disable-next-line no-restricted-imports
 import { Multicaller } from '@/lib/utils/balancer/contract';
-import { isGoerli, Network } from '@/composables/useNetwork';
+import { isGoerli } from '@/composables/useNetwork';
+import { Network } from '@/lib/config';
 
 const FIRST_WEEK_TIMESTAMP = 1648684800;
 

--- a/src/services/balancer/gauges/gauge-controller.decorator.ts
+++ b/src/services/balancer/gauges/gauge-controller.decorator.ts
@@ -1,4 +1,3 @@
-import { Network } from '@balancer-labs/sdk';
 import { BigNumber } from '@ethersproject/bignumber';
 import { JsonRpcProvider } from '@ethersproject/providers';
 
@@ -14,6 +13,7 @@ import { rpcProviderService } from '@/services/rpc-provider/rpc-provider.service
 import { getOldMulticaller } from '@/dependencies/OldMulticaller';
 // eslint-disable-next-line no-restricted-imports
 import { Multicaller } from '@/lib/utils/balancer/contract';
+import { isGoerli, Network } from '@/composables/useNetwork';
 
 const FIRST_WEEK_TIMESTAMP = 1648684800;
 
@@ -178,7 +178,7 @@ export class GaugeControllerDecorator {
    * so the network key can only be goerli (5) or mainnet (1).
    */
   private getNetwork(): Network {
-    if (this.config.env.NETWORK === Network.GOERLI) {
+    if (isGoerli.value) {
       return Network.GOERLI;
     } else {
       return Network.MAINNET;

--- a/src/services/config/config.service.ts
+++ b/src/services/config/config.service.ts
@@ -1,13 +1,10 @@
-import { Network } from '@balancer-labs/sdk';
-
-import { networkId } from '@/composables/useNetwork';
+import { Network, networkId } from '@/composables/useNetwork';
 import { Config } from '@/lib/config/types';
 import configs from '@/lib/config';
 import template from '@/lib/utils/template';
 
 interface Env {
   APP_ENV: string;
-  NETWORK: Network;
   APP_DOMAIN: string;
   APP_HOST: string;
   API_URL: string;
@@ -23,7 +20,6 @@ export default class ConfigService {
   public get env(): Env {
     return {
       APP_ENV: import.meta.env.VITE_ENV || 'development',
-      NETWORK: networkId.value,
       APP_DOMAIN: import.meta.env.VITE_DOMAIN || 'app.balancer.fi',
       APP_HOST: import.meta.env.VITE_HOST || 'balancer.fi',
       API_URL:

--- a/src/services/config/config.service.ts
+++ b/src/services/config/config.service.ts
@@ -1,6 +1,6 @@
-import { Network, networkId } from '@/composables/useNetwork';
+import { networkId } from '@/composables/useNetwork';
 import { Config } from '@/lib/config/types';
-import configs from '@/lib/config';
+import configs, { Network } from '@/lib/config';
 import template from '@/lib/utils/template';
 
 interface Env {

--- a/src/services/contracts/vault.service.mocks.ts
+++ b/src/services/contracts/vault.service.mocks.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 
 import { MetamaskConnectorMock } from '@/dependencies/wallets/wallet-connector-mocks';
 import { JsonRpcSigner } from '@ethersproject/providers';

--- a/src/services/cowswap/constants.ts
+++ b/src/services/cowswap/constants.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { BigNumber } from '@ethersproject/bignumber';
 import {
   GPv2Settlement,

--- a/src/services/cowswap/cowswapProtocol.service.ts
+++ b/src/services/cowswap/cowswapProtocol.service.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import axios from 'axios';
 
 import { networkId } from '@/composables/useNetwork';

--- a/src/services/gas-price/providers/arbitrum.provider.ts
+++ b/src/services/gas-price/providers/arbitrum.provider.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { GasPrice } from './types';
 import { bnum } from '@/lib/utils';
 import { configService } from '@/services/config/config.service';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 
 interface ArbitrumGasStationResponse {
   id: number;

--- a/src/services/gas-price/providers/gnosis.provider.ts
+++ b/src/services/gas-price/providers/gnosis.provider.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { GasPrice } from './types';
 import { bnum } from '@/lib/utils';
 import { configService } from '@/services/config/config.service';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 
 interface GnosisChainGasStationResponse {
   id: number;

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { JsonRpcProvider, WebSocketProvider } from '@ethersproject/providers';
 
 import { configService } from '@/services/config/config.service';

--- a/src/services/token-list/token-list.service.ts
+++ b/src/services/token-list/token-list.service.ts
@@ -5,7 +5,7 @@ import { TokenList, TokenListMap } from '@/types/TokenList';
 
 import { configService } from '../config/config.service';
 import { ipfsService } from '../ipfs/ipfs.service';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 
 interface TokenListUris {
   All: string[];

--- a/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
+++ b/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
@@ -3,7 +3,7 @@ import WalletConnectProvider from '@walletconnect/web3-provider';
 import ConfigService from '@/services/config/config.service';
 import config from '@/lib/config';
 import { WalletError } from '@/types';
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { Connector, ConnectorId } from '../connector';
 import { Config } from '@/lib/config/types';
 

--- a/src/services/web3/useWeb3.ts
+++ b/src/services/web3/useWeb3.ts
@@ -1,7 +1,5 @@
-import { Network } from '@balancer-labs/sdk';
 import { useQuery } from '@tanstack/vue-query';
 import debounce from 'lodash/debounce';
-import { computed, reactive, ref } from 'vue';
 
 import useNetwork from '@/composables/useNetwork';
 import QUERY_KEYS from '@/constants/queryKeys';
@@ -64,20 +62,6 @@ export default function useWeb3() {
   const isWalletConnecting = computed(() => walletState.value === 'connecting');
   const isWalletDisconnected = computed(
     () => walletState.value === 'disconnected'
-  );
-  const isMainnet = computed(
-    () => appNetworkConfig.chainId === Network.MAINNET
-  );
-  const isGoerli = computed(() => appNetworkConfig.chainId === Network.GOERLI);
-  const isPolygon = computed(
-    () => appNetworkConfig.chainId === Network.POLYGON
-  );
-  const isArbitrum = computed(
-    () => appNetworkConfig.chainId === Network.ARBITRUM
-  );
-  const isGnosis = computed(() => appNetworkConfig.chainId === Network.GNOSIS);
-  const isEIP1559SupportedNetwork = computed(
-    () => appNetworkConfig.supportsEIP1559
   );
 
   const canLoadProfile = computed(
@@ -155,12 +139,6 @@ export default function useWeb3() {
     explorerLinks,
     signer,
     blockNumber,
-    isMainnet,
-    isGoerli,
-    isPolygon,
-    isArbitrum,
-    isGnosis,
-    isEIP1559SupportedNetwork,
     isWalletConnecting,
     isBlocked,
 

--- a/src/services/web3/wallet.service.ts
+++ b/src/services/web3/wallet.service.ts
@@ -1,4 +1,4 @@
-import { Network } from '@balancer-labs/sdk';
+import { Network } from '@/lib/config';
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 import { resolveENSAvatar } from '@tomfrench/ens-avatar-resolver';
 


### PR DESCRIPTION
# Description

- Removes duplicated functions between `useNetwork` and `useWeb3` 
- Introduces `appNetworkConfig` into `useNetwork` and `Network` frontend type to avoid loading web3 dependencies from`index.vue` (this is a preparatory change for an incoming PR about boosting the initial load).


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
