### PR TITLE
chore: Pass reciept to submit vote button

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/GaugeVoteModal.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugeVoteModal.vue
@@ -394,21 +394,6 @@ onMounted(() => {
           </li>
         </ul>
       </div>
-      <BalAlert
-        v-if="voteWarning"
-        type="warning"
-        :title="voteWarning.title"
-        :description="voteWarning.description"
-        class="mb-4 w-full rounded"
-      />
-      <BalAlert
-        v-if="voteError"
-        type="error"
-        :title="voteError.title"
-        :description="voteError.description"
-        block
-        class="mt-2 mb-4"
-      />
 
       <div
         class="flex justify-between items-center p-2 mb-4 rounded-lg border dark:border-gray-800"
@@ -473,9 +458,26 @@ onMounted(() => {
           </div>
         </template>
 
+        <BalAlert
+          v-if="voteWarning"
+          type="warning"
+          :title="voteWarning.title"
+          :description="voteWarning.description"
+          class="my-2 w-full rounded"
+        />
+        <BalAlert
+          v-if="voteError"
+          type="error"
+          :title="voteError.title"
+          :description="voteError.description"
+          block
+          class="mt-2 mb-4"
+        />
+
         <SubmitVoteBtn
           :disabled="voteButtonDisabled"
           :loading="transactionInProgress"
+          :receipt="voteState.receipt.value"
           class="mt-4"
           :loadingLabel="
             voteState.state.value === State.TRANSACTION_INITIALIZED

--- a/src/components/contextual/pages/vebal/LMVoting/SubmitVoteBtn.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/SubmitVoteBtn.vue
@@ -9,7 +9,7 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider';
 type Props = {
   disabled: boolean;
   loading: boolean;
-  receipt?: TransactionReceipt;
+  receipt?: TransactionReceipt | null;
 };
 
 /**


### PR DESCRIPTION
# Description

The submit vote button wasn't updating after a successful transaction because at some point the receipt prop had been removed. The button requires the transaction receipt state in order to present the confirmation indicator and button to close the modal instead of a button that prompts the user to resubmit the vote.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Submit a vote, check that the success state of the vote modal makes sense.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
