### PR TITLE
Hotfix - Dont allow joining pools with native asset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.102.15",
+  "version": "1.102.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.102.15",
+      "version": "1.102.16",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.102.15",
+  "version": "1.102.16",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/forms/pool_actions/AddLiquidityForm/AddLiquidityForm.vue
+++ b/src/components/forms/pool_actions/AddLiquidityForm/AddLiquidityForm.vue
@@ -126,7 +126,7 @@ function tokenOptions(address: string): string[] {
     [wrappedNativeAsset.value.address, nativeAsset.address],
     address
   )
-    ? [wrappedNativeAsset.value.address, nativeAsset.address]
+    ? [wrappedNativeAsset.value.address]
     : [];
 }
 


### PR DESCRIPTION
# Description

Joining a pool with a native asset is currently broken. It always gives the error "Unable to construct join". This PR temporarily disables joining with a native asset until this is fixed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Try joining a pool that contains WETH/WMATIC
- You shouldn't be able to select ETH or MATIC to join with. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
