### PR TITLE
Hotfix: Auto bump master on hotfix merge

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,5 +1,7 @@
+# Bumps the package version with a patch if the version wasn't already updated
+# - This is skipped if there is already a version bump in the merged PR
 # Tags each push to master with version in package.json if not already a tag.
-name: Tag
+name: BumpTag
 
 on:
   push:
@@ -11,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: 'phips28/gh-action-bump-version@v9.1.3'
+      with:
+        commit-message: '{{version}}'
     - uses: Klemensas/action-autotag@stable
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.18",
+  "version": "1.100.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.100.18",
+      "version": "1.100.19",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.100.18",
+  "version": "1.100.19",
   "engines": {
     "node": "=16",
     "npm": ">=8"


### PR DESCRIPTION
# Description

We have many hotfixes coming in each day to add new pools / gauges to the allowlist. Each of these currently requires a patch version bump, but this means as soon as one is merged all the remainder have git conflicts. 

Instead of requiring the version bump in the PR, auto-bump the version on merge to master. This way we can easily merge all these hotfixes without constantly having to rebase and fix them. 

This plugin will not bump weekly releases because it ignores bumping if any of the merged commits already include a version bump (it does a regex search for `\d.\d.\d` as the commit message in any of the commits)

I've tested this on a fork of this repo and you can see how it works doing a weekly release and a hotfix patch here: https://github.com/timjrobinson/frontend-v2/commits/master (Look at just the most recent 6 commits, the ones prior were testing)

The only downside to this is develop will not get version bumps when we do a develop merge of hotfixes. I'd propose we merge  master into develop instead of merging the hotfix branch into develop instead to fix this, or just don't worry about the develop version. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Can fork this repo to test in your own personal version and see how it works. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
