### PR TITLE
Ignore more user rejected transaction errors

### DIFF
--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -3,11 +3,36 @@ import { useI18n } from 'vue-i18n';
 import { TransactionError } from '@/types/transactions';
 
 export function isUserRejected(error): boolean {
-  return (
-    (error?.code && error.code === 4001) ||
-    (error?.message && error.message.includes('user rejected transaction')) ||
-    (error?.cause && error.cause.message.includes('user rejected transaction'))
-  );
+  if (!error) return false;
+
+  const userRejectionMessages = [
+    'user rejected transaction',
+    'Request rejected',
+    'User rejected methods.',
+    'User rejected the transaction',
+    'Rejected by user',
+    'User canceled',
+    'Cancelled by User',
+    'Transaction declined',
+    'Transaction was rejected',
+  ];
+
+  if (error.message && userRejectionMessages.includes(error.message)) {
+    return true;
+  }
+
+  if (
+    error.cause?.message &&
+    userRejectionMessages.includes(error.cause.message)
+  ) {
+    return true;
+  }
+
+  if (error?.code && error.code === 4001) {
+    return true;
+  }
+
+  return false;
 }
 
 export default function useTranasactionErrors() {

--- a/src/composables/userTransactionErrors.spec.ts
+++ b/src/composables/userTransactionErrors.spec.ts
@@ -1,0 +1,36 @@
+import { isUserRejected } from './useTransactionErrors';
+
+describe('userTransactionErrors', () => {
+  describe('isUserRejected', () => {
+    it('Should return false for a non-user error', () => {
+      const error = new Error('Unsupported Exit Type For Pool');
+      expect(isUserRejected(error)).toBe(false);
+    });
+
+    it('Should return true for common user rejection messages', () => {
+      expect(isUserRejected(new Error('user rejected transaction'))).toBe(true);
+      expect(isUserRejected(new Error('Request rejected'))).toBe(true);
+      expect(isUserRejected(new Error('User rejected methods.'))).toBe(true);
+      expect(isUserRejected(new Error('User rejected the transaction'))).toBe(
+        true
+      );
+      expect(isUserRejected(new Error('Rejected by user'))).toBe(true);
+      expect(isUserRejected(new Error('User canceled'))).toBe(true);
+      expect(isUserRejected(new Error('Cancelled by User'))).toBe(true);
+      expect(isUserRejected(new Error('Transaction declined'))).toBe(true);
+      expect(isUserRejected(new Error('Transaction was rejected'))).toBe(true);
+    });
+
+    it('Should return true if the error message is in the cause', () => {
+      const rejectionError = new Error('Something went wrong');
+      rejectionError.cause = new Error('User rejected the transaction');
+      expect(isUserRejected(rejectionError)).toBe(true);
+    });
+
+    it('Should return true if the error code is 4001', () => {
+      const rejectionError = new Error('Something went wrong');
+      rejectionError.code = 4001;
+      expect(isUserRejected(rejectionError)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# Description

I went through the list of all user initiated transaction cancellations in https://balancer-labs.sentry.io/issues/2864750753/events/?cursor=0%3A0%3A1&project=5725878&referrer=issue-stream&statsPeriod=14d&stream_index=2 and added them to the ignore list so we can focus on the actual app errors. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Look at list and ensure the things make sense and won't conflict with any other non-user initiated cancellations. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
