### PR TITLE
Hotfix: Fix claimable rewards crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.102.6",
+  "version": "1.102.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.102.6",
+      "version": "1.102.7",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.102.6",
+  "version": "1.102.7",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/services/balancer/gauges/gauges.decorator.ts
+++ b/src/services/balancer/gauges/gauges.decorator.ts
@@ -159,6 +159,9 @@ export class GaugesDecorator {
     if (!claimableRewards) return {};
 
     Object.keys(claimableRewards).forEach(rewardToken => {
+      if (!claimableRewards[rewardToken]) {
+        claimableRewards[rewardToken] = '0';
+      }
       claimableRewards[rewardToken] = claimableRewards[rewardToken].toString();
     });
 


### PR DESCRIPTION
# Description

Some gauges are returning `null` for claimable rewards which makes the `toString` function crash and cause the rewards page to not load. This fixes that issue by setting the value to `0` if it's null/undefined etc. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Ensure claim rewards page on Polygon / Arbitrum / Ethereum are loading correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
