### PR TITLE
Add webhook to allowlist pools

### DIFF
--- a/.github/workflows/allowlist-manual.yml
+++ b/.github/workflows/allowlist-manual.yml
@@ -1,0 +1,36 @@
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        type: choice
+        description: Network
+        required: true
+        options:
+          - mainnet
+          - polygon
+          - arbitrum
+          - gnosis-chain
+      poolType:
+        type: choice
+        description: Pool Type
+        required: true
+        options:
+          - Weighted
+          - Stable
+      poolId:
+        type: string
+        description: Pool ID
+        required: true
+      poolDescription:
+        type: string
+        description: Pool Description
+        required: false
+
+jobs:
+  allowlist-pool:
+    uses: ./.github/workflows/allowlist.yml
+    with:
+      network: ${{ github.event.inputs.network }}
+      poolType: ${{ github.event.inputs.poolType }}
+      poolId: ${{ github.event.inputs.poolId }}
+      poolDescription: ${{ github.event.inputs.poolDescription }}

--- a/.github/workflows/allowlist-manual.yml
+++ b/.github/workflows/allowlist-manual.yml
@@ -1,3 +1,5 @@
+name: Allowlist pool
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/allowlist-webhook.yml
+++ b/.github/workflows/allowlist-webhook.yml
@@ -1,0 +1,14 @@
+name: Allowlist Pool Webhook
+
+on:
+  repository_dispatch:
+    types: ['allowlist_pool']
+
+jobs:
+  allowlist-pool:
+    uses: ./.github/workflows/allowlist.yml
+    with:
+      network: ${{ github.event.client_payload.network }}
+      poolType: ${{ github.event.client_payload.poolType }}
+      poolId: ${{ github.event.client_payload.poolId }}
+      poolDescription: ${{ github.event.client_payload.poolDescription }}

--- a/.github/workflows/allowlist.yml
+++ b/.github/workflows/allowlist.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install deps
         run: npm install cac
       - name: Run allowlist script
-        run: npx vite-node ./src/lib/scripts/automatic-prs/allowlist-pool.ts --network ${{github.event.inputs.network}} --poolType ${{github.event.inputs.poolType}} --poolId \"${{github.event.inputs.poolId}}\" --poolDescription "${{github.event.inputs.poolDescription}}"
+        run: npx vite-node ./src/lib/scripts/automatic-prs/allowlist-pool.ts --network ${{inputs.network}} --poolType ${{inputs.poolType}} --poolId \"${{inputs.poolId}}\" --poolDescription "${{inputs.poolDescription}}"
       - name: Run eslint fix of updated config files
         run: npm run lint:fix:config
       - name: Create Pull Request

--- a/.github/workflows/allowlist.yml
+++ b/.github/workflows/allowlist.yml
@@ -1,37 +1,24 @@
 name: Allowlist pool
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       network:
-        type: choice
-        description: Network
+        type: string
         required: true
-        options:
-          - mainnet
-          - polygon
-          - arbitrum
-          - gnosis-chain
       poolType:
-        type: choice
-        description: Pool Type
+        type: string
         required: true
-        options:
-          - Weighted
-          - Stable
       poolId:
         type: string
-        description: Pool ID
         required: true
       poolDescription:
         type: string
-        description: Pool Description
         required: false
 
 jobs:
   allowlist-pool:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

This adds a webhook so that we can create a pool allowlist request when new pool create transactions come in. These transaction notifications come from Hal.xyz and are sent to a lambda on the Balancer API that then calls this webhook with the correct parameters. 

I've made the allowlist code more generic so it can be called from either the manual workflow or the automatic one. 


## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How should this be tested?

- This can be manually tested with curl by forking this repo, creating a personal access token with webhook request, and running the following replacing `myGithubPatToken` with your token, and `timjrobinson` with your github username:

```
curl -X POST -H "Authorization: token myGithubPatToken" https://api.github.com/repos/timjrobinson/frontend-v2/dispatches --data '{"event_type": "allowlist_pool", "client_payload": { "network": "polygon", "poolType": "Weighted", "poolId": "0x8f4205e1604133d1875a3e771ae7e4f2b0865639000200000000000000000111", "poolDescription": "boop" }}'`
```

This is the format that requests from the API will use.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
