### PR TITLE
More ignoring of user errors and improvements to error handling

### DIFF
--- a/src/components/contextual/pages/claim/LegacyClaims.vue
+++ b/src/components/contextual/pages/claim/LegacyClaims.vue
@@ -7,7 +7,7 @@ import useUserClaimsQuery from '@/composables/queries/useUserClaimsQuery';
 import useEthers from '@/composables/useEthers';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { useTokens } from '@/providers/tokens.provider';
-import useTranasactionErrors from '@/composables/useTransactionErrors';
+import useTransactionErrors from '@/composables/useTransactionErrors';
 import useTransactions from '@/composables/useTransactions';
 import { TOKENS } from '@/constants/tokens';
 import { bnum } from '@/lib/utils';
@@ -55,7 +55,7 @@ const { account, getProvider, isMismatchedNetwork } = useWeb3();
 const { txListener } = useEthers();
 const { addTransaction } = useTransactions();
 const { priceFor, getToken } = useTokens();
-const { parseError } = useTranasactionErrors();
+const { parseError } = useTransactionErrors();
 
 const BALTokenAddress = getAddress(TOKENS.Addresses.BAL);
 

--- a/src/composables/swap/useCowswap.ts
+++ b/src/composables/swap/useCowswap.ts
@@ -21,7 +21,7 @@ import useTransactions from '../useTransactions';
 import { SwapQuote } from './types';
 import { captureException } from '@sentry/browser';
 import { Goals, trackGoal } from '../useFathom';
-import useTranasactionErrors from '../useTransactionErrors';
+import useTransactionErrors from '../useTransactionErrors';
 import { useI18n } from 'vue-i18n';
 import { useApp } from '@/composables/useApp';
 
