### PR TITLE
fix: Missing tokens join call

### DIFF
--- a/src/components/forms/pool_actions/AddLiquidityForm/AddLiquidityForm.vue
+++ b/src/components/forms/pool_actions/AddLiquidityForm/AddLiquidityForm.vue
@@ -61,8 +61,7 @@ const {
   hasValidInputs,
   hasAmountsIn,
   queryError,
-  setAmountsIn,
-  addTokensIn,
+  setTokensIn,
 } = useJoinPool();
 
 const { tokensWithBalance } = useUserTokens();
@@ -101,14 +100,13 @@ const joinTokensWithoutBalance = computed<string[]>(() =>
 );
 
 async function initializeTokensForm(isSingleAssetJoin: boolean) {
-  setAmountsIn([]);
   if (isSingleAssetJoin) {
     // Single asset joins are only relevant for Composable pools where swap
     // joins are possible. In this case we want to default to the wrapped native
     // asset.
-    addTokensIn([wrappedNativeAsset.value.address]);
+    setTokensIn([wrappedNativeAsset.value.address]);
   } else {
-    addTokensIn(joinTokensWithBalance.value);
+    setTokensIn(joinTokensWithBalance.value);
   }
 }
 

--- a/src/providers/local/join-pool.provider.ts
+++ b/src/providers/local/join-pool.provider.ts
@@ -243,13 +243,13 @@ export const joinPoolProvider = (
   }
 
   /**
-   * Adds amountsIn with no value for array of token addresses.
+   * Sets amountsIn with no value for array of token addresses.
    *
    * @param {string[]} tokensIn - Array of token addresses.
    */
-  function addTokensIn(tokensIn: string[]) {
-    tokensIn.forEach(address =>
-      amountsIn.value.push({ address, value: '', valid: true })
+  function setTokensIn(tokensIn: string[]) {
+    setAmountsIn(
+      tokensIn.map(address => ({ address, value: '', valid: true }))
     );
   }
 
@@ -284,22 +284,31 @@ export const joinPoolProvider = (
       : tokenApprovalActions;
   }
 
+  // Checks amountsIn for valid inputs and updates price impact state if
+  // invalid.
+  function validateAmountsIn(): boolean {
+    if (!hasAmountsIn.value) {
+      priceImpact.value = 0;
+      return false;
+    }
+
+    return true;
+  }
+
   /**
    * Simulate join transaction to get expected output and calculate price impact.
    */
   async function queryJoin() {
     // If form is empty or inputs are not valid, clear the price impact and
     // return early
-    if (!hasAmountsIn.value) {
-      priceImpact.value = 0;
-      return null;
-    }
+    if (!validateAmountsIn()) return null;
 
     try {
       joinPoolService.setJoinHandler(joinHandlerType.value);
       await setApprovalActions();
 
       console.log('joinHandler:', joinHandlerType.value);
+      if (!validateAmountsIn()) return null;
       const output = await joinPoolService.queryJoin({
         amountsIn: amountsInWithValue.value,
         tokensIn: tokensIn.value,
@@ -456,7 +465,7 @@ export const joinPoolProvider = (
 
     // Methods
     setAmountsIn,
-    addTokensIn,
+    setTokensIn,
     resetAmounts,
     join,
     resetTxState,

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -469,7 +469,6 @@ export const tokensProvider = (
   ): string {
     let maxAmount;
     const tokenBalance = balanceFor(tokenAddress) || '0';
-    console.log({ tokenBalance });
     const tokenBalanceBN = bnum(tokenBalance);
 
     if (tokenAddress === nativeAsset.address && !disableNativeAssetBuffer) {


### PR DESCRIPTION
# Description

Might fix: https://balancer-labs.sentry.io/share/issue/4078ca967f574832828e73caf59b44b4/

- Ensures setAmountsIn is never called with an empty array on mounting components.
- Adds extra guard for join query after approval action promise.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

It's difficult to replicate this issue. I only replicated by keeping the add liquidity page open for a long time, leaving it un focused and then returning. My guess is that some kind of re-render caused the setAmountsIn to be reset as empty during a call to query the join.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
