### PR TITLE
Hotfix: Add missing + to deploy script check. 

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - shell: bash
       run: |
-        [[ $(git log -1 --oneline) =~ ^.*([0-9]+\.[0-9]+\.[0-9])$ ]] || exit 0
+        [[ $(git log -1 --oneline) =~ ^.*([0-9]+\.[0-9]+\.[0-9]+)$ ]] || exit 0
         git config --global user.name "GitHub Actions"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git branch -f deploy


### PR DESCRIPTION
There was a plus missing which made pushing to deploy branch break when the patch version is double digits, which just happened. 