### PR TITLE
Hotfix: Fix useSignatures user setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.9",
+  "version": "1.100.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.100.9",
+      "version": "1.100.10",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.9",
+  "version": "1.100.10",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/providers/local/join-pool.provider.ts
+++ b/src/providers/local/join-pool.provider.ts
@@ -384,6 +384,9 @@ export const joinPoolProvider = (
     joinPoolService.setJoinHandler(joinHandlerType.value);
   });
 
+  // relayerApprovalAction can change if the user changes their useSignatures setting.
+  watch(relayerApprovalAction, () => setApprovalActions());
+
   /**
    * LIFECYCLE
    */

--- a/src/providers/user-settings.provider.ts
+++ b/src/providers/user-settings.provider.ts
@@ -20,7 +20,7 @@ export interface UserSettingsState {
  */
 const lsCurrency = lsGet(LS_KEYS.UserSettings.Currency, FiatCurrency.usd);
 const lsSlippage = lsGet(LS_KEYS.App.SwapSlippage, '0.005'); // Defaults to 0.5%
-const lsSupportSignatures = lsGet(LS_KEYS.App.SupportSignatures, true);
+const lsSupportSignatures = lsGet(LS_KEYS.App.SupportSignatures, 'true');
 
 /**
  * STATE
@@ -28,7 +28,7 @@ const lsSupportSignatures = lsGet(LS_KEYS.App.SupportSignatures, true);
 const state: UserSettingsState = reactive({
   currency: lsCurrency,
   slippage: lsSlippage,
-  supportSignatures: lsSupportSignatures,
+  supportSignatures: lsSupportSignatures === 'true',
 });
 
 /**
@@ -53,7 +53,7 @@ function setSlippage(newSlippage: string): void {
 }
 
 function setSupportSignatures(newValue: boolean): void {
-  lsSet(LS_KEYS.App.SupportSignatures, newValue);
+  lsSet(LS_KEYS.App.SupportSignatures, `${newValue}`);
   state.supportSignatures = newValue;
 }
 


### PR DESCRIPTION
# Description

Currently, the useSignature user setting is being set as a string but treated as a boolean, we need to add some parsing to ensure it's set as a boolean in state. Also, in the join flow, because approval actions are set with a function call, we need to trigger a recall of that function if the userSignature setting changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test that toggling the "Use signatures" setting in the join flow changes the preview flow back and forth between signatures and transactions for approval.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
