### PR TITLE
refactor: avoid using 2 useApprovalRelayerTx instances

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
@@ -58,7 +58,7 @@ const {
   queryExitQuery,
   fiatTotalOut,
   approvalActions: exitPoolApprovalActions,
-  relayerApproval,
+  relayerApprovalTx,
   shouldExitViaInternalBalance,
   isTxPayloadReady,
   relayerSignature,
@@ -103,7 +103,7 @@ const txSummary = computed<string>(() => {
 const isBuildingTx = computed((): boolean => {
   return (
     !isTxPayloadReady.value &&
-    (!!relayerSignature.value || relayerApproval.isUnlocked.value)
+    (!!relayerSignature.value || relayerApprovalTx.isUnlocked.value)
   );
 });
 

--- a/src/composables/approvals/useRelayerApproval.ts
+++ b/src/composables/approvals/useRelayerApproval.ts
@@ -41,7 +41,7 @@ export default function useRelayerApproval(relayerType: RelayerType) {
   const { networkId } = useNetwork();
   const { t } = useI18n();
   const { isGnosisSafeApp } = useGnosisSafeApp();
-  const { action: transactionAction } = useRelayerApprovalTx(relayerType);
+  const relayerApprovalTx = useRelayerApprovalTx(relayerType);
   const { supportSignatures } = useUserSettings();
 
   const signatureAction: TransactionActionInfo = {
@@ -61,7 +61,7 @@ export default function useRelayerApproval(relayerType: RelayerType) {
     return !supportSignatures.value ||
       isGnosisSafeApp.value ||
       isWalletConnectWallet(connector.value?.id)
-      ? transactionAction.value
+      ? relayerApprovalTx.action.value
       : signatureAction;
   });
 
@@ -95,5 +95,6 @@ export default function useRelayerApproval(relayerType: RelayerType) {
   return {
     relayerSignature,
     relayerApprovalAction,
+    relayerApprovalTx,
   };
 }

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -385,7 +385,6 @@ export const exitPoolProvider = (
       isTxPayloadReady.value = output.txReady;
       return output;
     } catch (error) {
-      console.log('ERROR CONSTRUCT', error);
       logExitException(error as Error);
       throw new Error('Failed to construct exit.', { cause: error });
     }


### PR DESCRIPTION
# Description



## Type of change

We were using 2 instances of useApprovalRelayerTx which contains local state. My hypothesis is that the state duplication could lead to some intermittent errors related with the approved state of the relayer. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
