### PR TITLE
Send a fatal exception to sentry if locking veBal fails

### DIFF
--- a/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
+++ b/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
@@ -25,6 +25,7 @@ import { TransactionActionInfo } from '@/types/transactions';
 import useVotingGauges from '@/composables/useVotingGauges';
 import { VeBalLockInfo } from '@/services/balancer/contracts/contracts/veBAL';
 import { ApprovalAction } from '@/composables/approvals/types';
+import { captureException } from '@sentry/browser';
 
 /**
  * TYPES
@@ -182,6 +183,17 @@ async function submit(lockType: LockType, actionIndex: number) {
     return tx;
   } catch (error) {
     console.error(error);
+
+    // An exception is already logged in balancerContractsService, but we should
+    // log another here in case any exceptions are thrown before it's sent
+    captureException(error, {
+      level: 'fatal',
+      extra: {
+        lockType,
+        props,
+      },
+    });
+
     return Promise.reject(error);
   }
 }


### PR DESCRIPTION
# Description

We are already sending fatal errors in the main transaction class, however this could fail earlier so send another fatal with additional data.

## Type of change

- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
