### PR TITLE
Disable actions for add liquidity, withdraw, and staking if user is on wrong network

### DIFF
--- a/src/components/contextual/pages/pool/staking/StakePreview.vue
+++ b/src/components/contextual/pages/pool/staking/StakePreview.vue
@@ -12,6 +12,7 @@ import { useTokens } from '@/providers/tokens.provider';
 import useTokenApprovalActions from '@/composables/approvals/useTokenApprovalActions';
 import { bnum, trackLoading } from '@/lib/utils';
 import { AnyPool } from '@/services/pool/types';
+import useWeb3 from '@/services/web3/useWeb3';
 import { TransactionActionInfo } from '@/types/transactions';
 import useTransactions from '@/composables/useTransactions';
 import { fiatValueOf, tokensListExclBpt } from '@/composables/usePoolHelpers';
@@ -44,6 +45,7 @@ const stakeActions = ref<TransactionActionInfo[]>([]);
 const { balanceFor, getToken, refetchBalances } = useTokens();
 const { fNum } = useNumbers();
 const { t } = useI18n();
+const { isMismatchedNetwork } = useWeb3();
 const { addTransaction } = useTransactions();
 const {
   stake,
@@ -224,7 +226,7 @@ onBeforeMount(async () => {
       v-if="!isActionConfirmed"
       :actions="stakeActions"
       :isLoading="isLoadingApprovalsForGauge"
-      :disabled="isStakeAndZero"
+      :disabled="isStakeAndZero || isMismatchedNetwork"
       @success="handleSuccess"
     />
     <BalStack v-if="isActionConfirmed && confirmationReceipt" vertical>

--- a/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActionsV2.vue
+++ b/src/components/forms/pool_actions/InvestForm/components/InvestPreviewModal/components/InvestActionsV2.vue
@@ -18,6 +18,7 @@ import { TransactionActionInfo } from '@/types/transactions';
 import { useJoinPool } from '@/providers/local/join-pool.provider';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { usePoolStaking } from '@/providers/local/pool-staking.provider';
+import useWeb3 from '@/services/web3/useWeb3';
 
 /**
  * TYPES
@@ -45,6 +46,7 @@ const { addTransaction } = useTransactions();
 const { txListener, getTxConfirmedAt } = useEthers();
 const { lockablePoolId } = useVeBal();
 const { isStakablePool } = usePoolStaking();
+const { isMismatchedNetwork } = useWeb3();
 const { poolWeightsLabel } = usePoolHelpers(toRef(props, 'pool'));
 const {
   rektPriceImpact,
@@ -136,7 +138,7 @@ async function submit(): Promise<TransactionResponse> {
     <BalActionSteps
       v-if="!txState.confirmed || !txState.receipt"
       :actions="actions"
-      :disabled="rektPriceImpact"
+      :disabled="rektPriceImpact || isMismatchedNetwork"
     />
     <div v-else>
       <ConfirmationIndicator :txReceipt="txState.receipt" />

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActionsV2.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActionsV2.vue
@@ -43,7 +43,7 @@ const emit = defineEmits<{
  * COMPOSABLES
  */
 const { t } = useI18n();
-const { blockNumber } = useWeb3();
+const { blockNumber, isMismatchedNetwork } = useWeb3();
 const { addTransaction } = useTransactions();
 const { txListener, getTxConfirmedAt } = useEthers();
 const { poolWeightsLabel } = usePoolHelpers(toRef(props, 'pool'));
@@ -166,6 +166,7 @@ watch(blockNumber, () => {
     <BalActionSteps
       v-if="!txState.confirmed || !txState.receipt"
       :actions="actions"
+      :disabled="isMismatchedNetwork"
     />
     <div v-else>
       <ConfirmationIndicator :txReceipt="txState.receipt" />

--- a/src/components/layouts/FocussedLayout.vue
+++ b/src/components/layouts/FocussedLayout.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import useAlerts from '@/composables/useAlerts';
 import { useReturnRoute } from '@/composables/useReturnRoute';
+import AppNavAlert from '@/components/navs/AppNav/AppNavAlert.vue';
 
 const { getReturnRoute } = useReturnRoute();
+const { currentAlert } = useAlerts();
 </script>
 <template>
+  <AppNavAlert v-if="currentAlert" :alert="currentAlert" />
   <div class="pb-16">
     <div class="mb-12 layout-header">
       <div />


### PR DESCRIPTION
# Description

Disable the Add Liquidity, Withdraw and Staking action steps if the user switches network before clicking it. Currently the button to show the preview modal becomes disabled, but the action steps in the preview modal are not.

I looked into fixing this on the swap page and it seems the swap page auto refreshes to the correct network so it's not needed there. 

Fixes: https://balancer-labs.sentry.io/issues/4173315674/events/85eabaedf7e345999ef3796c3676ffac/?project=5725878&referrer=previous-event - this is caused by the user submitting a transaction to the wrong network, you can see the URL is polygon but at the end of the tenderly simulation URL it is connected to 42161 (arbitrum). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Attempt to add liquidity to a pool, get all the way to the last action steps 
- Switch your wallet to another network
- Ensure the the button is disabled. 
- Do the above steps for Withdrawing from a pool and Staking

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
