### PR TITLE
Hotfix: Make cowswap and joinexit swaps fatal if they fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.13",
+  "version": "1.100.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.100.13",
+      "version": "1.100.14",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.14",
+  "version": "1.100.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.100.14",
+      "version": "1.100.15",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.14",
+  "version": "1.100.15",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.13",
+  "version": "1.100.14",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/swap/useCowswap.ts
+++ b/src/composables/swap/useCowswap.ts
@@ -143,11 +143,12 @@ export default function useCowswap({
   }
 
   async function swap(successCallback?: () => void) {
+    let quote;
     try {
       confirming.value = true;
       state.submissionError = null;
 
-      const quote = getQuote();
+      quote = getQuote();
 
       const unsignedOrder: UnsignedOrder = {
         sellToken: tokenInAddressInput.value,
@@ -240,7 +241,13 @@ export default function useCowswap({
       if (!isUserRejected(error)) {
         console.trace(error);
         state.submissionError = t('swapException', ['Cowswap']);
-        captureException(new Error(state.submissionError, { cause: error }));
+        captureException(new Error(state.submissionError, { cause: error }), {
+          level: 'fatal',
+          extra: {
+            sender: account.value,
+            quote,
+          },
+        });
       }
       confirming.value = false;
       throw error;


### PR DESCRIPTION
# Description

- Set error level to `fatal` if a CowSwap or JoinExit swap fails. 
- Send additional information to Sentry to make diagnosing what went wrong easier. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- Hard to test a failure case, but try performing a cowswap swap or a join/exit swap and ensure they are working correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
