### PR TITLE
Add missing ComposableStable v4 factory addresses to fix unknown pools

### DIFF
--- a/src/lib/config/arbitrum/pools.ts
+++ b/src/lib/config/arbitrum/pools.ts
@@ -84,7 +84,7 @@ const pools: Pools = {
     '0x1c99324edc771c82a0dccb780cc7dda0045e50e7': 'composableStablePool', // ComposableStable V3
     '0xf1665e19bc105be4edd3739f88315cc699cc5b65': 'weightedPool', // Weighted Pool V3
     '0xc7e5ed1054a24ef31d827e6f86caa58b3bc168d7': 'weightedPool', // weighted pool v4
-    '0x2498a2b0d6462d2260eac50ae1c3e03f4829ba95': 'weightedPool', // weighted pool
+    '0x2498a2b0d6462d2260eac50ae1c3e03f4829ba95': 'composableStablePool', // ComposableStable V4
   },
   Stakable: {
     VotingGaugePools: [

--- a/src/lib/config/arbitrum/pools.ts
+++ b/src/lib/config/arbitrum/pools.ts
@@ -84,6 +84,7 @@ const pools: Pools = {
     '0x1c99324edc771c82a0dccb780cc7dda0045e50e7': 'composableStablePool', // ComposableStable V3
     '0xf1665e19bc105be4edd3739f88315cc699cc5b65': 'weightedPool', // Weighted Pool V3
     '0xc7e5ed1054a24ef31d827e6f86caa58b3bc168d7': 'weightedPool', // weighted pool v4
+    '0x2498a2b0d6462d2260eac50ae1c3e03f4829ba95': 'weightedPool', // weighted pool
   },
   Stakable: {
     VotingGaugePools: [

--- a/src/lib/config/gnosis-chain/pools.ts
+++ b/src/lib/config/gnosis-chain/pools.ts
@@ -49,6 +49,7 @@ const pools: Pools = {
     '0xc128468b7ce63ea702c1f104d55a2566b13d3abd': 'composableStablePool', // ComposableStable V3
     '0xc128a9954e6c874ea3d62ce62b468ba073093f25': 'weightedPool', // WeightedPool V3
     '0x6cad2ea22bfa7f4c14aae92e47f510cd5c509bc7': 'weightedPool', // weighted pool v4
+    '0xd87f44df0159dc78029ab9ca7d7e57e7249f5acd': 'stablePool', // Gnosis Stable
   },
   Stakable: {
     VotingGaugePools: [

--- a/src/lib/config/gnosis-chain/pools.ts
+++ b/src/lib/config/gnosis-chain/pools.ts
@@ -49,7 +49,7 @@ const pools: Pools = {
     '0xc128468b7ce63ea702c1f104d55a2566b13d3abd': 'composableStablePool', // ComposableStable V3
     '0xc128a9954e6c874ea3d62ce62b468ba073093f25': 'weightedPool', // WeightedPool V3
     '0x6cad2ea22bfa7f4c14aae92e47f510cd5c509bc7': 'weightedPool', // weighted pool v4
-    '0xd87f44df0159dc78029ab9ca7d7e57e7249f5acd': 'stablePool', // Gnosis Stable
+    '0xd87f44df0159dc78029ab9ca7d7e57e7249f5acd': 'composableStablePool', // ComposableStable V4
   },
   Stakable: {
     VotingGaugePools: [

--- a/src/lib/config/mainnet/pools.ts
+++ b/src/lib/config/mainnet/pools.ts
@@ -142,7 +142,7 @@ const pools: Pools = {
     '0xb08e16cfc07c684daa2f93c70323badb2a6cbfd2': 'boostedPool', // mainnet stablephantom
     '0x8df6efec5547e31b0eb7d1291b511ff8a2bf987c': 'stablePool', // stable pool v2
     '0xf9ac7b9df2b3454e841110cce5550bd5ac6f875f': 'composableStablePool', // ComposableStable
-    '0xfada0f4547ab2de89d1304a668c39b3e09aa7c76': 'composableStablePool', // ComposableStable
+    '0xfada0f4547ab2de89d1304a668c39b3e09aa7c76': 'composableStablePool', // ComposableStable v4
     '0xcc508a455f5b0073973107db6a878ddbdab957bc': 'weightedPool', // weighted pool v2
     '0xdba127fbc23fb20f5929c546af220a991b5c6e01': 'composableStablePool', // ComposableStable v2
     '0x5dd94da3644ddd055fcf6b3e1aa310bb7801eb8b': 'weightedPool', // weighted pool v3


### PR DESCRIPTION
# Description

Add missing factory addresses to fix unknown pools. 

Fixes "**unknown pool type**" in these pools: 

https://beta-app-v2-git-fix-unknown-pool-type-balancer.vercel.app/#/arbitrum/pool/0x542f16da0efb162d20bf4358efa095b70a100f9e000000000000000000000436

https://beta-app-v2-git-fix-unknown-pool-type-balancer.vercel.app/#/gnosis-chain/pool/0xbad20c15a773bf03ab973302f61fabcea5101f0a000000000000000000000034

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
