### PR TITLE
chore: Balancer sor swap errors should be tagged as fatal

### DIFF
--- a/src/composables/swap/useSor.ts
+++ b/src/composables/swap/useSor.ts
@@ -196,7 +196,7 @@ export default function useSor({
   const poolsLoading = ref(true);
 
   // COMPOSABLES
-  const { getProvider: getWeb3Provider, appNetworkConfig } = useWeb3();
+  const { account, getProvider: getWeb3Provider, appNetworkConfig } = useWeb3();
   const provider = computed(() => getWeb3Provider());
   const { trackGoal, Goals } = useFathom();
   const { txListener } = useEthers();
@@ -635,7 +635,7 @@ export default function useSor({
         }
         trackSwapEvent();
       } catch (error) {
-        handleSwapException(error as Error);
+        handleSwapException(error as Error, tokenInAddress, tokenOutAddress);
       }
       return;
     } else if (wrapType.value == WrapType.Unwrap) {
@@ -655,7 +655,7 @@ export default function useSor({
         }
         trackSwapEvent();
       } catch (error) {
-        handleSwapException(error as Error);
+        handleSwapException(error as Error, tokenInAddress, tokenOutAddress);
       }
       return;
     }
@@ -679,7 +679,7 @@ export default function useSor({
         }
         trackSwapEvent();
       } catch (error) {
-        handleSwapException(error as Error);
+        handleSwapException(error as Error, tokenInAddress, tokenOutAddress);
       }
     } else {
       const tokenInAmountMax = getMaxIn(tokenInAmountScaled);
@@ -700,7 +700,7 @@ export default function useSor({
         }
         trackSwapEvent();
       } catch (error) {
-        handleSwapException(error as Error);
+        handleSwapException(error as Error, tokenInAddress, tokenOutAddress);
       }
     }
   }
@@ -797,11 +797,22 @@ export default function useSor({
     return amount;
   }
 
-  function handleSwapException(error: Error) {
+  function handleSwapException(
+    error: Error,
+    tokenIn: string,
+    tokenOut: string
+  ) {
     if (!isUserError(error)) {
       console.trace(error);
       state.submissionError = t('swapException', ['Balancer']);
-      captureException(new Error(state.submissionError, { cause: error }));
+      captureException(new Error(state.submissionError, { cause: error }), {
+        level: 'fatal',
+        extra: {
+          sender: account.value,
+          tokenIn,
+          tokenOut,
+        },
+      });
     }
     swapping.value = false;
     confirming.value = false;


### PR DESCRIPTION
# Description

Updates balancer swap capturing to tag as `fatal` and provide some extra context.

## Type of change

- [x] Other

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
