### PR TITLE
Hotfix: Add hosted graph app alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.101.8",
+  "version": "1.101.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.101.8",
+      "version": "1.101.9",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.101.8",
+  "version": "1.101.9",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,11 @@ import useExploitWatcher from './composables/watchers/useExploitWatcher';
 import useGlobalQueryWatchers from './composables/watchers/useGlobalQueryWatchers';
 import usePoolCreationWatcher from './composables/watchers/usePoolCreationWatcher';
 import { useThirdPartyServices } from './composables/useThirdPartyServices';
+import useAlerts, {
+  Alert,
+  AlertPriority,
+  AlertType,
+} from './composables/useAlerts';
 
 // Dynamic import of layout components:
 // it prevents the initial bundle from including all the layouts (and their unique dependencies)
@@ -67,8 +72,21 @@ const { isWalletSelectVisible, toggleWalletSelectModal, isBlocked } = useWeb3();
 const route = useRoute();
 const { newRouteHandler: updateBgColorFor } = useBackgroundColor();
 const { sidebarOpen } = useSidebar();
+const { addAlert } = useAlerts();
 const { handleThirdPartyModalToggle, isThirdPartyServicesModalVisible } =
   useThirdPartyServices();
+
+// ADD FEATURE ALERT HERE
+const featureAlert: Alert = {
+  id: 'feature-alert',
+  priority: AlertPriority.LOW,
+  label:
+    'The Graph’s hosted service (our data provider) will undergo scheduled database maintenance on May 22, 2023, 05:00 UTC for a window of up to five hours. During this time, some features of the app might be unavailable and data might be stale.',
+  type: AlertType.FEATURE,
+  rememberClose: false,
+  actionOnClick: false,
+};
+addAlert(featureAlert);
 
 /**
  * WATCHERS


### PR DESCRIPTION
# Description

Adds app-wide alert for hosted graph downtime.

## Type of change

- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
