### PR TITLE
Move Voting Gauge Generation config to files

### DIFF
--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -15,6 +15,7 @@ const config: Config = {
   monorepoName: 'arbitrum',
   slug: 'arbitrum',
   network: 'arbitrum-one',
+  trustWalletNetwork: 'arbitrum',
   unknown: false,
   visibleInUI: true,
   testNetwork: false,

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -14,6 +14,7 @@ const config: Config = {
   monorepoName: 'gnosis',
   slug: 'gnosis-chain',
   network: 'gnosis-chain',
+  trustWalletNetwork: 'xdai',
   unknown: false,
   visibleInUI: true,
   testNetwork: false,

--- a/src/lib/config/goerli/index.ts
+++ b/src/lib/config/goerli/index.ts
@@ -15,6 +15,7 @@ const config: Config = {
   monorepoName: 'goerli',
   slug: 'goerli',
   network: 'goerli',
+  trustWalletNetwork: 'goerli',
   unknown: false,
   visibleInUI: true,
   testNetwork: true,

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -15,6 +15,7 @@ const config: Config = {
   monorepoName: 'mainnet',
   slug: 'ethereum',
   network: 'mainnet',
+  trustWalletNetwork: 'ethereum',
   unknown: false,
   visibleInUI: true,
   testNetwork: false,

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -13,6 +13,7 @@ const config: Config = {
   monorepoName: 'optimism',
   slug: 'optimism',
   network: 'optimism',
+  trustWalletNetwork: 'optimism',
   unknown: false,
   visibleInUI: false,
   testNetwork: false,

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -15,6 +15,7 @@ const config: Config = {
   monorepoName: 'polygon',
   slug: 'polygon',
   network: 'polygon',
+  trustWalletNetwork: 'polygon',
   unknown: false,
   visibleInUI: true,
   testNetwork: false,

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -75,6 +75,7 @@ export interface Config {
   monorepoName?: string;
   slug: string;
   network: string;
+  trustWalletNetwork?: string;
   unknown: boolean;
   visibleInUI: boolean;
   testNetwork: boolean;

--- a/src/lib/config/zkevm/index.ts
+++ b/src/lib/config/zkevm/index.ts
@@ -15,6 +15,7 @@ const config: Config = {
   monorepoName: 'zkevm',
   slug: 'zkevm',
   network: 'polygon-zkevm',
+  trustWalletNetwork: 'polygonzkevm',
   unknown: false,
   visibleInUI: true,
   testNetwork: false,

--- a/src/lib/scripts/voting-gauge.generator.ts
+++ b/src/lib/scripts/voting-gauge.generator.ts
@@ -485,10 +485,19 @@ function checkNodeJSVersion() {
   }
 }
 
+function checkRPCIsSet() {
+  if (!import.meta.env[`VITE_RPC_URL_1`]) {
+    throw new Error(
+      'This script requires the env variable VITE_RPC_URL_1 to be set to your RPC URL, as the default Infura RPC will not work with CLI apps.'
+    );
+  }
+}
+
 (async () => {
   console.log('Generating voting-gauges.json...');
 
   checkNodeJSVersion();
+  checkRPCIsSet();
 
   console.log('Fetching gauges info...');
   console.time('getGaugeInfo');

--- a/src/lib/scripts/voting-gauge.generator.ts
+++ b/src/lib/scripts/voting-gauge.generator.ts
@@ -153,16 +153,8 @@ function getTrustWalletAssetsURI(
   log(
     `getTrustWalletAssetsURI network: ${network} tokenAddress: ${tokenAddress}`
   );
-  const networksMap = {
-    [Network.MAINNET]: 'ethereum',
-    [Network.ARBITRUM]: 'arbitrum',
-    [Network.POLYGON]: 'polygon',
-    [Network.GOERLI]: 'goerli',
-    [Network.OPTIMISM]: 'optimism',
-    [Network.GNOSIS]: 'xdai',
-  };
 
-  return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${networksMap[network]}/assets/${tokenAddress}/logo.png`;
+  return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${config[network].trustWalletNetwork}/assets/${tokenAddress}/logo.png`;
 }
 
 async function isValidLogo(uri: string | undefined): Promise<boolean> {
@@ -197,12 +189,7 @@ async function getTokenLogoURI(
   logoUri = await getAssetURIFromTokenlists(tokenAddress, network);
   if (await isValidLogo(logoUri)) return logoUri;
 
-  if (
-    network === Network.ARBITRUM ||
-    network === Network.OPTIMISM ||
-    network === Network.POLYGON ||
-    network === Network.GNOSIS
-  ) {
+  if (network !== Network.MAINNET && config[network].testNetwork === false) {
     const mainnetAddress = await getMainnetTokenAddresss(tokenAddress, network);
     logoUri = getTrustWalletAssetsURI(mainnetAddress, Network.MAINNET);
     if (await isValidLogo(logoUri)) return logoUri;

--- a/src/lib/scripts/voting-gauge.generator.ts
+++ b/src/lib/scripts/voting-gauge.generator.ts
@@ -476,8 +476,19 @@ async function getGaugeInfo(
   }
 }
 
+function checkNodeJSVersion() {
+  const nodeVersion = process.versions.node;
+  if (Number(nodeVersion.split('.')[0]) > 16) {
+    throw new Error(
+      `This script does not work with NodeJS > 16. You are using ${nodeVersion}. Please downgrade to continue.`
+    );
+  }
+}
+
 (async () => {
   console.log('Generating voting-gauges.json...');
+
+  checkNodeJSVersion();
 
   console.log('Fetching gauges info...');
   console.time('getGaugeInfo');


### PR DESCRIPTION
# Description

There were some hardcoded networks in the voting gauge generator. I moved this info to config files so that it supports new networks automatically. 

I also found this script doesn't work for me with NodeJS 18. Ethers always complains about no connection. So I've added a check for that so others don't run into issues. 

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- Create voting gauges
- Ensure they are generated correctly for all networks

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
