### PR TITLE
Hotfix - fetch pool type version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.103.4",
+  "version": "1.103.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.103.4",
+      "version": "1.103.5",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.103.4",
+  "version": "1.103.5",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/services/balancer/api/entities/pools/query.ts
+++ b/src/services/balancer/api/entities/pools/query.ts
@@ -74,6 +74,7 @@ export const defaultAttrs = {
     id: true,
     address: true,
     poolType: true,
+    poolTypeVersion: true,
     swapFee: true,
     tokensList: true,
     totalLiquidity: true,


### PR DESCRIPTION
# Description

Fetches poolTypeVersion from the Balancer API as it's needed by the frontend. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Load the pools page 
- Ensure that each pool has poolTypeVersion set. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
