### PR TITLE
Ignore queryExit error once tx was confirmed

### DIFF
--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -498,6 +498,8 @@ export const exitPoolProvider = (
   }
 
   async function logExitException(error: Error) {
+    // Ignore error when queryExit fails once the tx has been confirmed
+    if (txState.confirmed && queryError.value) return;
     const sender = await getSigner().getAddress();
     captureException(error, {
       level: 'fatal',


### PR DESCRIPTION
# Description

I could also reproduce this problem once and I couldn't record it but, this is my theory: 

We have [this watche](https://github.com/balancer/frontend-v2/blob/f9d4fbdc281bee57a852d7251ebf01cb29603e0a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue#L170)r to refetch the `queryExit` whenever the blockNumber changes. 
Although we avoid refetching when `txInProgress.value` there could be an edge case when a pending `queryExit` is executed after the transaction has been confirmed. 

This PR would detect and ignore that case, reducing the number of false positives in sentry.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
