### PR TITLE
Hotfix - Ignore BalAsset tokens with undefined address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.6",
+  "version": "1.100.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.100.6",
+      "version": "1.100.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.3",
+  "version": "1.100.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.100.3",
+      "version": "1.100.4",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.6",
+  "version": "1.100.7",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.3",
+  "version": "1.100.4",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/_global/BalAsset/BalAsset.vue
+++ b/src/components/_global/BalAsset/BalAsset.vue
@@ -36,7 +36,9 @@ const error = ref(false);
 /**
  * COMPUTED
  */
-const token = computed<TokenInfo | undefined>(() => getToken(address.value));
+const token = computed<TokenInfo | undefined>(() =>
+  address.value ? getToken(address.value) : undefined
+);
 
 const iconSRC = computed(() => {
   if (props.iconURI) return resolve(props.iconURI);


### PR DESCRIPTION
# Description

Sometimes when on the pool withdraw page (e.g. https://app.balancer.fi/#/arbitrum/pool/0x32df62dc3aed2cd6224193052ce665dc181658410002000000000000000003bd/withdraw/#/) there is a `BalAsset` being loaded with an undefined address, which cases `getToken` to throw an error. 

I can't figure out where this BalAsset is coming from - it seems to be the Pool icon but the debugger is bad at showing where in the vue file the `BalAsset` is being loaded, so I haven't been able to fix the root cause (maybe someone else knows how?)

This ensures that if a BalAsset is loaded with an undefined address that it doesn't attempt to fetch token info. 

Fixes https://balancer-labs.sentry.io/issues/4165680712/?project=5725878

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Withdraw tokens from a pool, ensure that no errors are thrown from loading a token with an undefined address. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
