### PR TITLE
Re-add bump tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,5 +1,7 @@
+# Bumps the package version with a patch if the version wasn't already updated
+# - This is skipped if there is already a version bump in the merged PR
 # Tags each push to master with version in package.json if not already a tag.
-name: Tag
+name: BumpTag
 
 on:
   push:
@@ -10,7 +12,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: Klemensas/action-autotag@stable
-        with:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - uses: 'phips28/gh-action-bump-version@v9.1.3'
+      with:
+        commit-message: '{{version}}'
+      env:
+        GITHUB_TOKEN: ${{ secrets.TIM_PAT_TOKEN }}
+    - uses: Klemensas/action-autotag@stable
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - uses: actions/checkout@v3
+    - shell: bash
+      run: |
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git branch -f deploy
+        git push -f origin deploy


### PR DESCRIPTION
This fixes and re-adds the BumpTag action removed in #3477 

It failed because the master branch is protected. I changed it to use a personal access token that I created to get around this restriction. The other changes are making it checkout without default Github credentials, and re-checkout at the end to push to the deploy branch. 

The permissions on the personal access token are:

![Screenshot from 2023-06-01 16-49-01](https://github.com/balancer/frontend-v2/assets/525534/262802d4-266f-44fc-b7cd-94eb9cc39bc0)

I'm not sure if all of these are necessary. We could create a balancer bot with these permissions instead of using my token too. 

Tested in my personal fork by protecting my master branch in the same way this repo is protected, then making sure this worked. 
