### PR TITLE
fix: Pass isEnabled to balance/allowance queries

### DIFF
--- a/src/composables/queries/useAllowancesQuery.spec.ts
+++ b/src/composables/queries/useAllowancesQuery.spec.ts
@@ -42,7 +42,7 @@ test('Returns token allowances from balancer SDK', async () => {
   ]);
 
   const { result } = mountComposable(() =>
-    useAllowancesQuery(tokens, spenders)
+    useAllowancesQuery({ tokens, contractAddresses: spenders })
   );
 
   const data = await waitForQueryData(result);

--- a/src/composables/queries/useAllowancesQuery.ts
+++ b/src/composables/queries/useAllowancesQuery.ts
@@ -14,15 +14,20 @@ import useNetwork from '../useNetwork';
  */
 type QueryResponse = ContractAllowancesMap;
 type QueryOptions = UseQueryOptions<QueryResponse>;
+interface QueryInputs {
+  tokens: Ref<TokenInfoMap>;
+  contractAddresses: Ref<string[]>;
+  isEnabled?: Ref<boolean>;
+}
 
 /**
  * Fetches all allowances for given tokens for each provided contract address.
  */
-export default function useAllowancesQuery(
-  tokens: Ref<TokenInfoMap> = ref({}),
-  contractAddresses: Ref<string[]> = ref([]),
-  options: QueryOptions = {}
-) {
+export default function useAllowancesQuery({
+  tokens,
+  contractAddresses,
+  isEnabled = ref(true),
+}: QueryInputs) {
   /**
    * COMPOSABLES
    */
@@ -32,7 +37,7 @@ export default function useAllowancesQuery(
   /**
    * COMPUTED
    */
-  const enabled = computed(() => isWalletReady.value);
+  const enabled = computed(() => isWalletReady.value && isEnabled.value);
   const tokenAddresses = computed(() => Object.keys(tokens.value));
 
   /**
@@ -62,7 +67,6 @@ export default function useAllowancesQuery(
     enabled,
     keepPreviousData: true,
     refetchOnWindowFocus: false,
-    ...options,
   });
 
   return useQuery<QueryResponse>(

--- a/src/composables/queries/useBalancesQuery.spec.ts
+++ b/src/composables/queries/useBalancesQuery.spec.ts
@@ -14,9 +14,7 @@ test('Returns token balances', async () => {
     [daiAddress]: aTokenInfo({ address: daiAddress }),
   });
 
-  const { result } = mountComposable(() =>
-    useBalancesQuery(tokens, { keepPreviousData: true })
-  );
+  const { result } = mountComposable(() => useBalancesQuery({ tokens }));
 
   const data = await waitForQueryData(result);
 

--- a/src/composables/queries/useBalancesQuery.ts
+++ b/src/composables/queries/useBalancesQuery.ts
@@ -15,14 +15,18 @@ import useNetwork from '../useNetwork';
  */
 type QueryResponse = BalanceMap;
 type QueryOptions = UseQueryOptions<QueryResponse>;
+interface QueryInputs {
+  tokens: Ref<TokenInfoMap>;
+  isEnabled?: Ref<boolean>;
+}
 
 /**
  * Fetches all balances for provided tokens.
  */
-export default function useBalancesQuery(
-  tokens: Ref<TokenInfoMap> = ref({}),
-  options: QueryOptions = {}
-) {
+export default function useBalancesQuery({
+  tokens,
+  isEnabled = ref(true),
+}: QueryInputs) {
   /**
    * COMPOSABLES
    */
@@ -32,7 +36,7 @@ export default function useBalancesQuery(
   /**
    * COMPUTED
    */
-  const enabled = computed(() => isWalletReady.value);
+  const enabled = computed(() => isWalletReady.value && isEnabled.value);
   const tokenAddresses = computed(() => Object.keys(tokens.value));
 
   /**
@@ -51,7 +55,6 @@ export default function useBalancesQuery(
     enabled,
     keepPreviousData: true,
     refetchOnWindowFocus: false,
-    ...options,
   });
 
   return useQuery<QueryResponse>(

--- a/src/providers/tokens.provider.ts
+++ b/src/providers/tokens.provider.ts
@@ -164,7 +164,7 @@ export const tokensProvider = (
     isRefetching: balanceQueryRefetching,
     isError: balancesQueryError,
     refetch: refetchBalances,
-  } = useBalancesQuery(tokens, { enabled: queriesEnabled });
+  } = useBalancesQuery({ tokens, isEnabled: queriesEnabled });
 
   const {
     data: allowanceData,
@@ -173,8 +173,10 @@ export const tokensProvider = (
     isRefetching: allowanceQueryRefetching,
     isError: allowancesQueryError,
     refetch: refetchAllowances,
-  } = useAllowancesQuery(tokens, toRef(state, 'spenders'), {
-    enabled: queriesEnabled,
+  } = useAllowancesQuery({
+    tokens,
+    contractAddresses: toRef(state, 'spenders'),
+    isEnabled: queriesEnabled,
   });
 
   const prices = computed(


### PR DESCRIPTION
# Description

I introduced a bug by enabling balance/allowance queries with the query options object where it bypassed the wallet is connected check. So it was trying to fetch balances/allowances for accounts when no wallet was connected. This PR cleans up that code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Check for balance fetching errors in the console, there shouldn't be any.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
