### PR TITLE
Hotfix: Fathom analytics script link

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
     <!-- Fathom Analytics -->
     <script
-      src="https://quality-yellow.balancer.fi/script.js"
+      src="https://cdn.usefathom.com/script.js"
       data-spa="hash"
       data-site="<%= VITE_FATHOM_SITE_ID %>"
       defer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.7",
+  "version": "1.100.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.100.7",
+      "version": "1.100.8",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.7",
+  "version": "1.100.8",
   "engines": {
     "node": "=16",
     "npm": ">=8"


### PR DESCRIPTION
# Description

Received a warning from Fathom that custom domains for scripts are no longer supported and that we should switch to their script URL.

## Type of change
- [x] Dependency changes

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