@@ -93,7 +93,7 @@ export default function useCowswap({
   const { addTransaction } = useTransactions();
   const { fNum } = useNumbers();
   const { balanceFor } = useTokens();
-  const { isUserRejected } = useTranasactionErrors();
+  const { isUserRejected } = useTransactionErrors();
   const { t } = useI18n();
 
   // DATA

--- a/src/composables/swap/useJoinExit.ts
+++ b/src/composables/swap/useJoinExit.ts
@@ -28,7 +28,7 @@ import useEthers from '../useEthers';
 import useRelayerApprovalQuery from '@/composables/queries/useRelayerApprovalQuery';
 import { TransactionBuilder } from '@/services/web3/transactions/transaction.builder';
 import BatchRelayerAbi from '@/lib/abi/BatchRelayer.json';
-import useTranasactionErrors from '../useTransactionErrors';
+import useTransactionErrors from '../useTransactionErrors';
 import { useI18n } from 'vue-i18n';
 
 type JoinExitState = {
@@ -91,7 +91,7 @@ export default function useJoinExit({
   const { addTransaction } = useTransactions();
   const { txListener } = useEthers();
   const { fNum } = useNumbers();
-  const { isUserRejected } = useTranasactionErrors();
+  const { isUserRejected } = useTransactionErrors();
   const { t } = useI18n();
 
   const hasValidationError = computed(

--- a/src/composables/swap/useSor.ts
+++ b/src/composables/swap/useSor.ts
@@ -43,7 +43,7 @@ import useTransactions, { TransactionAction } from '../useTransactions';
 import { SwapQuote } from './types';
 import { captureException } from '@sentry/browser';
 import { overflowProtected } from '@/components/_global/BalTextInput/helpers';
-import useTranasactionErrors from '../useTransactionErrors';
+import useTransactionErrors from '../useTransactionErrors';
 
 type SorState = {
   validationErrors: {
@@ -204,7 +204,7 @@ export default function useSor({
   const { fNum, toFiat } = useNumbers();
   const { t } = useI18n();
   const { injectTokens, priceFor, getToken } = useTokens();
-  const { isUserRejected } = useTranasactionErrors();
+  const { isUserRejected } = useTransactionErrors();
   const { swapIn, swapOut } = useSwapper();
 
   onMounted(async () => {

--- a/src/composables/useTransactionErrors.spec.ts
+++ b/src/composables/useTransactionErrors.spec.ts
@@ -40,6 +40,7 @@ describe('useTransactionErrors', () => {
       expect(isUserRejected(rejectionError)).toBe(true);
     });
 
+    // See https://balancer-labs.sentry.io/issues/4199718124/events/f1a41824e66141b4806c50db5f081f7b/
     it('Should return true if its a user error where they are out of gas', () => {
       const rejectionError = {
         code: 5002,

--- a/src/composables/useTransactionErrors.spec.ts
+++ b/src/composables/useTransactionErrors.spec.ts
@@ -49,5 +49,14 @@ describe('useTransactionErrors', () => {
       };
       expect(isUserRejected(rejectionError)).toBe(true);
     });
+
+    // See https://balancer-labs.sentry.io/issues/4199718124/events/57d26b71647046f2be3620f3c0165714/
+    it('Should return true if its a user error as an object', () => {
+      const rejectionError = {
+        code: 5001,
+        message: 'User disapproved requested methods',
+      };
+      expect(isUserRejected(rejectionError)).toBe(true);
+    });
   });
 });

--- a/src/composables/useTransactionErrors.spec.ts
+++ b/src/composables/useTransactionErrors.spec.ts
@@ -1,7 +1,7 @@
 import { WalletError } from '@/types';
 import { isUserRejected } from './useTransactionErrors';
 
-describe('userTransactionErrors', () => {
+describe('useTransactionErrors', () => {
   describe('isUserRejected', () => {
     it('Should return false for a non-user error', () => {
       const error = new Error('Unsupported Exit Type For Pool');

--- a/src/composables/useTransactionErrors.spec.ts
+++ b/src/composables/useTransactionErrors.spec.ts
@@ -33,5 +33,11 @@ describe('useTransactionErrors', () => {
       rejectionError.code = 4001;
       expect(isUserRejected(rejectionError)).toBe(true);
     });
+
+    // See https://balancer-labs.sentry.io/issues/4199718124/events/74a6db95ab424cd6a286af7a00076d2c/
+    it('Should return true if the error is an object with a and b parameters', () => {
+      const rejectionError = { a: -500, b: 'Cancelled by User' };
+      expect(isUserRejected(rejectionError)).toBe(true);
+    });
   });
 });

--- a/src/composables/useTransactionErrors.spec.ts
+++ b/src/composables/useTransactionErrors.spec.ts
@@ -39,5 +39,14 @@ describe('useTransactionErrors', () => {
       const rejectionError = { a: -500, b: 'Cancelled by User' };
       expect(isUserRejected(rejectionError)).toBe(true);
     });
+
+    it('Should return true if its a user error where they are out of gas', () => {
+      const rejectionError = {
+        code: 5002,
+        message:
+          "User rejected methods. Your wallet doesn't have enough Ethereum to start this transfer.",
+      };
+      expect(isUserRejected(rejectionError)).toBe(true);
+    });
   });
 });

--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -48,6 +48,9 @@ export function isUserRejected(error): boolean {
   )
     return true;
 
+  if (error.b && userRejectionMessages.includes(error.b.toLowerCase()))
+    return true;
+
   if (error?.code && error.code === 4001) {
     return true;
   }

--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -16,6 +16,7 @@ export function isUserRejected(error): boolean {
     /transaction declined/,
     /transaction was rejected/,
     /user denied transaction signature/,
+    /user disapproved requested methods/,
   ];
 
   if (

--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -57,7 +57,7 @@ export function isUserRejected(error): boolean {
   return false;
 }
 
-export default function useTranasactionErrors() {
+export default function useTransactionErrors() {
   /**
    * COMPOSABLES
    */

--- a/src/composables/useTransactionErrors.ts
+++ b/src/composables/useTransactionErrors.ts
@@ -6,49 +6,54 @@ export function isUserRejected(error): boolean {
   if (!error) return false;
 
   const userRejectionMessages = [
-    'user rejected transaction',
-    'request rejected',
-    'user rejected methods.',
-    'user rejected the transaction',
-    'rejected by user',
-    'user canceled',
-    'cancelled by user',
-    'transaction declined',
-    'transaction was rejected',
-    'user denied transaction signature',
+    /user rejected transaction/,
+    /request rejected/,
+    /user rejected methods./,
+    /user rejected the transaction/,
+    /rejected by user/,
+    /user canceled/,
+    /cancelled by user/,
+    /transaction declined/,
+    /transaction was rejected/,
+    /user denied transaction signature/,
   ];
 
   if (
     typeof error === 'string' &&
-    userRejectionMessages.includes(error.toLowerCase())
+    userRejectionMessages.some(msg => msg.test(error.toLowerCase()))
   )
     return true;
 
   if (
     error.message &&
-    userRejectionMessages.includes(error.message.toLowerCase())
+    userRejectionMessages.some(msg => msg.test(error.message.toLowerCase()))
   )
     return true;
 
   if (
     typeof error.reason === 'string' &&
-    userRejectionMessages.includes(error.reason.toLowerCase())
+    userRejectionMessages.some(msg => msg.test(error.reason.toLowerCase()))
   )
     return true;
 
   if (
     error.cause?.message &&
-    userRejectionMessages.includes(error.cause.message.toLowerCase())
+    userRejectionMessages.some(msg =>
+      msg.test(error.cause.message.toLowerCase())
+    )
   )
     return true;
 
   if (
     typeof error.cause === 'string' &&
-    userRejectionMessages.includes(error.cause.toLowerCase())
+    userRejectionMessages.some(msg => msg.test(error.cause.toLowerCase()))
   )
     return true;
 
-  if (error.b && userRejectionMessages.includes(error.b.toLowerCase()))
+  if (
+    error.b &&
+    userRejectionMessages.some(msg => msg.test(error.b.toLowerCase()))
+  )
     return true;
 
   if (error?.code && error.code === 4001) {


### PR DESCRIPTION
# Description

- Rename useTransactions where it's misspelt
- Rename test file from user -> use. 
- Add more test cases for user errors found in sentry. 
- Change checks to regexes so they can match part of the error string instead of having to be an exact match. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
