### PR TITLE
feat: Allow redirect for other types of balance withdrawals

### DIFF
--- a/src/components/tables/InternalBalancesTable.vue
+++ b/src/components/tables/InternalBalancesTable.vue
@@ -10,7 +10,7 @@ import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { useTokens } from '@/providers/tokens.provider';
 import { vaultService } from '@/services/contracts/vault.service';
 import useWeb3 from '@/services/web3/useWeb3';
-import { bnum, trackLoading } from '@/lib/utils';
+import { bnum, selectByAddress, trackLoading } from '@/lib/utils';
 import { formatUnits, parseUnits } from '@ethersproject/units';
 import TxActionBtn from '@/components/btns/TxActionBtn/TxActionBtn.vue';
 import { TokenInfo } from '@/types/TokenList';
@@ -29,6 +29,14 @@ export type InternalBalanceRow = TokenInfo & {
  */
 const internalBalances = ref<InternalBalanceRow[]>([]);
 const loading = ref(true);
+const externalWithdrawActions = {
+  '0xEb91861f8A4e1C12333F42DCE8fB0Ecdc28dA716':
+    'https://redemptions.euler.finance/',
+  '0x4d19F33948b99800B6113Ff3e83beC9b537C85d2':
+    'https://redemptions.euler.finance/',
+  '0xe025E3ca2bE02316033184551D4d3Aa22024D9DC':
+    'https://redemptions.euler.finance/',
+};
 
 /**
  * COMPOSABLES
@@ -143,7 +151,8 @@ const columns = ref<ColumnDefinition<any>[]>([
     id: 'value',
     align: 'right',
     width: 150,
-    accessor: ({ value }) => fNum(value, FNumFormats.fiat),
+    accessor: ({ value }) =>
+      bnum(value).eq(0) ? '-' : fNum(value, FNumFormats.fiat),
   },
   {
     name: '',
@@ -178,7 +187,20 @@ const columns = ref<ColumnDefinition<any>[]>([
       </template>
       <template #withdrawColumnCell="{ address, value }">
         <div class="flex justify-end py-4 px-6">
+          <BalBtn
+            v-if="selectByAddress(externalWithdrawActions, address)"
+            tag="a"
+            :href="selectByAddress(externalWithdrawActions, address)"
+            target="_blank"
+            rel="noopener noreferrer"
+            external
+            color="gradient"
+            size="sm"
+            >{{ $t('redeem') }}
+            <BalIcon name="arrow-up-right" size="sm" class="ml-1"
+          /></BalBtn>
           <TxActionBtn
+            v-else
             :label="$t('transactionAction.withdraw')"
             color="gradient"
             size="sm"

--- a/src/lib/config/mainnet/tokens.ts
+++ b/src/lib/config/mainnet/tokens.ts
@@ -16,6 +16,11 @@ const tokens: TokenConstants = {
     bbaUSD: '0x7B50775383d3D6f0215A8F290f2C9e2eEBBEceb2',
     bbaUSDv2: '0xA13a9247ea42D743238089903570127DdA72fE44',
   },
+  DisableInternalBalanceWithdrawals: [
+    '0xEb91861f8A4e1C12333F42DCE8fB0Ecdc28dA716',
+    '0x4d19F33948b99800B6113Ff3e83beC9b537C85d2',
+    '0xe025E3ca2bE02316033184551D4d3Aa22024D9DC',
+  ],
 };
 
 export default tokens;

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -21,6 +21,7 @@ export type TokenConstants = {
     output: string;
   };
   PriceChainMap?: Record<string, string>;
+  DisableInternalBalanceWithdrawals?: string[];
 };
 
 export interface Contracts {

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -704,7 +704,8 @@
       }
     },
     "balances": {
-      "title": "My Vault balances"
+      "title": "My Vault balances",
+      "eulerHack": "Euler eTokens (e.g. eUSDC, eUSDT and eDAI) affected by the Euler hack have been paused and are not transferrable from the Balancer Vault. To redeem your share of the recovered funds of the Euler hack, if you haven't done so already, go to:"
     }
   },
   "pastEarnings": {

--- a/src/pages/balances.vue
+++ b/src/pages/balances.vue
@@ -13,6 +13,12 @@ import InternalBalancesTable from '@/components/tables/InternalBalancesTable.vue
       <BalStack vertical spacing="2xl">
         <InternalBalancesTable />
       </BalStack>
+      <p class="px-4 lg:px-0 mt-4 max-w-3xl text-sm text-gray-500">
+        {{ $t('pages.balances.eulerHack') }}
+        <BalLink href="https://redemptions.euler.finance/" external
+          >https://redemptions.euler.finance/</BalLink
+        >
+      </p>
     </BalStack>
   </div>
 </template>


### PR DESCRIPTION
# Description

This change is specifically to allow for a redirect to the Euler redeem app for eTokens but could cover other cases where we need to do the same thing but to different URLs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] If you have eTokens visit the /ethereum/balances page and check that the withdrawal button actually says "Redeem" and links to the Euler redeem app.

## Visual context

<img width="1389" alt="Screenshot 2023-05-04 at 11 01 38" src="https://user-images.githubusercontent.com/2406506/236173552-d0ff5b06-9671-437d-a344-d1c96227c320.png">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
