### PR TITLE
Refactor to async layout load

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,13 +7,6 @@ import ThirdPartyServicesModal from '@/components/web3/ThirdPartyServicesModal.v
 import WalletSelectModal from '@/components/web3/WalletSelectModal.vue';
 import useWeb3Watchers from '@/composables/watchers/useWeb3Watchers';
 import { DEFAULT_TOKEN_DECIMALS } from '@/constants/tokens';
-import {
-  BlankLayout,
-  ContentLayout,
-  DefaultLayout,
-  FocussedLayout,
-  JoinExitLayout,
-} from '@/pages/_layouts';
 import useWeb3 from '@/services/web3/useWeb3';
 
 import GlobalModalContainer from './components/modals/GlobalModalContainer.vue';
@@ -27,6 +20,25 @@ import useExploitWatcher from './composables/watchers/useExploitWatcher';
 import useGlobalQueryWatchers from './composables/watchers/useGlobalQueryWatchers';
 import usePoolCreationWatcher from './composables/watchers/usePoolCreationWatcher';
 import { useThirdPartyServices } from './composables/useThirdPartyServices';
+
+// Dynamic import of layout components:
+// it prevents the initial bundle from including all the layouts (and their unique dependencies)
+// each route will only load the layout that it needs
+const DefaultLayout = defineAsyncComponent(
+  () => import('@/pages/_layouts/DefaultLayout.vue')
+);
+const BlankLayout = defineAsyncComponent(
+  () => import('@/pages/_layouts/BlankLayout.vue')
+);
+const FocussedLayout = defineAsyncComponent(
+  () => import('@/pages/_layouts/FocussedLayout.vue')
+);
+const ContentLayout = defineAsyncComponent(
+  () => import('@/pages/_layouts/ContentLayout.vue')
+);
+const JoinExitLayout = defineAsyncComponent(
+  () => import('@/pages/_layouts/JoinExitLayout.vue')
+);
 
 BigNumber.config({ DECIMAL_PLACES: DEFAULT_TOKEN_DECIMALS });
 

--- a/src/pages/_layouts/index.ts
+++ b/src/pages/_layouts/index.ts
@@ -1,5 +1,0 @@
-export { default as BlankLayout } from './BlankLayout.vue';
-export { default as ContentLayout } from './ContentLayout.vue';
-export { default as DefaultLayout } from './DefaultLayout.vue';
-export { default as FocussedLayout } from './FocussedLayout.vue';
-export { default as JoinExitLayout } from './JoinExitLayout.vue';


### PR DESCRIPTION
# Description

Instead of loading all the layouts from an index, we use dynamic imports to only load the layout that is needed for the current route. 
It prevents the initial bundle from including all the layouts (and their unique dependencies).

The impact in the bundle size is clear (the biggest bundle chunk goes from ` 2634 kB` to `1335 KB`)

Old build: 
<img width="1102" alt="oldBuild" src="https://user-images.githubusercontent.com/1316240/236663456-8720cf8d-3be8-4b5d-b3e6-4b05a1cc6dbd.png">


New build:
<img width="1164" alt="newBuild" src="https://user-images.githubusercontent.com/1316240/236663410-3a77505e-6a6f-42de-9113-57c4bca73fc2.png">



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
