### PR TITLE
Hotfix: Fix bumptag always doing major bumps

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Bump version
-        uses: 'phips28/gh-action-bump-version@v9.1.3'
+        uses: 'timjrobinson/gh-action-bump-version@master'
         with:
           commit-message: '{{version}}'
           minor-wording: ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "2.0.0",
+  "version": "1.105.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "2.0.0",
+      "version": "1.105.2",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.105.2",
+  "version": "1.105.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.105.2",
+      "version": "1.105.1",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.105.2",
+  "version": "1.105.1",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "2.0.0",
+  "version": "1.105.2",
   "engines": {
     "node": "=16",
     "npm": ">=8"


### PR DESCRIPTION
# Description

Bumptag has a bug where when you specify `''` for a major bump it takes that to mean "Always major bump becuase this empty string is always found". Which made it bump package.json to 2.0.0.

I patched bumptag to fix this (https://github.com/phips28/gh-action-bump-version/pull/216) and switched to using my fork until this is merged into the main repo. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

See: https://github.com/timjrobinson/frontend-v2/actions/runs/5196894274/jobs/9371076804, it does a patch update as expected. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
