### PR TITLE
Hotfix - add gyro pool types to pools list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.103.0",
+  "version": "1.103.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.103.0",
+      "version": "1.103.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.103.0",
+  "version": "1.103.1",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/lib/config/mainnet/pools.ts
+++ b/src/lib/config/mainnet/pools.ts
@@ -33,6 +33,9 @@ const pools: Pools = {
     'ComposableStable',
     'FX',
     'EulerLinear',
+    'Gyro2',
+    'Gyro3',
+    'GyroE',
   ],
   Stable: {
     AllowList: [

--- a/src/lib/config/polygon/pools.ts
+++ b/src/lib/config/polygon/pools.ts
@@ -38,6 +38,9 @@ const pools: Pools = {
     'StablePhantom',
     'ComposableStable',
     'FX',
+    'Gyro2',
+    'Gyro3',
+    'GyroE',
   ],
   Stable: {
     AllowList: [


### PR DESCRIPTION
# Description

- Include Gyro2, Gyro3, and GyroE pool types in the main pools list so users can search for them and see them. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Search for `stMATIC` on Polygon. Ensure https://app.balancer.fi/#/polygon/pool/0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2000200000000000000000b49 appears in the list. 
- Sort pools by APR. Ensure that pool is near the top of the list (currently 55% APR)

Other Gyro pools that should now appear in search on Polygon:

```
GyroE
0x97469e6236bd467cd147065f77752b00efadce8a0002000000000000000008c0
0x3f6110b9322bc1633d5f63ccdfdf5dd648588b8a0002000000000000000008e3
0xa489c057de6c3177380ea264ebdf686b7f564f510002000000000000000008e2
0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2000200000000000000000b49

Gyro2
0xfa9ee04a5545d8e0a26b30f5ca5cbecd75ea645f000200000000000000000798
0x08b83439aeaccbcfb172a7327af38832fb9b7af400020000000000000000077b
0xc35864c1fb71d4f620e3e808a78fe2005af1efa7000200000000000000000797
0xae2a061c9f7a0486febfce17bcfb19dd777dd23c0002000000000000000006dc
0xdac42eeb17758daa38caf9a3540c808247527ae3000200000000000000000a2b
0x7ec3e47ca85602351ee252c0bfae14e1e2c90bd500020000000000000000077f
0xf16a66320fafe03c9bf6daaaebe9418f17620de60002000000000000000008e1
0x6313449d06ad99a7baca0ddb7e0b5f9f2048cf86000200000000000000000772

Gyro3
0x88856e26914a4503fb9669e159aae96d3f3cb66b0001000000000000000006e9
0x17f1ef81707811ea15d9ee7c741179bbe2a63887000100000000000000000799
0x66f6db795a93ce1ca5dc5daba74aead98da8e06a0001000000000000000006fa
0xb211043347cb9f2dfd8b981996820e2886b0ef1800010000000000000000077e
0x1a076c59321a38bf48431081e8fe3420de67de8f000100000000000000000771
```

There are no pools on mainnet yet, but there might be in the future and when there are we want to show them. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
