### PR TITLE
refactor: Optimise pool page queries

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,8 +41,8 @@ const FocussedLayout = defineAsyncComponent(
 const ContentLayout = defineAsyncComponent(
   () => import('@/pages/_layouts/ContentLayout.vue')
 );
-const JoinExitLayout = defineAsyncComponent(
-  () => import('@/pages/_layouts/JoinExitLayout.vue')
+const PoolLayout = defineAsyncComponent(
+  () => import('@/pages/_layouts/PoolLayout.vue')
 );
 
 BigNumber.config({ DECIMAL_PLACES: DEFAULT_TOKEN_DECIMALS });
@@ -57,7 +57,7 @@ const Layouts = {
   ContentLayout: ContentLayout,
   DefaultLayout: DefaultLayout,
   FocussedLayout: FocussedLayout,
-  JoinExitLayout: JoinExitLayout,
+  PoolLayout: PoolLayout,
 };
 /**
  * COMPOSABLES

--- a/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
+++ b/src/components/contextual/pages/pool/MyPoolBalancesCard.vue
@@ -45,7 +45,7 @@ const { isMigratablePool } = usePoolHelpers(toRef(props, 'pool'));
 const { stakedShares } = usePoolStaking();
 const { networkSlug } = useNetwork();
 const router = useRouter();
-const { totalLockedValue } = useLock();
+const { totalLockedValue } = useLock({ enabled: isVeBalPool(props.pool.id) });
 
 /**
  * COMPUTED

--- a/src/components/layouts/DefaultLayout.vue
+++ b/src/components/layouts/DefaultLayout.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import Footer from '@/components/footer/Footer.vue';
+import AppNav from '@/components/navs/AppNav/AppNav.vue';
+</script>
+
+<template>
+  <div>
+    <div class="app-body">
+      <AppNav />
+      <div class="pb-16">
+        <slot />
+      </div>
+    </div>
+    <Footer />
+  </div>
+</template>
+
+<style>
+.VueQueryDevtoolsPanel + button {
+  @apply text-black bg-gray-100 p-2 rounded text-sm;
+}
+
+.app-body {
+  @apply mb-8;
+
+  min-height: calc(100vh - 2rem);
+}
+</style>

--- a/src/composables/queries/usePoolQuery.ts
+++ b/src/composables/queries/usePoolQuery.ts
@@ -79,7 +79,7 @@ export default function usePoolQuery(
     }
 
     // Inject pool tokens into token registry
-    await injectTokens([
+    injectTokens([
       ...tokensListExclBpt(pool),
       ...tokenTreeLeafs(pool.tokens),
       pool.address, // We need to inject pool addresses so we can fetch a user's balance for that pool.
@@ -90,6 +90,8 @@ export default function usePoolQuery(
 
   const queryOptions = reactive({
     enabled,
+    keepPreviousData: true,
+    refetchOnWindowFocus: false,
     ...options,
   });
 

--- a/src/pages/_layouts/DefaultLayout.vue
+++ b/src/pages/_layouts/DefaultLayout.vue
@@ -1,32 +1,13 @@
 <script setup lang="ts">
-import Footer from '@/components/footer/Footer.vue';
-import AppNav from '@/components/navs/AppNav/AppNav.vue';
+import DefaultLayout from '@/components/layouts/DefaultLayout.vue';
 </script>
 
 <template>
-  <div>
-    <div class="app-body">
-      <AppNav />
-      <div class="pb-16">
-        <router-view v-slot="{ Component }" :key="$route.path">
-          <transition appear name="appear">
-            <component :is="Component" />
-          </transition>
-        </router-view>
-      </div>
-    </div>
-    <Footer />
-  </div>
+  <DefaultLayout>
+    <router-view v-slot="{ Component }" :key="$route.path">
+      <transition appear name="appear">
+        <component :is="Component" />
+      </transition>
+    </router-view>
+  </DefaultLayout>
 </template>
-
-<style>
-.VueQueryDevtoolsPanel + button {
-  @apply text-black bg-gray-100 p-2 rounded text-sm;
-}
-
-.app-body {
-  @apply mb-8;
-
-  min-height: calc(100vh - 2rem);
-}
-</style>

--- a/src/pages/_layouts/PoolLayout.vue
+++ b/src/pages/_layouts/PoolLayout.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import FocussedLayout from '@/components/layouts/FocussedLayout.vue';
+import DefaultLayout from '@/components/layouts/DefaultLayout.vue';
 import { providePoolStaking } from '@/providers/local/pool-staking.provider';
 import { providePool } from '@/providers/local/pool.provider';
 import { provideUserTokens } from '@/providers/local/user-tokens.provider';
@@ -11,6 +12,17 @@ const route = useRoute();
 const poolId = (route.params.id as string).toLowerCase();
 
 /**
+ * COMPUTED
+ */
+const isJoinOrExitPath = computed(
+  () => route.path.includes('add-liquidity') || route.path.includes('withdraw')
+);
+
+const layoutComponent = computed(() =>
+  isJoinOrExitPath.value ? FocussedLayout : DefaultLayout
+);
+
+/**
  * PROVIDERS
  */
 providePool(poolId);
@@ -19,11 +31,11 @@ provideUserTokens();
 </script>
 
 <template>
-  <FocussedLayout>
+  <component :is="layoutComponent">
     <router-view v-slot="{ Component }" :key="$route.path">
       <transition appear name="appear">
         <component :is="Component" />
       </transition>
     </router-view>
-  </FocussedLayout>
+  </component>
 </template>

--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -91,12 +91,13 @@ const routes: RouteRecordRaw[] = [
     path: '/:networkSlug/pool/:id',
     name: 'pool',
     component: PoolPage,
+    meta: { layout: 'PoolLayout' },
   },
   {
     path: '/:networkSlug/pool/:id/add-liquidity',
     name: 'add-liquidity',
     component: PoolAddLiquidityPage,
-    meta: { layout: 'JoinExitLayout' },
+    meta: { layout: 'PoolLayout' },
   },
   {
     path: '/:networkSlug/pool/:id/invest',
@@ -109,7 +110,7 @@ const routes: RouteRecordRaw[] = [
     path: '/:networkSlug/pool/:id/withdraw',
     name: 'withdraw',
     component: PoolWithdrawPage,
-    meta: { layout: 'JoinExitLayout' },
+    meta: { layout: 'PoolLayout' },
   },
   {
     path: '/:networkSlug/vebal',

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -77,6 +77,8 @@ export const tokensProvider = (
   /**
    * STATE
    */
+  const queriesEnabled = ref(false);
+
   const nativeAsset: NativeAsset = {
     ...networkConfig.nativeAsset,
     chainId: networkConfig.chainId,
@@ -162,7 +164,7 @@ export const tokensProvider = (
     isRefetching: balanceQueryRefetching,
     isError: balancesQueryError,
     refetch: refetchBalances,
-  } = useBalancesQuery(tokens);
+  } = useBalancesQuery(tokens, { enabled: queriesEnabled });
 
   const {
     data: allowanceData,
@@ -171,7 +173,9 @@ export const tokensProvider = (
     isRefetching: allowanceQueryRefetching,
     isError: allowancesQueryError,
     refetch: refetchAllowances,
-  } = useAllowancesQuery(tokens, toRef(state, 'spenders'));
+  } = useAllowancesQuery(tokens, toRef(state, 'spenders'), {
+    enabled: queriesEnabled,
+  });
 
   const prices = computed(
     (): TokenPrices => (priceData.value ? priceData.value : {})
@@ -494,6 +498,7 @@ export const tokensProvider = (
     // Inject veBAL because it's not in tokenlists.
     const { veBAL } = configService.network.addresses;
     await injectTokens([veBAL]);
+    queriesEnabled.value = true;
     state.loading = false;
   });
 


### PR DESCRIPTION
# Description

- Uses pool provider on pool page.
- Refactors layouts so that pool page + nested join/exit flows use the same layout and providers.
- Optimises tokens provider to avoid running queries before vebal has been injected.
- Optimises usePoolQuery to not wait for token injection, this used to be important when prices were also dependent on token injection.

## Type of change

- [x] Code refactor / cleanup

## How should this be tested?

- [ ] Check network requests on pool pages.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
