### PR TITLE
Hotfix:  only deploy tagged

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - shell: bash
       run: |
+        [[ $(git log -1 --oneline) =~ ^.*([0-9]+\.[0-9]+\.[0-9])$ ]] || exit 0
         git config --global user.name "GitHub Actions"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git branch -f deploy


### PR DESCRIPTION
# Description

Only run the script to push to the deploy branch if the last commit is a tag number. 