### PR TITLE
chore: Use pool metadata for claims page tables

### DIFF
--- a/src/pages/claim/index.vue
+++ b/src/pages/claim/index.vue
@@ -25,6 +25,7 @@ import useWeb3 from '@/services/web3/useWeb3';
 import { TOKENS } from '@/constants/tokens';
 import { buildNetworkIconURL } from '@/lib/utils/urls';
 import { Network } from '@/lib/config';
+import { poolMetadata } from '@/lib/config/metadata';
 
 /**
  * TYPES
@@ -162,6 +163,9 @@ async function injectPoolTokens(pools: GaugePool[]): Promise<void> {
 }
 
 function gaugeTitle(pool: GaugePool): string {
+  const metadata = poolMetadata(pool.id);
+  if (metadata?.name) return metadata.name;
+
   const _tokens = pool.tokens.map(token => ({
     ...token,
     ...getToken(getAddress(token.address)),


### PR DESCRIPTION
# Description

If pool metadata exists for a pool gauge on the claims page, use it. Previously we were just combining token symbols and weights.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Test claims page displays pool names above reward gauges.

## Visual context

<img width="578" alt="Screenshot 2023-06-02 at 16 16 00" src="https://github.com/balancer/frontend-v2/assets/2406506/9fc36a85-99ad-487e-b8f4-8da186d94cdc">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
