### PR TITLE
Fix allowance validation when staking in gauges

### DIFF
--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -213,10 +213,9 @@ function handleSignAction(state: TransactionActionState) {
 async function handleTransaction(
   tx: TransactionResponse,
   state: TransactionActionState,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   actionInfo: TransactionActionInfo
 ): Promise<void> {
-  // const { postActionValidation, actionInvalidReason } = actionInfo;
+  const { postActionValidation, actionInvalidReason } = actionInfo;
 
   await txListener(tx, {
     onTxConfirmed: async (receipt: TransactionReceipt) => {
@@ -230,21 +229,21 @@ async function handleTransaction(
 
       state.confirming = false;
 
-      // const isValid = await postActionValidation?.();
-      // if (isValid || !postActionValidation) {
-      const confirmedAt = await getTxConfirmedAt(receipt);
-      state.confirmedAt = dateTimeLabelFor(confirmedAt);
-      state.confirmed = true;
-      if (currentActionIndex.value >= actions.value.length - 1) {
-        emit('success', { receipt, confirmedAt: state.confirmedAt });
+      const isValid = await postActionValidation?.();
+      if (isValid || !postActionValidation) {
+        const confirmedAt = await getTxConfirmedAt(receipt);
+        state.confirmedAt = dateTimeLabelFor(confirmedAt);
+        state.confirmed = true;
+        if (currentActionIndex.value >= actions.value.length - 1) {
+          emit('success', { receipt, confirmedAt: state.confirmedAt });
+        } else {
+          currentActionIndex.value += 1;
+        }
       } else {
-        currentActionIndex.value += 1;
+        // post action validation failed, display reason.
+        if (actionInvalidReason) state.error = actionInvalidReason;
+        state.init = false;
       }
-      // } else {
-      //   // post action validation failed, display reason.
-      //   if (actionInvalidReason) state.error = actionInvalidReason;
-      //   state.init = false;
-      // }
     },
     onTxFailed: () => {
       state.confirming = false;

--- a/src/composables/approvals/useTokenApprovalActions.ts
+++ b/src/composables/approvals/useTokenApprovalActions.ts
@@ -37,13 +37,8 @@ export default function useTokenApprovalActions() {
   /**
    * COMPOSABLES
    */
-  const {
-    refetchAllowances,
-    approvalsRequired,
-    approvalRequired,
-    getToken,
-    injectSpenders,
-  } = useTokens();
+  const { approvalsRequired, approvalRequired, getToken, injectSpenders } =
+    useTokens();
   const { t } = useI18n();
   const { getSigner } = useWeb3();
   const { addTransaction } = useTransactions();
@@ -95,7 +90,7 @@ export default function useTokenApprovalActions() {
     spender: string
   ): Promise<AmountToApprove[]> {
     await injectSpenders([spender]);
-    await refetchAllowances();
+
     return approvalsRequired(amountsToApprove, spender);
   }
 
@@ -104,7 +99,7 @@ export default function useTokenApprovalActions() {
     spender: string
   ): Promise<boolean> {
     await injectSpenders([spender]);
-    await refetchAllowances();
+
     return !approvalRequired(
       amountToApprove.address,
       amountToApprove.amount,

--- a/src/composables/approvals/useTokenApprovalActions.ts
+++ b/src/composables/approvals/useTokenApprovalActions.ts
@@ -37,8 +37,13 @@ export default function useTokenApprovalActions() {
   /**
    * COMPOSABLES
    */
-  const { refetchAllowances, approvalsRequired, approvalRequired, getToken } =
-    useTokens();
+  const {
+    refetchAllowances,
+    approvalsRequired,
+    approvalRequired,
+    getToken,
+    injectSpenders,
+  } = useTokens();
   const { t } = useI18n();
   const { getSigner } = useWeb3();
   const { addTransaction } = useTransactions();
@@ -89,6 +94,7 @@ export default function useTokenApprovalActions() {
     amountsToApprove: AmountToApprove[],
     spender: string
   ): Promise<AmountToApprove[]> {
+    await injectSpenders([spender]);
     await refetchAllowances();
     return approvalsRequired(amountsToApprove, spender);
   }
@@ -97,6 +103,7 @@ export default function useTokenApprovalActions() {
     amountToApprove: AmountToApprove,
     spender: string
   ): Promise<boolean> {
+    await injectSpenders([spender]);
     await refetchAllowances();
     return !approvalRequired(
       amountToApprove.address,

--- a/src/composables/queries/useAllowancesQuery.spec.ts
+++ b/src/composables/queries/useAllowancesQuery.spec.ts
@@ -35,14 +35,14 @@ test('Returns token allowances from balancer SDK', async () => {
 
   initMulticall(generateMulticallMock(processCall));
 
-  const allowanceContracts = ref([
+  const spenders = ref([
     '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     '0x6320cD32aA674d2898A68ec82e869385Fc5f7E2f',
     '0x33A99Dcc4C85C014cf12626959111D5898bbCAbF',
   ]);
 
   const { result } = mountComposable(() =>
-    useAllowancesQuery(tokens, allowanceContracts)
+    useAllowancesQuery(tokens, spenders)
   );
 
   const data = await waitForQueryData(result);

--- a/src/providers/__mocks__/tokens.provider.fake.ts
+++ b/src/providers/__mocks__/tokens.provider.fake.ts
@@ -39,7 +39,7 @@ silenceConsoleLog(vi, message => message.startsWith('Fetching'));
 export interface TokensProviderState {
   loading: boolean;
   injectedTokens: TokenInfoMap;
-  allowanceContracts: string[];
+  spenders: string[];
   injectedPrices: TokenPrices;
 }
 

--- a/src/providers/__mocks__/tokens.provider.fake.ts
+++ b/src/providers/__mocks__/tokens.provider.fake.ts
@@ -89,6 +89,11 @@ export const fakeTokensProvider = (
   /**
    * METHODS
    */
+  async function injectSpenders(addresses: string[]): Promise<void> {
+    //TODO: add logic test scenarios using spenders in a more realistic way
+    return Promise.resolve();
+  }
+
   /**
    * Fetch price for a token
    */
@@ -147,6 +152,7 @@ export const fakeTokensProvider = (
     refetchBalances,
     refetchAllowances,
     hasBalance,
+    injectSpenders,
     priceFor,
     balanceFor,
     getMaxBalanceFor,

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -53,7 +53,7 @@ const { uris: tokenListUris } = tokenListService;
 export interface TokensProviderState {
   loading: boolean;
   injectedTokens: TokenInfoMap;
-  allowanceContracts: string[];
+  spenders: string[];
   injectedPrices: TokenPrices;
 }
 
@@ -87,7 +87,7 @@ export const tokensProvider = (
   const state: TokensProviderState = reactive({
     loading: true,
     injectedTokens: {},
-    allowanceContracts: compact([
+    spenders: compact([
       networkConfig.addresses.vault,
       networkConfig.tokens.Addresses.wstETH,
       configService.network.addresses.veBAL,
@@ -173,7 +173,7 @@ export const tokensProvider = (
     isRefetching: allowanceQueryRefetching,
     isError: allowancesQueryError,
     refetch: refetchAllowances,
-  } = useAllowancesQuery(tokens, toRef(state, 'allowanceContracts'));
+  } = useAllowancesQuery(tokens, toRef(state, 'spenders'));
 
   const prices = computed(
     (): TokenPrices => (priceData.value ? priceData.value : {})
@@ -279,6 +279,21 @@ export const tokensProvider = (
   }
 
   /**
+   * Injects contract addresses that could possibly spend the users tokens into
+   * the spenders map. E.g. This is used for injecting gauges into the map as they
+   * must be allowed to spend a users BPT in order to stake the BPT in the gauge.
+   */
+  async function injectSpenders(addresses: string[]): Promise<void> {
+    addresses = addresses.filter(a => a).map(getAddress);
+
+    state.spenders = [...new Set(state.spenders.concat(addresses))];
+
+    // Wait for balances/allowances to be fetched for newly injected tokens.
+    await nextTick();
+    await forChange(onchainDataLoading, false);
+  }
+
+  /**
    * Given query, filters tokens map by name, symbol or address.
    * If address is provided, search for address in tokens or injectToken
    */
@@ -344,14 +359,16 @@ export const tokensProvider = (
   function approvalRequired(
     tokenAddress: string,
     amount: string,
-    contractAddress = networkConfig.addresses.vault
+    spenderAddress = networkConfig.addresses.vault
   ): boolean {
     if (!amount || bnum(amount).eq(0)) return false;
-    if (!contractAddress) return false;
+    if (!spenderAddress) return false;
     if (isSameAddress(tokenAddress, nativeAsset.address)) return false;
 
     const allowance = bnum(
-      (allowances.value[contractAddress] || {})[getAddress(tokenAddress)]
+      (allowances.value[getAddress(spenderAddress)] || {})[
+        getAddress(tokenAddress)
+      ]
     );
     return allowance.lt(amount);
   }
@@ -510,6 +527,7 @@ export const tokensProvider = (
     refetchBalances,
     refetchAllowances,
     injectTokens,
+    injectSpenders,
     searchTokens,
     hasBalance,
     approvalRequired,


### PR DESCRIPTION
This adds the post allowance validation from #3515 back into BalActionSteps. 

It had a bug previously where no one was able to stake their BPT because we didn't think they had allowed it to be spent. This happened because the allowances query only checks spenders of the vault, wstETH and veBAL. It doesn't check if a gauge can spend a users BPT. 

The bug was fixed by allowing injecting of new spenders, and injecting the gauge into the spenders list before the user stakes their BPT. 

I renamed `allowanceContracts` to `spenders` as that's how the ERC20 standard refers to them, it made it less confusing to understand, and they might not be contracts (you can allow normal EOA's to be a spender of your tokens). 

This also fixes a minor bug we didn't notice before: Users had to re-allow their BPT every time they staked previously, now they don't have to do that. 

This could be made faster by not re-fetching all allowances after the injection and only fetching the allowances of that gauge, but that could come in a future PR. 

## Testing

- Invest in a pool 
- Try and stake those BPT. It should work correctly. 
- Unstake and restake the BPT, if you allowed max previously it should not ask for an approval again. 
- Check normal swaps allowances work correctly. 