### PR TITLE
Fixed z-index safari bug affecting dark mode modals

### DIFF
--- a/src/components/_global/BalModal/BalModal.vue
+++ b/src/components/_global/BalModal/BalModal.vue
@@ -112,7 +112,7 @@ defineExpose({ hide });
 }
 
 .modal-card {
-  @apply mx-auto h-full rounded-b-none sm:rounded-b-lg dark:border-0;
+  @apply mx-auto h-full rounded-b-none sm:rounded-b-lg dark:border-0 relative;
 }
 
 .dark .bal-modal .content::before {
@@ -129,7 +129,7 @@ defineExpose({ hide });
   left: 0;
   bottom: 0;
   right: 0;
-  z-index: -1;
+  z-index: 0;
   filter: blur(80px);
   transform: translateZ(-1px);
   animation: fadeInMoveUpScaleUp 0.2s ease-out both;


### PR DESCRIPTION
# Description

Fixes Safari z-index bug affecting the dark mode modals (like the new accept terms on the Connect Wallet modal).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Test out the Connect wallet modal in dark mode on Safari (and other browsers)
- Test out other modals across the site to see if anything else breaks as a result. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
