### PR TITLE
Fix pool risks link in PoolActionCard

### DIFF
--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -28,9 +28,12 @@ type Props = {
 };
 
 /**
- * PROPS
+ * PROPS & EMITS
  */
 const props = defineProps<Props>();
+const emit = defineEmits<{
+  (e: 'risksClicked'): void;
+}>();
 
 /**
  * COMPOSABLES
@@ -103,7 +106,11 @@ function navigateToPoolMigration(pool: Pool) {
       </BalBtn>
     </div>
     <template #footer>
-      <PoolActionsCard :pool="pool" :missingPrices="missingPrices" />
+      <PoolActionsCard
+        :pool="pool"
+        :missingPrices="missingPrices"
+        @risks-clicked="emit('risksClicked')"
+      />
     </template>
   </BalCard>
 </template>

--- a/src/components/contextual/pages/pool/PoolActionsCard.vue
+++ b/src/components/contextual/pages/pool/PoolActionsCard.vue
@@ -23,9 +23,12 @@ type Props = {
 };
 
 /**
- * PROPS
+ * PROPS & EMITS
  */
 const props = defineProps<Props>();
+const emit = defineEmits<{
+  (e: 'risksClicked'): void;
+}>();
 
 /**
  * COMPOSABLES
@@ -37,7 +40,6 @@ const { isWalletReady, startConnectWithInjectedProvider } = useWeb3();
 const { networkSlug } = useNetwork();
 const { shouldDisableJoins } = useDisabledJoinPool(props.pool);
 const { balanceFor } = useTokens();
-const route = useRoute();
 
 /**
  * COMPUTED
@@ -92,12 +94,9 @@ const joinDisabled = computed(
       <div class="pt-4 text-xs text-secondary">
         {{ $t('poolTransfer.myPoolBalancesCard.risksDisclaimer') }}
 
-        <router-link :to="{ path: route.fullPath, hash: '#risks-section' }"
-          ><span class="font-medium link">{{
-            $t('poolTransfer.myPoolBalancesCard.poolsRisks')
-          }}</span></router-link
-        >
-        .
+        <a class="font-medium link" @click="emit('risksClicked')">
+          {{ $t('poolTransfer.myPoolBalancesCard.poolsRisks') }} </a
+        >.
       </div>
     </div>
   </div>

--- a/src/pages/pool/_id.vue
+++ b/src/pages/pool/_id.vue
@@ -43,6 +43,7 @@ import PoolRisks from '@/components/contextual/pages/pool/risks/PoolRisks.vue';
  * STATE
  */
 const route = useRoute();
+const router = useRouter();
 const poolId = (route.params.id as string).toLowerCase();
 const isRestakePreviewVisible = ref(false);
 
@@ -133,6 +134,14 @@ function addIntersectionObserver(): void {
   observer = new IntersectionObserver(callback, options);
   observer.observe(intersectionSentinel.value);
 }
+
+async function goToRisksSection() {
+  isSentinelIntersected.value = true;
+  // Wait for risks section to be rendered
+  await nextTick();
+  router.push({ path: route.fullPath, hash: '#risks-section' });
+}
+
 onMounted(() => {
   addIntersectionObserver();
 });
@@ -293,6 +302,7 @@ watch(
             :pool="pool"
             :missingPrices="missingPrices"
             class="mb-4"
+            @risks-clicked="goToRisksSection()"
           />
 
           <BalLoadingBlock v-if="loadingPool" class="h-40 pool-actions-card" />


### PR DESCRIPTION
# Description

In `_id.vue` we have a `isSentinelIntersected` that prevents some components to be rendered, being `PoolRisks` one of them.

I noticed this problem after fixing the original router link  so this is a second definitive fix:

We now emit an event that will be received in _id.vue to manually trigger `isSentinelIntersected = true` so that the PoolRisks section is rendered before trying to navigate to it. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Uploading pool-risks-link.mp4…

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
