### PR TITLE
Hotfix: BPT balance fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.101.4",
+  "version": "1.101.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.101.4",
+      "version": "1.101.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.101.4",
+  "version": "1.101.5",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -82,6 +82,7 @@ export default function usePoolQuery(
     await injectTokens([
       ...tokensListExclBpt(pool),
       ...tokenTreeLeafs(pool.tokens),
+      pool.address, // We need to inject pool addresses so we can fetch a user's balance for that pool.
     ]);
 
     return pool;


### PR DESCRIPTION
# Description

We need to inject pool addresses into the token registry so we include it in balance fetching. This is how we know if a user has an unstaked balance in a pool.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test a user balance is displayed on the pool page when you refresh the page. If you try this on production it will always be zero.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
