### PR TITLE
chore: Stringify params sent to sentry

### DIFF
--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -503,19 +503,23 @@ export const exitPoolProvider = (
       level: 'fatal',
       extra: {
         exitHandler: exitHandlerType.value,
-        params: {
-          exitType: exitType.value,
-          bptIn: _bptIn.value,
-          amountsOut: amountsOut.value,
-          signer: sender,
-          slippageBsp: slippageBsp.value,
-          tokenInfo: exitTokenInfo.value,
-          approvalActions: approvalActions.value,
-          bptInValid: bptInValid.value,
-          relayerSignature: relayerSignature.value,
-          transactionDeadline: transactionDeadline.value,
-          toInternalBalance: shouldExitViaInternalBalance.value,
-        },
+        params: JSON.stringify(
+          {
+            exitType: exitType.value,
+            bptIn: _bptIn.value,
+            amountsOut: amountsOut.value,
+            signer: sender,
+            slippageBsp: slippageBsp.value,
+            tokenInfo: exitTokenInfo.value,
+            approvalActions: approvalActions.value,
+            bptInValid: bptInValid.value,
+            relayerSignature: relayerSignature.value,
+            transactionDeadline: transactionDeadline.value,
+            toInternalBalance: shouldExitViaInternalBalance.value,
+          },
+          null,
+          2
+        ),
       },
     });
   }

--- a/src/providers/local/join-pool.provider.ts
+++ b/src/providers/local/join-pool.provider.ts
@@ -379,15 +379,19 @@ export const joinPoolProvider = (
       level: 'fatal',
       extra: {
         joinHandler: joinHandlerType.value,
-        params: {
-          amountsIn: amountsInWithValue.value,
-          tokensIn: tokensIn.value,
-          signer: sender,
-          slippageBsp: slippageBsp.value,
-          relayerSignature: relayerSignature.value,
-          approvalActions: approvalActions.value,
-          transactionDeadline: transactionDeadline.value,
-        },
+        params: JSON.stringify(
+          {
+            amountsIn: amountsInWithValue.value,
+            tokensIn: tokensIn.value,
+            signer: sender,
+            slippageBsp: slippageBsp.value,
+            relayerSignature: relayerSignature.value,
+            approvalActions: approvalActions.value,
+            transactionDeadline: transactionDeadline.value,
+          },
+          null,
+          2
+        ),
       },
     });
   }


### PR DESCRIPTION
# Description

When a tx fails before being submitted, e.g. the query function before a join/exit call, we were logging the params for debugging to Sentry as a JS object. This results in un parsable nested params like [Object] in Sentry. This PR uses JSON.stringify to format params before sending to Sentry.

## Type of change

- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
