### PR TITLE
Ignore user errors in more places

### DIFF
--- a/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
+++ b/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
@@ -24,6 +24,7 @@ import { VeBalLockInfo } from '@/services/balancer/contracts/contracts/veBAL';
 import { ApprovalAction } from '@/composables/approvals/types';
 import { captureException } from '@sentry/browser';
 import useTokenApprovalActions from '@/composables/approvals/useTokenApprovalActions';
+import { isUserRejected } from '@/composables/useTransactionErrors';
 
 /**
  * TYPES
@@ -187,13 +188,15 @@ async function submit(lockType: LockType, actionIndex: number) {
 
     // An exception is already logged in balancerContractsService, but we should
     // log another here in case any exceptions are thrown before it's sent
-    captureException(error, {
-      level: 'fatal',
-      extra: {
-        lockType,
-        props,
-      },
-    });
+    if (!isUserRejected(error)) {
+      captureException(error, {
+        level: 'fatal',
+        extra: {
+          lockType,
+          props,
+        },
+      });
+    }
 
     return Promise.reject(error);
   }

--- a/src/providers/local/join-pool.provider.ts
+++ b/src/providers/local/join-pool.provider.ts
@@ -49,6 +49,7 @@ import useTokenApprovalActions from '@/composables/approvals/useTokenApprovalAct
 import { useApp } from '@/composables/useApp';
 import { throwQueryError } from '@/lib/utils/queries';
 import { ApprovalAction } from '@/composables/approvals/types';
+import { isUserRejected } from '@/composables/useTransactionErrors';
 
 /**
  * TYPES
@@ -375,6 +376,8 @@ export const joinPoolProvider = (
   }
 
   async function logJoinException(error: Error) {
+    if (isUserRejected(error)) return;
+
     const sender = await getSigner().getAddress();
     captureException(error, {
       level: 'fatal',


### PR DESCRIPTION
# Description

When a user rejects a join or lock transaction it still logs an error to sentry. Add additional checks for these errors to skip logging them. 

Fixes https://balancer-labs.sentry.io/issues/3905587191/?project=5725878&query=is%3Aunresolved+level%3Afatal&referrer=issue-stream&statsPeriod=14d&stream_index=2

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Perform a join transaction and reject it when the metamask window pops up. Ensure that this rejection is not logged to Sentry

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
