### PR TITLE
Hotfix - Improve allowance check on Gnosis Chain

### DIFF
--- a/src/composables/approvals/useTokenApprovalActions.ts
+++ b/src/composables/approvals/useTokenApprovalActions.ts
@@ -37,8 +37,13 @@ export default function useTokenApprovalActions() {
   /**
    * COMPOSABLES
    */
-  const { approvalsRequired, approvalRequired, getToken, injectSpenders } =
-    useTokens();
+  const {
+    refetchAllowances,
+    approvalsRequired,
+    approvalRequired,
+    getToken,
+    injectSpenders,
+  } = useTokens();
   const { t } = useI18n();
   const { getSigner } = useWeb3();
   const { addTransaction } = useTransactions();
@@ -99,6 +104,7 @@ export default function useTokenApprovalActions() {
     spender: string
   ): Promise<boolean> {
     await injectSpenders([spender]);
+    await refetchAllowances();
 
     return !approvalRequired(
       amountToApprove.address,

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -18,7 +18,7 @@ const config: Config = {
   unknown: false,
   visibleInUI: true,
   testNetwork: false,
-  rpc: 'https://poa-xdai.gateway.pokt.network/v1/lb/91bc0e12a76e7a84dd76189d',
+  rpc: 'https://rpc.gnosischain.com',
   ws: 'wss://rpc.gnosischain.com/wss',
   publicRpc: 'https://rpc.gnosis.gateway.fm',
   explorer: 'https://gnosisscan.io',


### PR DESCRIPTION
# Description

- Refetch allowances before running the `isApprovalValid` action as sometimes it won't pick up the newly approved allowance (especially on Gnosis chain).
- Switch Gnosis chain to the official RPC as it seems to be more reliable than pokt. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Join a pool or stake on Gnosis Chain
- Ensure you don't get any errors about not having enough allowance. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
