### PR TITLE
Make veBAL gauge filter run via config

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/GaugesFilters.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesFilters.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { networkLabelMap } from '@/composables/useNetwork';
-import { Network } from '@/lib/config';
+import configs, { Network } from '@/lib/config';
 
 /**
  * TYPES
@@ -96,7 +95,7 @@ function updateNetwork(network: number) {
         <BalCheckbox
           :modelValue="networkFiltersArr.includes(Number(network))"
           name="networkFilter"
-          :label="networkLabelMap[network]"
+          :label="configs[network].chainName"
           noMargin
           alignCheckbox="items-center"
           @input="updateNetwork(Number(network))"

--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -13,7 +13,7 @@ import GaugesTable from './GaugesTable.vue';
 import GaugeVoteModal from './GaugeVoteModal.vue';
 import ResubmitVotesAlert from './ResubmitVotes/ResubmitVotesAlert.vue';
 import { orderedTokenURIs } from '@/composables/useVotingGauges';
-import { Network } from '@/lib/config';
+import configs, { Network } from '@/lib/config';
 import GaugesFilters from './GaugesFilters.vue';
 import { isGaugeExpired } from './voting-utils';
 
@@ -25,13 +25,15 @@ const showExpiredGauges = useDebouncedRef<boolean>(false, 500);
 const activeNetworkFilters = useDebouncedRef<Network[]>([], 500);
 const activeVotingGauge = ref<VotingGaugeWithVotes | null>(null);
 
-const networkFilters = [
-  Network.MAINNET,
-  Network.POLYGON,
-  Network.ARBITRUM,
-  Network.OPTIMISM,
-  Network.GNOSIS,
-];
+const networkFilters = Object.entries(configs)
+  .map(([network, config]) => {
+    if (
+      !config.testNetwork &&
+      config.pools.Stakable.VotingGaugePools.length > 0
+    )
+      return network;
+  })
+  .filter(network => !!network);
 
 /**
  * COMPOSABLES

--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -25,15 +25,14 @@ const showExpiredGauges = useDebouncedRef<boolean>(false, 500);
 const activeNetworkFilters = useDebouncedRef<Network[]>([], 500);
 const activeVotingGauge = ref<VotingGaugeWithVotes | null>(null);
 
-const networkFilters = Object.entries(configs)
-  .map(([network, config]) => {
-    if (
-      !config.testNetwork &&
-      config.pools.Stakable.VotingGaugePools.length > 0
-    )
-      return network;
+const networkFilters: Network[] = Object.entries(configs)
+  .filter(details => {
+    const config = details[1];
+    return (
+      !config.testNetwork && config.pools.Stakable.VotingGaugePools.length > 0
+    );
   })
-  .filter(network => !!network);
+  .map(details => Number(details[0]) as Network);
 
 /**
  * COMPOSABLES

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -25,14 +25,6 @@ const NETWORK_ID =
 if (windowAvailable) localStorage.setItem('networkId', NETWORK_ID.toString());
 export const networkSlug = config[NETWORK_ID].slug;
 export const networkConfig = config[NETWORK_ID];
-export const networkLabelMap = {
-  [Network.MAINNET]: 'Ethereum',
-  [Network.POLYGON]: 'Polygon',
-  [Network.ARBITRUM]: 'Arbitrum',
-  [Network.GOERLI]: 'Goerli',
-  [Network.OPTIMISM]: 'Optimism',
-  [Network.GNOSIS]: 'Gnosis chain',
-};
 
 /**
  * COMPUTED
@@ -171,7 +163,6 @@ export default function useNetwork() {
     getNetworkSlug,
     getSubdomain,
     handleNetworkSlug,
-    networkLabelMap,
     appNetworkConfig,
   };
 }


### PR DESCRIPTION
# Description

- Refactor the filter list on the veBAL gauge page to use config settings so that it automatically adds new networks that are not test networks and have pools users can vote for.
- This will show zkEVM once we add gauges people can vote for to the list. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

- Load the veBAL page
- Attempt to filter by a network
- See same networks are present as before with same names

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
