### PR TITLE
Extract metadata from pool helpers

### DIFF
--- a/src/components/contextual/pages/pool/PoolContractDetails.vue
+++ b/src/components/contextual/pages/pool/PoolContractDetails.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { POOLS } from '@/constants/pools';
-import { poolMetadata } from '@/composables/usePoolHelpers';
+import { poolMetadata } from '@/lib/config/metadata';
 import { shortenLabel } from '@/lib/utils';
 import { Pool, PoolType } from '@/services/pool/types';
 import useWeb3 from '@/services/web3/useWeb3';
 import { format } from 'date-fns';
-import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 /**

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { PoolToken } from '@balancer-labs/sdk';
-import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 
@@ -14,7 +13,6 @@ import { getNetworkSlug } from '@/composables/useNetwork';
 import {
   isStableLike,
   isUnknownType,
-  poolMetadata,
   poolURLFor,
 } from '@/composables/usePoolHelpers';
 import { isSameAddress } from '@/lib/utils';
@@ -33,6 +31,7 @@ import IconLimit from '@/components/icons/IconLimit.vue';
 import { differenceInWeeks } from 'date-fns';
 import { oneSecondInMs } from '@/composables/useTime';
 import { buildNetworkIconURL } from '@/lib/utils/urls';
+import { poolMetadata } from '@/lib/config/metadata';
 
 /**
  * TYPES
@@ -252,12 +251,10 @@ function getPickedTokens(tokens: PoolToken[]) {
           <BalAssetSet :logoURIs="orderedTokenURIs(gauge)" :width="100" />
         </div>
       </template>
-      <template
-        #poolCompositionCell="{ pool, address, addedTimestamp, network }"
-      >
+      <template #poolCompositionCell="{ pool, address, addedTimestamp }">
         <div v-if="!isLoading" class="flex items-center py-4 px-6">
-          <div v-if="poolMetadata(pool.id, network)" class="text-left">
-            {{ poolMetadata(pool.id, network)?.name }}
+          <div v-if="poolMetadata(pool.id)" class="text-left">
+            {{ poolMetadata(pool.id)?.name }}
           </div>
           <TokenPills
             v-else

--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -138,7 +138,7 @@ function symbolFor(titleTokenIndex: number): string {
     <div class="flex flex-wrap items-center -mt-2">
       <div v-if="hasMetadata">
         <h3 class="pool-title">
-          {{ poolMetadata.name }}
+          {{ poolMetadata?.name }}
         </h3>
         <h5 class="text-sm">
           {{ poolTypeLabel }}

--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -16,7 +16,7 @@ import { Pool, PoolToken } from '@/services/pool/types';
 import useWeb3 from '@/services/web3/useWeb3';
 import { AprBreakdown } from '@balancer-labs/sdk';
 import { useDisabledJoinPool } from '@/composables/useDisabledJoinPool';
-import { poolMetadata } from '@/lib/config/metadata';
+import { poolMetadata as getPoolMetadata } from '@/lib/config/metadata';
 
 /**
  * TYPES
@@ -121,7 +121,8 @@ const poolTypeLabel = computed(() => {
   return key ? t(key) : t('unknownPoolType');
 });
 
-const hasMetadata = !!poolMetadata;
+const poolMetadata = computed(() => getPoolMetadata(props.pool.id));
+const hasMetadata = computed((): boolean => !!poolMetadata.value);
 
 /**
  * METHODS

--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -16,6 +16,7 @@ import { Pool, PoolToken } from '@/services/pool/types';
 import useWeb3 from '@/services/web3/useWeb3';
 import { AprBreakdown } from '@balancer-labs/sdk';
 import { useDisabledJoinPool } from '@/composables/useDisabledJoinPool';
+import { poolMetadata } from '@/lib/config/metadata';
 
 /**
  * TYPES
@@ -120,8 +121,7 @@ const poolTypeLabel = computed(() => {
   return key ? t(key) : t('unknownPoolType');
 });
 
-const poolMetadata = computed(() => POOLS.Metadata[props.pool?.id]);
-const hasMetadata = computed((): boolean => !!poolMetadata.value);
+const hasMetadata = !!poolMetadata;
 
 /**
  * METHODS

--- a/src/components/tables/BalClaimsTable.vue
+++ b/src/components/tables/BalClaimsTable.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 
@@ -11,7 +10,6 @@ import useBreakpoints from '@/composables/useBreakpoints';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import {
   isStableLike,
-  poolMetadata,
   orderedPoolTokens,
   orderedTokenAddresses,
 } from '@/composables/usePoolHelpers';
@@ -21,6 +19,7 @@ import { GaugePool } from '@/composables/useClaimsData';
 import { Gauge } from '@/services/balancer/gauges/types';
 import PoolWarningTooltip from '@/components/pool/PoolWarningTooltip.vue';
 import useNetwork from '@/composables/useNetwork';
+import { poolMetadata } from '@/lib/config/metadata';
 
 /**
  * TYPES

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -26,7 +26,6 @@ import {
   orderedTokenAddresses,
   totalAprLabel,
   isLBP,
-  poolMetadata,
 } from '@/composables/usePoolHelpers';
 import { bnum } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
@@ -38,6 +37,7 @@ import TokenPills from './TokenPills/TokenPills.vue';
 import PoolWarningTooltip from '@/components/pool/PoolWarningTooltip.vue';
 import TokensWhite from '@/assets/images/icons/tokens_white.svg';
 import TokensBlack from '@/assets/images/icons/tokens_black.svg';
+import { poolMetadata } from '@/lib/config/metadata';
 
 /**
  * TYPES

--- a/src/composables/usePoolHelpers.spec.ts
+++ b/src/composables/usePoolHelpers.spec.ts
@@ -26,7 +26,6 @@ import {
   tokenTreeLeafs,
   tokenTreeNodes,
   usePoolHelpers,
-  poolMetadata,
   deprecatedDetails,
   isJoinsDisabled,
   totalAprLabel,
@@ -519,24 +518,6 @@ test('returns undefined when there is no deprecated details', async () => {
 
 test('returns existing deprecated details', async () => {
   expect(deprecatedDetails('deprecatedId')).toEqual({});
-});
-
-test('returns undefined when there is no pool metadata', async () => {
-  const GOERLI = 5;
-  expect(poolMetadata('inventedId', GOERLI)).toBeUndefined();
-});
-
-test('returns existing pool metadata', async () => {
-  const GOERLI = 5;
-  expect(
-    poolMetadata(
-      '0x13acd41c585d7ebb4a9460f7c8f50be60dc080cd00000000000000000000005f',
-      GOERLI
-    )
-  ).toEqual({
-    hasIcon: false,
-    name: 'Balancer Boosted Aave USD',
-  });
 });
 
 test('detects disabled joins by id', async () => {

--- a/src/composables/usePoolHelpers.ts
+++ b/src/composables/usePoolHelpers.ts
@@ -2,7 +2,6 @@ import { AprBreakdown, Network, PoolType } from '@balancer-labs/sdk';
 import { getAddress } from '@ethersproject/address';
 
 import { APR_THRESHOLD } from '@/constants/pools';
-import configs from '@/lib/config';
 import {
   bnum,
   includesAddress,
@@ -12,7 +11,7 @@ import {
 } from '@/lib/utils';
 import { includesWstEth } from '@/lib/utils/balancer/lido';
 import { configService } from '@/services/config/config.service';
-import { DeprecatedDetails, PoolMetadata } from '@/types/pools';
+import { DeprecatedDetails } from '@/types/pools';
 
 import { AnyPool, Pool, PoolToken, SubPool } from '@/services/pool/types';
 import { hasBalEmissions } from './useAPR';
@@ -22,10 +21,10 @@ import {
   getNetworkSlug,
   isMainnet,
   isPoolBoostsEnabled,
-  networkId,
 } from './useNetwork';
 import useNumbers, { FNumFormats, numF } from './useNumbers';
 import { dateToUnixTimestamp } from './useTime';
+import { poolMetadata } from '@/lib/config/metadata';
 
 const POOLS = configService.network.pools;
 
@@ -557,16 +556,6 @@ export function isJoinsDisabled(id: string): boolean {
  */
 export function deprecatedDetails(id: string): DeprecatedDetails | undefined {
   return POOLS.Deprecated?.[id.toLowerCase()];
-}
-
-/**
- * Get metadata for a pool if it exists
- */
-export function poolMetadata(
-  id: string,
-  network = networkId.value
-): PoolMetadata | undefined {
-  return configs[network]?.pools.Metadata[id.toLowerCase()];
 }
 
 /**

--- a/src/lib/config/metadata.spec.ts
+++ b/src/lib/config/metadata.spec.ts
@@ -1,0 +1,16 @@
+import { poolMetadata } from './metadata';
+
+test('returns undefined when there is no pool metadata', async () => {
+  expect(poolMetadata('inventedId')).toBeUndefined();
+});
+
+test('returns existing pool metadata', async () => {
+  expect(
+    poolMetadata(
+      '0x13acd41c585d7ebb4a9460f7c8f50be60dc080cd00000000000000000000005f'
+    )
+  ).toEqual({
+    hasIcon: false,
+    name: 'Balancer Boosted Aave USD',
+  });
+});

--- a/src/lib/config/metadata.ts
+++ b/src/lib/config/metadata.ts
@@ -1,0 +1,9 @@
+import { POOLS } from '@/constants/pools';
+import { PoolMetadata } from '@/types/pools';
+
+/**
+ * Get metadata for a pool if it exists
+ */
+export function poolMetadata(id: string): PoolMetadata | undefined {
+  return POOLS.Metadata[id.toLowerCase()];
+}

--- a/src/services/meta/meta.service.ts
+++ b/src/services/meta/meta.service.ts
@@ -1,11 +1,18 @@
-import { Pool } from '@balancer-labs/sdk';
+import { poolMetadata } from '@/lib/config/metadata';
 import { RouteLocationNormalized } from 'vue-router';
 import { configService } from '../config/config.service';
 import { ROUTE_META_DATA } from './meta.constants';
-import { poolMetadata } from '@/composables/usePoolHelpers';
 
 interface IMetaService {
   setMeta(route: RouteLocationNormalized | string): void;
+}
+
+// We use this interface to avoid importing Pool type from SDK while it is not tree-shakable
+interface Pool {
+  id: string;
+  name: string;
+  poolType: string;
+  symbol?: string;
 }
 
 class MetaService implements IMetaService {


### PR DESCRIPTION
# Description

This is a preparatory PR to boost app loading time. 

We want to avoid that router handlers like `meta.service.ts `depend on SDK so that we extract metadata logic to make it independent of global Pool logic. 

At the same time, we move metadata logic closer to the config (metadata is defined in config files) so that there's more cohesion. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
