### PR TITLE
chore: For fetching metadata only use main balancer tokenlist

### DIFF
--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -1,5 +1,5 @@
 import { getAddress, isAddress } from '@ethersproject/address';
-import { compact, pick } from 'lodash';
+import { compact, omit, pick } from 'lodash';
 import {
   computed,
   InjectionKey,
@@ -42,6 +42,9 @@ import {
   TokenListMap,
 } from '@/types/TokenList';
 import useWeb3 from '@/services/web3/useWeb3';
+import { tokenListService } from '@/services/token-list/token-list.service';
+
+const { uris: tokenListUris } = tokenListService;
 
 /**
  * TYPES
@@ -264,7 +267,7 @@ export const tokensProvider = (
 
     const newTokens = await new TokenService().metadata.get(
       injectable,
-      allTokenLists.value
+      omit(allTokenLists.value, tokenListUris.Balancer.Default)
     );
 
     state.injectedTokens = { ...state.injectedTokens, ...newTokens };


### PR DESCRIPTION
# Description

Should fix issue with missing icons for some tokens.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test this mainnet pool has all icons `0x639883476960a23b38579acfd7d71561a0f408cf000200000000000000000505`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
