### PR TITLE
Refactor: Avoid capturing sentry error until the last retry attempt

### DIFF
--- a/src/lib/utils/vue-query.ts
+++ b/src/lib/utils/vue-query.ts
@@ -1,0 +1,11 @@
+import { UseQueryReturnType } from '@tanstack/vue-query';
+
+// Returns true unless vue-query already retried 3 times
+// We use this function to reduce the amount of sentry captured errors as we will ignore certain random errors that only happens once
+// but do not happen in the next retry
+export function shouldIgnoreError(
+  query: UseQueryReturnType<any, any>
+): boolean {
+  const defaultMaxRetries = 3;
+  return query.failureCount.value < defaultMaxRetries;
+}


### PR DESCRIPTION
# Description

Goal: we want to reduce false positives in sentry issues

In the exit flow, we use a watcher to repeatedly call queryExit to simulate the exit transaction from the "preview modal".
If some of this queries goes wrong (due to different causes) vue-query will retry 3 times.
We have some random errors that happen just once but they don't in the second/third retry so they are not actually affecting the user, however we currently log this errors increasing fatal-error/transaction ratio in sentry.

I reproduced this scenario in the generalized exit flow, where, I get random 'out-of-bounds' exceptions during queryExit simulations that do not happen after the first retry.

Solution: In the simulation queries, instead of calling logExitException after the first error, we wait for the 3 vue-query retries to be attempted, so that, we will avoid this sentry issues when they don't actually affect the user flow.

Closes #3513 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
