### PR TITLE
Fixed broken veBAL learn more link

### DIFF
--- a/src/components/contextual/pages/vebal/Hero.vue
+++ b/src/components/contextual/pages/vebal/Hero.vue
@@ -60,7 +60,7 @@ function navigateToGetVeBAL() {
           </BalBtn>
           <BalBtn
             tag="a"
-            href="https://docs.balancer.fi/ecosystem/vebal-and-gauges"
+            href="https://docs.balancer.fi/concepts/governance/veBAL/"
             target="_blank"
             rel="noreferrer"
             color="white"


### PR DESCRIPTION
# Description

Updated the veBAL learn more link to point to the correct place in the docs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Click the learn more link. It should now go to: https://docs.balancer.fi/concepts/governance/veBAL/

<img width="958" alt="CleanShot 2023-06-21 at 23 43 40@2x" src="https://github.com/balancer/frontend-v2/assets/1121139/f1c077a4-1f24-4ad0-95ed-46bf37b35a2f">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
