### PR TITLE
Don't allow users to withdraw 0 BPT

### DIFF
--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -87,6 +87,7 @@ export const exitPoolProvider = (
   const priceImpact = ref<number>(0);
   const highPriceImpactAccepted = ref<boolean>(false);
   const bptIn = ref<string>('0');
+  const bptInValid = ref<boolean>(true);
   const txError = ref<string>('');
   const singleAmountOut = reactive<AmountOut>({
     address: '',
@@ -265,11 +266,6 @@ export const exitPoolProvider = (
     );
   });
 
-  // Is the bptIn a valid value
-  const bptInValid = computed<boolean>(() => {
-    return bnum(bptIn.value).gt(0);
-  });
-
   // Amounts out to pass into exit functions
   const amountsOut = computed((): AmountOut[] => {
     if (isSingleAssetExit.value) return [singleAmountOut];
@@ -339,7 +335,7 @@ export const exitPoolProvider = (
   const validAmounts = computed((): boolean => {
     return isSingleAssetExit.value
       ? amountsOut.value.every(ao => ao.valid)
-      : bptInValid.value;
+      : bptInValid.value && bnum(bptIn.value).gt(0);
   });
 
   // Map of amount out address to value as fiat amount.

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -87,7 +87,6 @@ export const exitPoolProvider = (
   const priceImpact = ref<number>(0);
   const highPriceImpactAccepted = ref<boolean>(false);
   const bptIn = ref<string>('0');
-  const bptInValid = ref<boolean>(true);
   const txError = ref<string>('');
   const singleAmountOut = reactive<AmountOut>({
     address: '',
@@ -264,6 +263,11 @@ export const exitPoolProvider = (
     return tokens.filter(
       token => !isSameAddress(token.address, pool.value.address)
     );
+  });
+
+  // Is the bptIn a valid value
+  const bptInValid = computed<boolean>(() => {
+    return bnum(bptIn.value).gt(0);
   });
 
   // Amounts out to pass into exit functions


### PR DESCRIPTION


# Description

- Set bptInValid to only be true if bptIn amount is > 0 so that users can't start a withdraw for 0 tokens. This value was previously always true. 

Fixes: https://balancer-labs.sentry.io/issues/4000665600/?project=5725878&query=is%3Aunresolved+level%3Afatal&referrer=issue-stream&statsPeriod=14d&stream_index=1 (can see in additional info that bptIn is 0.0. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Try withdrawing nothing from a pool. The preview button should now be disabled when you set the slider to 0 BPT. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
