### PR TITLE
chore: Ensure only proportional recovery exits are available for ComposableStableV1

### DIFF
--- a/src/components/contextual/pages/pool/withdraw/WithdrawPage.vue
+++ b/src/components/contextual/pages/pool/withdraw/WithdrawPage.vue
@@ -8,6 +8,7 @@ import useWithdrawPageTabs from '@/composables/pools/useWithdrawPageTabs';
 import WithdrawPageTabs from './WithdrawPageTabs.vue';
 import { provideExitPool } from '@/providers/local/exit-pool.provider';
 import { Pool } from '@/services/pool/types';
+import { isComposableStableV1, isDeep } from '@/composables/usePoolHelpers';
 
 type Props = {
   pool: Pool;
@@ -32,6 +33,18 @@ const { network } = configService;
 const { resetTabs } = useWithdrawPageTabs();
 
 onMounted(() => resetTabs());
+
+/**
+ * COMPUTED
+ */
+const singleAssetExitsAvailable = computed((): boolean => {
+  const notPaused = !(pool.value.isInRecoveryMode && pool.value.isPaused);
+  const notShallowComposableStableV1 = !(
+    !isDeep(pool.value) && isComposableStableV1(pool.value)
+  );
+
+  return notPaused && notShallowComposableStableV1;
+});
 </script>
 
 <template>
@@ -45,7 +58,7 @@ onMounted(() => resetTabs());
           <h4>{{ $t('withdrawFromPool') }}</h4>
           <SwapSettingsPopover :context="SwapSettingsContext.invest" />
         </div>
-        <WithdrawPageTabs v-if="!(pool.isInRecoveryMode && pool.isPaused)" />
+        <WithdrawPageTabs v-if="singleAssetExitsAvailable" />
       </div>
     </template>
     <WithdrawFormV2 :pool="pool" />

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -219,7 +219,9 @@ export const exitPoolProvider = (
   const shouldUseRecoveryExit = computed(
     (): boolean =>
       (pool.value.isInRecoveryMode && pool.value.isPaused) ||
-      (!isDeepPool.value && isComposableStableV1(pool.value))
+      (!isDeepPool.value &&
+        isComposableStableV1(pool.value) &&
+        !isSingleAssetExit.value)
   );
 
   const exitHandlerType = computed((): ExitHandler => {


### PR DESCRIPTION
# Description

We were showing the option to single asset withdraw from shallow ComposableStableV1 pools. This works if you withdraw everything, but not if you try to withdraw a specific amount, because the pool type doesn't support the required exit type. This PR effectively enforces proportional recovery withdrawals for ComposableStableV1 pools.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test withdrawals from this pool polygon pool `0x216690738aac4aa0c4770253ca26a28f0115c595000000000000000000000b2c` you may need to unblock add-liquidity locally in order to test withdrawals.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
