### PR TITLE
Fail CI build step if chunks bigger than 750kB

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,12 +48,18 @@ jobs:
       - name: Install deps
         run: npm install -g npm@7 && npm ci
       - name: Run build
+        id: build
         env:
           # Increase memory to avoid heap error
           # https://github.com/vitejs/vite/issues/2433
           NODE_OPTIONS: "--max-old-space-size=8192"
         run: npm run build
-
+      - name: Fail if big chunks
+        run: |
+          if echo "${{join(steps.build.outputs.*, '\n')}}" | grep -q "Some chunks are larger than 500 kBs after minification"; then
+            echo "Chunks larger than 500 kBs. Please review the PR so that it does not increase bundle chunk size so much."
+            exit 1
+          fi
   Lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=8192"
         run: |
           output=$(npm run build)
-          echo "::set-env name=build-output::$output"
+          echo "::set-output name=build-output::$output"
       - name: Fail if big chunks
         run: |
           if echo "${{join(steps.build.outputs.build-output, '\n')}}" | grep -q "Some chunks are larger than 500 kBs after minification"; then

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,10 +53,12 @@ jobs:
           # Increase memory to avoid heap error
           # https://github.com/vitejs/vite/issues/2433
           NODE_OPTIONS: "--max-old-space-size=8192"
-        run: npm run build
+        run: |
+          output=$(npm run build)
+          echo "::set-env name=build-output::$output"
       - name: Fail if big chunks
         run: |
-          if echo "${{join(steps.build.outputs.*, '\n')}}" | grep -q "Some chunks are larger than 500 kBs after minification"; then
+          if echo "${{join(steps.build.outputs.build-output, '\n')}}" | grep -q "Some chunks are larger than 500 kBs after minification"; then
             echo "Chunks larger than 500 kBs. Please review the PR so that it does not increase bundle chunk size so much."
             exit 1
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -58,7 +58,7 @@ jobs:
           echo "::set-output name=build-output::$output"
       - name: Fail if big chunks
         run: |
-          if echo "${{join(steps.build.outputs.build-output, '\n')}}" | grep -q "Some chunks are larger than 500 kBs after minification"; then
+          if echo "${{steps.build.outputs.build-output}}" | grep -q "Some chunks are larger than 500 kBs after minification"; then
             echo "Chunks larger than 500 kBs. Please review the PR so that it does not increase bundle chunk size so much."
             exit 1
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,20 +48,12 @@ jobs:
       - name: Install deps
         run: npm install -g npm@7 && npm ci
       - name: Run build
-        id: build
         env:
           # Increase memory to avoid heap error
           # https://github.com/vitejs/vite/issues/2433
           NODE_OPTIONS: "--max-old-space-size=8192"
-        run: |
-          output=$(npm run build)
-          echo "::set-output name=build-output::$output"
-      - name: Fail if big chunks
-        run: |
-          if echo "${{steps.build.outputs.build-output}}" | grep -q "Some chunks are larger than 500 kBs after minification"; then
-            echo "Chunks larger than 500 kBs. Please review the PR so that it does not increase bundle chunk size so much."
-            exit 1
-          fi
+        run: npm run build:witChunkSizeCheck
+
   Lint:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "npm run generate:tokenlists && vite",
     "serve": "npm run dev",
     "build": "npm run generate:tokenlists && vite build",
+    "build:witChunkSizeCheck": "node ./scripts/buildWithChunkSizeCheck.mjs",
     "build:analyze": "BUILD_ANALIZE=true npm run build",
     "build:docker": "export NODE_OPTIONS=--max-old-space-size=8192 && npm run build",
     "build:withouttokenlists": "vite build",

--- a/scripts/buildWithChunkSizeCheck.mjs
+++ b/scripts/buildWithChunkSizeCheck.mjs
@@ -1,0 +1,26 @@
+import { spawn } from 'child_process';
+
+async function buildWithChunkSizeCheck() {
+  const buildCommand = spawn('npm run build', {
+    shell: true,
+    stdio: ['inherit', 'inherit'],
+  });
+
+  buildCommand.stderr.on('data', data => {
+    const output = data.toString();
+    failWhenBigChunkDetected(output);
+  });
+}
+
+function failWhenBigChunkDetected(data) {
+  const bigChunksText = '(!) Some chunks are larger than';
+  process.stderr.write(data);
+  if (data.includes(bigChunksText)) {
+    console.error(
+      '📦🚨 Build contains big chunks exceeding the max size limit. Review your changes to fix this problem before deploying this version.'
+    );
+    process.exit(1);
+  }
+}
+
+buildWithChunkSizeCheck();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -139,6 +139,7 @@ export default defineConfig(({ mode }) => {
           rollupPolyfillNode(),
         ],
       },
+      chunkSizeWarningLimit: 700,
       commonjsOptions: {
         // Allows to import tailwind.config.js from useTailwind.ts
         // Check: https://github.com/tailwindlabs/tailwindcss.com/issues/765

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -139,7 +139,7 @@ export default defineConfig(({ mode }) => {
           rollupPolyfillNode(),
         ],
       },
-      chunkSizeWarningLimit: 700,
+      chunkSizeWarningLimit: 750,
       commonjsOptions: {
         // Allows to import tailwind.config.js from useTailwind.ts
         // Check: https://github.com/tailwindlabs/tailwindcss.com/issues/765


### PR DESCRIPTION
# Description

Adds a node script enforcing that our build chunk sizes won't go worst (max chunk size should not be bigger than 750kB).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Our current biggest chunk is 735kB. We set the limit to 700kB in a previous commit to enforce a build failure:

<img width="1401" alt="failed" src="https://user-images.githubusercontent.com/1316240/236878300-1d81f8d2-5264-4c1a-a93a-da5c2690f8db.png">

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
