### PR TITLE
refactor: extract and test useStakePreview

### DIFF
--- a/src/__mocks__/weighted-pool.ts
+++ b/src/__mocks__/weighted-pool.ts
@@ -15,6 +15,9 @@ type DeepPartial<T> = {
 export const defaultWeightedPoolAddress =
   '0x9ee0af1ee0a0782daf5f1af47fd49b2a766bd8d4';
 
+// Used in tokens-5.json
+export const defaultWeightedPoolSymbol = 'test-pool-symbol';
+
 const defaults: DeepPartial<Pool> = {
   id: defaultWeightedPoolId,
   poolType: PoolType.Weighted,

--- a/src/components/contextual/pages/pool/staking/StakePreviewModal.vue
+++ b/src/components/contextual/pages/pool/staking/StakePreviewModal.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue';
-
 import { Pool } from '@/services/pool/types';
-import StakePreview, { StakeAction } from './StakePreview.vue';
+import StakePreview from './StakePreview.vue';
 import { usePoolStaking } from '@/providers/local/pool-staking.provider';
+import { StakeAction } from './composables/useStakePreview';
 
 /**
  * TYPES

--- a/src/components/contextual/pages/pool/staking/StakeSummary.vue
+++ b/src/components/contextual/pages/pool/staking/StakeSummary.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
-import { StakeAction } from './StakePreview.vue';
+import { StakeAction } from './composables/useStakePreview';
 
 /**
  * PROPS

--- a/src/components/contextual/pages/pool/staking/StakingIncentivesCard.vue
+++ b/src/components/contextual/pages/pool/staking/StakingIncentivesCard.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { getAddress } from '@ethersproject/address';
-import { computed, ref } from 'vue';
 
 import BalLoadingBlock from '@/components/_global/BalLoadingBlock/BalLoadingBlock.vue';
 import AnimatePresence from '@/components/animate/AnimatePresence.vue';
@@ -10,11 +9,11 @@ import { bnum } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
 
 import StakePreviewModal from './StakePreviewModal.vue';
-import { StakeAction } from '@/components/contextual/pages/pool/staking/StakePreview.vue';
 import { usePoolStaking } from '@/providers/local/pool-staking.provider';
 
 import { deprecatedDetails } from '@/composables/usePoolHelpers';
 import { usePoolWarning } from '@/composables/usePoolWarning';
+import { StakeAction } from './composables/useStakePreview';
 
 type Props = {
   pool: Pool;

--- a/src/components/contextual/pages/pool/staking/composables/useStakePreview.spec.ts
+++ b/src/components/contextual/pages/pool/staking/composables/useStakePreview.spec.ts
@@ -83,31 +83,6 @@ test('Successfully creates and runs stake action', async () => {
   expect(params.details?.pool).toEqual(pool);
 });
 
-test('Changes staking actions when action prop changes', async () => {
-  const { props, loadStakeAction } = buildProps();
-  const { stakeActions } = await mountUseStakePreview(props);
-
-  await loadStakeAction('stake');
-
-  expect(stakeActions.value).toHaveLength(2);
-
-  expect(stakeActions.value[0].label).toEqual(
-    `Approve ${defaultWeightedPoolSymbol} for staking`
-  );
-  expect(stakeActions.value[1].label).toEqual('Stake');
-
-  await loadStakeAction('unstake');
-
-  expect(stakeActions.value).toHaveLength(1);
-  expect(stakeActions.value[0].label).toEqual('Unstake');
-
-  await loadStakeAction('restake');
-
-  expect(stakeActions.value).toHaveLength(2);
-  expect(stakeActions.value[0].label).toEqual('Unstake');
-  expect(stakeActions.value[1].label).toEqual('Stake');
-});
-
 test('Successfully creates and runs unstake action', async () => {
   const { props, loadStakeAction } = buildProps();
 
@@ -135,6 +110,31 @@ test('Successfully creates and runs unstake action', async () => {
   const params = firstCallParams(addTransactionMock);
   expect(params.action).toBe('unstake');
   expect(params.details?.pool).toEqual(pool);
+});
+
+test('Changes staking actions when action prop changes', async () => {
+  const { props, loadStakeAction } = buildProps();
+  const { stakeActions } = await mountUseStakePreview(props);
+
+  await loadStakeAction('stake');
+
+  expect(stakeActions.value).toHaveLength(2);
+
+  expect(stakeActions.value[0].label).toEqual(
+    `Approve ${defaultWeightedPoolSymbol} for staking`
+  );
+  expect(stakeActions.value[1].label).toEqual('Stake');
+
+  await loadStakeAction('unstake');
+
+  expect(stakeActions.value).toHaveLength(1);
+  expect(stakeActions.value[0].label).toEqual('Unstake');
+
+  await loadStakeAction('restake');
+
+  expect(stakeActions.value).toHaveLength(2);
+  expect(stakeActions.value[0].label).toEqual('Unstake');
+  expect(stakeActions.value[1].label).toEqual('Stake');
 });
 
 test('Handles staking action success', async () => {

--- a/src/components/contextual/pages/pool/staking/composables/useStakePreview.spec.ts
+++ b/src/components/contextual/pages/pool/staking/composables/useStakePreview.spec.ts
@@ -1,4 +1,7 @@
-import { aWeightedPool } from '@/__mocks__/weighted-pool';
+import {
+  aWeightedPool,
+  defaultWeightedPoolSymbol,
+} from '@/__mocks__/weighted-pool';
 import { initDependenciesWithDefaultMocks } from '@/dependencies/default-mocks';
 import { sleep } from '@/lib/utils';
 import { providePoolStaking } from '@/providers/local/pool-staking.provider';
@@ -9,50 +12,154 @@ import {
   StakePreviewProps,
   useStakePreview,
 } from './useStakePreview';
+import { walletProviderMock } from '@/services/contracts/vault.service.mocks';
+import { walletService as walletServiceInstance } from '@/services/web3/wallet.service';
+import { defaultContractTransactionResponse } from '@/dependencies/contract.concern.mocks';
+import { addTransactionMock } from '@/composables/__mocks__/useTransactions';
+import { firstCallParams } from '@tests/vitest/assertions';
 
 initDependenciesWithDefaultMocks();
+walletServiceInstance.setUserProvider(computed(() => walletProviderMock));
 
 const emit = vi.fn();
 
-const props: StakePreviewProps = reactive({
-  pool: aWeightedPool(),
-  action: 'stake',
-});
-async function mountUseStakePreview() {
+const pool = aWeightedPool();
+
+function buildProps() {
+  const props: StakePreviewProps = reactive({
+    pool,
+    action: 'stake',
+  });
+  async function changeStakeActionProp(action: StakeAction) {
+    props.action = action;
+    // Wait for watcher to change actions and for stake staking provider to be finished
+    await sleep(10);
+  }
+  return { props, loadStakeAction: changeStakeActionProp };
+}
+
+async function mountUseStakePreview(props: StakePreviewProps) {
   const { result } = await mountComposable(() => useStakePreview(props, emit), {
     intermediateProvider: () => {
-      providePoolStaking();
+      providePoolStaking(pool.id);
     },
     extraProvidersCb: () => provideUserData(),
   });
   return result;
 }
 
-test('Changes action label when props action changes', async () => {
-  const { stakeActions } = await mountUseStakePreview();
+test('Successfully creates and runs stake action', async () => {
+  const { props, loadStakeAction } = buildProps();
 
-  expect(stakeActions.value).toHaveLength(1);
-  expect(stakeActions.value[0].label).toEqual('Stake');
+  const { stakeActions } = await mountUseStakePreview(props);
 
-  props.action = 'unstake';
-  // Wait for watcher to change actions
-  await sleep(10);
+  await loadStakeAction('stake');
+
+  const approvalAction = stakeActions.value[0];
+  expect(approvalAction).toMatchObject({
+    confirmingLabel: 'Confirming...',
+    label: `Approve ${defaultWeightedPoolSymbol} for staking`,
+    loadingLabel: 'Confirm approval in wallet',
+    stepTooltip: `You must approve ${defaultWeightedPoolSymbol} to stake this token on Balancer. Approvals are required once per token, per wallet.`,
+  });
+
+  const stakeAction = stakeActions.value[1];
+  expect(stakeAction).toMatchObject({
+    confirmingLabel: 'Confirming...',
+    label: 'Stake',
+    loadingLabel: 'Staking',
+    stepTooltip:
+      'Confirm staking of LP tokens to earn liquidity mining incentives on this pool',
+  });
+
+  // Stake action implementation is deeply tested in pool staking provider tests
+  const stakeTransactionResult = await stakeAction.action();
+  expect(stakeTransactionResult).toEqual(defaultContractTransactionResponse);
+
+  //Saves transaction
+  expect(addTransactionMock).toHaveBeenCalledOnce();
+  const params = firstCallParams(addTransactionMock);
+  expect(params.action).toBe('stake');
+  expect(params.details?.pool).toEqual(pool);
+});
+
+test('Changes staking actions when action prop changes', async () => {
+  const { props, loadStakeAction } = buildProps();
+  const { stakeActions } = await mountUseStakePreview(props);
+
+  await loadStakeAction('stake');
+
+  expect(stakeActions.value).toHaveLength(2);
+
+  expect(stakeActions.value[0].label).toEqual(
+    `Approve ${defaultWeightedPoolSymbol} for staking`
+  );
+  expect(stakeActions.value[1].label).toEqual('Stake');
+
+  await loadStakeAction('unstake');
 
   expect(stakeActions.value).toHaveLength(1);
   expect(stakeActions.value[0].label).toEqual('Unstake');
 
-  props.action = 'restake';
-  // Wait for watcher to change actions
-  await sleep(10);
+  await loadStakeAction('restake');
 
   expect(stakeActions.value).toHaveLength(2);
   expect(stakeActions.value[0].label).toEqual('Unstake');
   expect(stakeActions.value[1].label).toEqual('Stake');
 });
 
-test.only('Changes action label when props action changes', async () => {
-  props.action = 'stake';
-  const { stakeActions } = await mountUseStakePreview();
-  props.action = 'restake';
-  await sleep(10);
+test('Successfully creates and runs unstake action', async () => {
+  const { props, loadStakeAction } = buildProps();
+
+  const { stakeActions } = await mountUseStakePreview(props);
+
+  await loadStakeAction('unstake');
+
+  expect(stakeActions.value).toHaveLength(1);
+
+  const unstakeAction = stakeActions.value[0];
+  expect(unstakeAction).toMatchObject({
+    confirmingLabel: 'Confirming...',
+    label: 'Unstake',
+    loadingLabel: 'Unstaking',
+    stepTooltip:
+      "Confirm unstaking of LP tokens. You'll lose eligibility to earn liquidity mining incentives for this pool.",
+  });
+
+  // Unstake action implementation is deeply tested in pool staking provider tests
+  const stakeTransactionResult = await unstakeAction.action();
+  expect(stakeTransactionResult).toEqual(defaultContractTransactionResponse);
+
+  //Saves transaction
+  expect(addTransactionMock).toHaveBeenCalledOnce();
+  const params = firstCallParams(addTransactionMock);
+  expect(params.action).toBe('unstake');
+  expect(params.details?.pool).toEqual(pool);
+});
+
+test('Handles staking action success', async () => {
+  const { props } = buildProps();
+  const { handleSuccess, isActionConfirmed } = await mountUseStakePreview(
+    props
+  );
+
+  expect(isActionConfirmed.value).toBeFalse();
+
+  await handleSuccess({ receipt: vi.fn });
+
+  expect(isActionConfirmed.value).toBeTrue();
+  expect(emit).toHaveBeenCalledOnceWith('success');
+});
+
+test('Handles staking close', async () => {
+  const { props } = buildProps();
+
+  const { handleClose, isActionConfirmed } = await mountUseStakePreview(props);
+
+  expect(isActionConfirmed.value).toBeFalse();
+
+  handleClose();
+
+  expect(isActionConfirmed.value).toBeFalse();
+  expect(emit).toHaveBeenCalledOnceWith('close');
 });

--- a/src/components/contextual/pages/pool/staking/composables/useStakePreview.spec.ts
+++ b/src/components/contextual/pages/pool/staking/composables/useStakePreview.spec.ts
@@ -1,0 +1,58 @@
+import { aWeightedPool } from '@/__mocks__/weighted-pool';
+import { initDependenciesWithDefaultMocks } from '@/dependencies/default-mocks';
+import { sleep } from '@/lib/utils';
+import { providePoolStaking } from '@/providers/local/pool-staking.provider';
+import { provideUserData } from '@/providers/user-data.provider';
+import { mountComposableWithFakeTokensProvider as mountComposable } from '@tests/mount-helpers';
+import {
+  StakeAction,
+  StakePreviewProps,
+  useStakePreview,
+} from './useStakePreview';
+
+initDependenciesWithDefaultMocks();
+
+const emit = vi.fn();
+
+const props: StakePreviewProps = reactive({
+  pool: aWeightedPool(),
+  action: 'stake',
+});
+async function mountUseStakePreview() {
+  const { result } = await mountComposable(() => useStakePreview(props, emit), {
+    intermediateProvider: () => {
+      providePoolStaking();
+    },
+    extraProvidersCb: () => provideUserData(),
+  });
+  return result;
+}
+
+test('Changes action label when props action changes', async () => {
+  const { stakeActions } = await mountUseStakePreview();
+
+  expect(stakeActions.value).toHaveLength(1);
+  expect(stakeActions.value[0].label).toEqual('Stake');
+
+  props.action = 'unstake';
+  // Wait for watcher to change actions
+  await sleep(10);
+
+  expect(stakeActions.value).toHaveLength(1);
+  expect(stakeActions.value[0].label).toEqual('Unstake');
+
+  props.action = 'restake';
+  // Wait for watcher to change actions
+  await sleep(10);
+
+  expect(stakeActions.value).toHaveLength(2);
+  expect(stakeActions.value[0].label).toEqual('Unstake');
+  expect(stakeActions.value[1].label).toEqual('Stake');
+});
+
+test.only('Changes action label when props action changes', async () => {
+  props.action = 'stake';
+  const { stakeActions } = await mountUseStakePreview();
+  props.action = 'restake';
+  await sleep(10);
+});

--- a/src/components/contextual/pages/pool/staking/composables/useStakePreview.ts
+++ b/src/components/contextual/pages/pool/staking/composables/useStakePreview.ts
@@ -1,0 +1,213 @@
+import { ApprovalAction } from '@/composables/approvals/types';
+import useRelayerApproval, {
+  RelayerType,
+} from '@/composables/approvals/useRelayerApproval';
+import useTokenApprovalActions from '@/composables/approvals/useTokenApprovalActions';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
+import { fiatValueOf } from '@/composables/usePoolHelpers';
+import useTransactions from '@/composables/useTransactions';
+import { trackLoading } from '@/lib/utils';
+import { usePoolStaking } from '@/providers/local/pool-staking.provider';
+import { useTokens } from '@/providers/tokens.provider';
+import { AnyPool } from '@/services/pool/types';
+import { TransactionActionInfo } from '@/types/transactions';
+import {
+  TransactionReceipt,
+  TransactionResponse,
+} from '@ethersproject/abstract-provider';
+import { getAddress } from '@ethersproject/address';
+import { useI18n } from 'vue-i18n';
+
+/**
+ * TYPES
+ */
+export type StakeAction = 'stake' | 'unstake' | 'restake';
+export type StakePreviewProps = {
+  pool: AnyPool;
+  action: StakeAction;
+};
+
+export function useStakePreview(props: StakePreviewProps, emit) {
+  /**
+   * STATE
+   */
+  const isLoadingApprovalsForGauge = ref(false);
+  const isActionConfirmed = ref(false);
+  const confirmationReceipt = ref<TransactionReceipt>();
+  const stakeActions = ref<TransactionActionInfo[]>([]);
+
+  /**
+   * COMPOSABLES
+   */
+  const { balanceFor, getToken, refetchBalances } = useTokens();
+  const { fNum } = useNumbers();
+  const { t } = useI18n();
+  const { addTransaction } = useTransactions();
+  const {
+    stake,
+    unstake,
+    restake,
+    stakedShares,
+    refetchAllPoolStakingData,
+    preferentialGaugeAddress,
+    isLoading,
+  } = usePoolStaking();
+  //TODO: this is only used for restake (better not always calling it)
+  const { relayerSignature, relayerApprovalAction } = useRelayerApproval(
+    RelayerType.BATCH
+  );
+
+  // console.log('preferentialGaugeAddress', preferentialGaugeAddress);
+
+  // Staked or unstaked shares depending on action type.
+  const currentShares =
+    props.action === 'stake'
+      ? balanceFor(getAddress(props.pool.address))
+      : stakedShares.value;
+
+  const { getTokenApprovalActionsForSpender } = useTokenApprovalActions(
+    ref<string[]>([props.pool.address]),
+    ref<string[]>([currentShares]),
+    ApprovalAction.Staking
+  );
+
+  const stakeAction = {
+    label: t('stake'),
+    loadingLabel: t('staking.staking'),
+    confirmingLabel: t('confirming'),
+    action: () => txWithNotification(stake, 'stake'),
+    stepTooltip: t('staking.stakeTooltip'),
+  };
+
+  const unstakeAction = {
+    label: t('unstake'),
+    loadingLabel: t('staking.unstaking'),
+    confirmingLabel: t('confirming'),
+    action: () => txWithNotification(unstake, 'unstake'),
+    stepTooltip: t('staking.unstakeTooltip'),
+  };
+
+  const restakeAction = {
+    label: t('restake'),
+    loadingLabel: t('staking.unstaking'),
+    confirmingLabel: t('confirming'),
+    action: () => txWithNotification(restake, 'restake'),
+    stepTooltip: t('staking.restakeTooltip'),
+  };
+
+  // /**
+  //  * COMPUTED
+  //  */
+  // const assetRowWidth = computed(
+  //   () => (tokensListExclBpt(props.pool).length * 32) / 1.5
+  // );
+
+  // const isStakeAndZero = computed(
+  //   () =>
+  //     props.action === 'stake' &&
+  //     (currentShares === '0' || currentShares === '')
+  // );
+
+  // const totalUserPoolSharePct = ref(
+  //   bnum(
+  //     bnum(stakedShares.value).plus(balanceFor(getAddress(props.pool.address)))
+  //   )
+  //     .div(props.pool.totalShares)
+  //     .toString()
+  // );
+
+  /**
+   * METHODS
+   */
+  async function handleSuccess({ receipt }) {
+    isActionConfirmed.value = true;
+    confirmationReceipt.value = receipt;
+    await Promise.all([refetchBalances(), refetchAllPoolStakingData()]);
+    emit('success');
+  }
+
+  async function txWithNotification(
+    action: () => Promise<TransactionResponse>,
+    actionType: StakeAction
+  ) {
+    try {
+      const tx = await action();
+      addTransaction({
+        id: tx.hash,
+        type: 'tx',
+        action: actionType,
+        summary: t(`transactionSummary.${actionType}`, {
+          pool: props.pool.symbol,
+          amount: fNum(
+            fiatValueOf(props.pool, currentShares),
+            FNumFormats.fiat
+          ),
+        }),
+        details: {
+          total: fNum(fiatValueOf(props.pool, currentShares), FNumFormats.fiat),
+          pool: props.pool,
+        },
+      });
+      return tx;
+    } catch (error) {
+      throw new Error(`Failed create ${actionType} transaction`, {
+        cause: error,
+      });
+    }
+  }
+
+  async function loadApprovalsForGauge() {
+    const approvalActions = await trackLoading(async () => {
+      if (!preferentialGaugeAddress.value) return;
+      return await getTokenApprovalActionsForSpender(
+        preferentialGaugeAddress.value
+      );
+    }, isLoadingApprovalsForGauge);
+
+    if (approvalActions) stakeActions.value.unshift(...approvalActions);
+  }
+
+  // async function loadApprovalsForRestake() {
+  //   const { relayerSignature, relayerApprovalAction } = useRelayerApproval(
+  //     RelayerType.BATCH
+  //   );
+  //   if (relayerApprovalAction)
+  //     stakeActions.value.unshift(relayerApprovalAction.value);
+  // }
+
+  function handleClose() {
+    isActionConfirmed.value = false;
+    confirmationReceipt.value = undefined;
+    emit('close');
+  }
+
+  /**
+   * WATCHERS
+   */
+  watch(
+    () => props.action,
+    () => {
+      if (props.action === 'stake') stakeActions.value = [stakeAction];
+      if (props.action === 'unstake') stakeActions.value = [unstakeAction];
+      if (props.action === 'restake')
+        // What if relayerApprovalAction.value is not loaded?
+        stakeActions.value = [relayerApprovalAction.value, restakeAction];
+    },
+    { immediate: true }
+  );
+
+  watch(preferentialGaugeAddress, async () => {
+    if (props.action === 'stake') await loadApprovalsForGauge();
+    // if (props.action === 'restake') await loadApprovalsForRestake();
+  });
+
+  /**
+   * LIFECYCLE
+   */
+  onBeforeMount(async () => {
+    if (props.action === 'stake') await loadApprovalsForGauge();
+    // if (props.action === 'restake') await loadApprovalsForRestake();
+  });
+
+  return { handleSuccess, handleClose, getToken, stakeActions };
+}

--- a/src/composables/__mocks__/useTransactions.ts
+++ b/src/composables/__mocks__/useTransactions.ts
@@ -1,5 +1,13 @@
-export default function useTransactions() {
+import useTransactions from '@/composables/useTransactions';
+import { MockedFunction } from 'vitest';
+
+type UseTransactionsResponse = ReturnType<typeof useTransactions>;
+type AddTransaction = UseTransactionsResponse['addTransaction'];
+
+export const addTransactionMock: MockedFunction<AddTransaction> = vi.fn();
+
+export default function useTransactionsMock() {
   return {
-    addTransaction: vi.fn(),
+    addTransaction: addTransactionMock,
   };
 }

--- a/src/dependencies/contract.concern.mocks.ts
+++ b/src/dependencies/contract.concern.mocks.ts
@@ -8,8 +8,11 @@ import { aSigner } from '@tests/unit/builders/signer';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { mock } from 'vitest-mock-extended';
 
+export const defaultContractTransactionHash =
+  '0x0679d36034a11eb150a807e9aa648ed79ecdcf7f3fe5ec3cbad9123e67b02c96';
 export const defaultContractTransactionResponse = mock<TransactionResponse>();
 defaultContractTransactionResponse.chainId = 5;
+defaultContractTransactionResponse.hash = defaultContractTransactionHash;
 
 export const sendTransactionMock = vi.fn(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/vitest/assertions.ts
+++ b/tests/vitest/assertions.ts
@@ -1,5 +1,10 @@
 import { Mock } from 'vitest';
 
-export function firstCallParams(mock: Mock) {
+/**
+ * Returns the parameters used in the first call to the provided mock
+ */
+export function firstCallParams<TArgs extends any[] = any>(
+  mock: Mock<TArgs>
+): TArgs[0] {
   return mock.mock.calls[0][0];
 }


### PR DESCRIPTION
# Description

This PR extracts useStakePreview composable to make it more testable and adds tests for covering the different staking flows.

This is the last preparatory PR before safely changing `restake` action to use SDK's `gauge2gauge`.   

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
