### PR TITLE
Hotfix: New child-chain non BAL rewards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.102.15",
+  "version": "1.102.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.102.15",
+      "version": "1.102.16",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.102.15",
+  "version": "1.102.16",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
+++ b/src/components/btns/ClaimRewardsBtn/ClaimRewardsBtn.vue
@@ -12,7 +12,6 @@ import { Gauge } from '@/services/balancer/gauges/types';
 import TxActionBtn from '../TxActionBtn/TxActionBtn.vue';
 import { configService } from '@/services/config/config.service';
 import useWeb3 from '@/services/web3/useWeb3';
-import { networkHasNativeGauges } from '@/composables/useNetwork';
 
 /**
  * TYPES
@@ -46,7 +45,7 @@ const liquidityGaugeContract = new LiquidityGauge(gaugeAddress);
  * METHODS
  */
 function claimTx() {
-  if (!networkHasNativeGauges.value) {
+  if (props.gauge.streamer) {
     const liquidityGaugeRewardsHelperContract = new LiquidityGaugeRewardsHelper(
       configService.network.addresses.gaugeRewardsHelper || ''
     );

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -57,9 +57,7 @@ export const isEIP1559SupportedNetwork = computed(
 export const isPoolBoostsEnabled = computed<boolean>(
   () => configService.network.pools.BoostsEnabled
 );
-export const networkHasNativeGauges = computed<boolean>(() => {
-  return networkConfig.addresses.gaugeController !== '';
-});
+
 /**
  * METHODS
  */

--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -12,7 +12,6 @@ import ProtocolRewardsTable, {
   ProtocolRewardRow,
 } from '@/components/tables/ProtocolRewardsTable.vue';
 import { GaugePool, useClaimsData } from '@/composables/useClaimsData';
-import { networkHasNativeGauges } from '@/composables/useNetwork';
 import useNumbers from '@/composables/useNumbers';
 import { isStableLike } from '@/composables/usePoolHelpers';
 import { useTokenHelpers } from '@/composables/useTokenHelpers';
@@ -293,7 +292,7 @@ onBeforeMount(async () => {
             />
           </div>
         </template>
-        <div v-if="networkHasNativeGauges">
+        <div>
           <h3 class="inline-block px-4 xl:px-0 mt-8 mr-1.5 text-xl">
             {{ $t('otherTokenIncentives') }}
           </h3>

--- a/src/services/balancer/gauges/entities/gauges/query.ts
+++ b/src/services/balancer/gauges/entities/gauges/query.ts
@@ -14,6 +14,7 @@ const defaultAttrs = {
     id: true,
   },
   isPreferentialGauge: true,
+  streamer: true,
 };
 
 export const gaugeQueryBuilder = (

--- a/src/services/balancer/gauges/types.ts
+++ b/src/services/balancer/gauges/types.ts
@@ -17,6 +17,7 @@ export interface SubgraphGauge {
     id: string;
   };
   isPreferentialGauge: boolean;
+  streamer: string;
 }
 
 export interface OnchainGaugeData {


### PR DESCRIPTION
# Description

Non BAL rewards on child-chains were not showing because there was still an assumption that we needed to use the rewardsHelper contract to fetch the amounts. This PR changes the conditional to if the gauge has a `streamer` address set. If so then we assume that we need to interact it with via the rewardHelper contract.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] You should see USDC rewards on the claims page if you stake this pool `0x4a77ef015ddcd972fd9ba2c7d5d658689d090f1a000000000000000000000b38` on polygon.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
