### PR TITLE
fix: zkevm tx confirmation callback

### DIFF
--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -51,7 +51,8 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const emit = defineEmits<{
-  (e: 'success', value: any): void;
+  (e: 'success', tx: TransactionReceipt, confirmedAt: string): void;
+  (e: 'failed'): void;
   (e: 'setCurrentActionIndex', value: number): void;
 }>();
 
@@ -230,7 +231,7 @@ async function handleTransaction(
         state.confirmedAt = dateTimeLabelFor(confirmedAt);
         state.confirmed = true;
         if (currentActionIndex.value >= actions.value.length - 1) {
-          emit('success', { receipt, confirmedAt: state.confirmedAt });
+          emit('success', receipt, state.confirmedAt);
         } else {
           currentActionIndex.value += 1;
         }
@@ -242,6 +243,7 @@ async function handleTransaction(
     },
     onTxFailed: () => {
       state.confirming = false;
+      emit('failed');
     },
   });
 }

--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -7,7 +7,6 @@
  * Useful if there are an arbitrary number of actions the user must take such as
  * "approve n tokens, then add liquidity to a pool.""
  */
-import { ChainId } from '@aave/protocol-js';
 import {
   TransactionReceipt,
   TransactionResponse,
@@ -17,7 +16,6 @@ import AnimatePresence from '@/components/animate/AnimatePresence.vue';
 import useEthers from '@/composables/useEthers';
 import { dateTimeLabelFor } from '@/composables/useTime';
 import useTransactionErrors from '@/composables/useTransactionErrors';
-import { configService } from '@/services/config/config.service';
 import { Step, StepState } from '@/types';
 import {
   TransactionAction,
@@ -27,6 +25,7 @@ import {
 import signature from '@/assets/images/icons/signature.svg';
 import { captureException } from '@sentry/core';
 import { useI18n } from 'vue-i18n';
+import { postConfirmationDelay } from '@/composables/useTransactions';
 
 /**
  * TYPES
@@ -221,11 +220,7 @@ async function handleTransaction(
     onTxConfirmed: async (receipt: TransactionReceipt) => {
       state.receipt = receipt;
 
-      // need to explicity wait for a number of confirmations
-      // on polygon
-      if (Number(configService.network.chainId) === ChainId.polygon) {
-        await tx.wait(10);
-      }
+      await postConfirmationDelay(tx);
 
       state.confirming = false;
 

--- a/src/components/contextual/pages/pool/staking/composables/useStakePreview.spec.ts
+++ b/src/components/contextual/pages/pool/staking/composables/useStakePreview.spec.ts
@@ -18,6 +18,7 @@ import {
   StakePreviewProps,
   useStakePreview,
 } from './useStakePreview';
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
 
 initDependenciesWithDefaultMocks();
 walletServiceInstance.setUserProvider(computed(() => walletProviderMock));
@@ -185,7 +186,7 @@ test('Handles staking action success', async () => {
 
   expect(isActionConfirmed.value).toBeFalse();
 
-  await handleSuccess({ receipt: vi.fn });
+  await handleSuccess({} as TransactionReceipt);
 
   expect(isActionConfirmed.value).toBeTrue();
   expect(emit).toHaveBeenCalledOnceWith('success');

--- a/src/components/contextual/pages/pool/staking/composables/useStakePreview.ts
+++ b/src/components/contextual/pages/pool/staking/composables/useStakePreview.ts
@@ -145,7 +145,7 @@ export function useStakePreview(props: StakePreviewProps, emit) {
     if (approvalActions) stakeActions.value.unshift(...approvalActions);
   }
 
-  async function handleSuccess({ receipt }) {
+  async function handleSuccess(receipt: TransactionReceipt) {
     isActionConfirmed.value = true;
     confirmationReceipt.value = receipt;
     await Promise.all([refetchBalances(), refetchAllPoolStakingData()]);

--- a/src/components/forms/pool_actions/AddLiquidityForm/components/AddLiquidityPreview/components/Actions.vue
+++ b/src/components/forms/pool_actions/AddLiquidityForm/components/AddLiquidityPreview/components/Actions.vue
@@ -77,19 +77,6 @@ async function handleSuccess(
   receipt: TransactionReceipt,
   confirmedAt: string
 ): Promise<void> {
-  addTransaction({
-    id: receipt.transactionHash,
-    type: 'tx',
-    action: 'invest',
-    summary: t('transactionSummary.investInPool', [
-      fNum(fiatValueOut.value, FNumFormats.fiat),
-      poolWeightsLabel(props.pool),
-    ]),
-    details: {
-      total: fNum(fiatValueOut.value, FNumFormats.fiat),
-      pool: props.pool,
-    },
-  });
   txState.receipt = receipt;
   txState.confirmedAt = confirmedAt;
   txState.confirmed = true;
@@ -105,8 +92,21 @@ async function submit(): Promise<TransactionResponse> {
   txState.init = true;
   try {
     const tx = await join();
-    console.log('tx', tx);
     txState.confirming = true;
+
+    addTransaction({
+      id: tx.hash,
+      type: 'tx',
+      action: 'invest',
+      summary: t('transactionSummary.investInPool', [
+        fNum(fiatValueOut.value, FNumFormats.fiat),
+        poolWeightsLabel(props.pool),
+      ]),
+      details: {
+        total: fNum(fiatValueOut.value, FNumFormats.fiat),
+        pool: props.pool,
+      },
+    });
 
     return tx;
   } catch (error) {

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/components/WithdrawActions.vue
@@ -111,22 +111,11 @@ async function handleSuccess(
   receipt: TransactionReceipt,
   confirmedAt: string
 ): Promise<void> {
-  addTransaction({
-    id: receipt.transactionHash,
-    type: 'tx',
-    action: 'withdraw',
-    summary: txSummary.value,
-    details: {
-      total: fNum(fiatTotalOut.value, FNumFormats.fiat),
-      pool: props.pool,
-    },
-  });
-
-  emit('success', receipt);
   txState.confirmed = true;
   txState.confirming = false;
   txState.receipt = receipt;
   txState.confirmedAt = confirmedAt;
+  emit('success', receipt);
 }
 
 function handleFailed(): void {
@@ -139,6 +128,17 @@ async function submit(): Promise<TransactionResponse> {
     const tx = await exit();
 
     txState.confirming = true;
+
+    addTransaction({
+      id: tx.hash,
+      type: 'tx',
+      action: 'withdraw',
+      summary: txSummary.value,
+      details: {
+        total: fNum(fiatTotalOut.value, FNumFormats.fiat),
+        pool: props.pool,
+      },
+    });
 
     return tx;
   } catch (error) {

--- a/src/composables/useNetwork.ts
+++ b/src/composables/useNetwork.ts
@@ -34,6 +34,7 @@ export const networkId = ref<Network>(NETWORK_ID);
 
 export const isMainnet = computed(() => networkId.value === Network.MAINNET);
 export const isPolygon = computed(() => networkId.value === Network.POLYGON);
+export const isZkevm = computed(() => networkId.value === Network.ZKEVM);
 export const isOptimism = computed(() => networkId.value === Network.OPTIMISM);
 export const isArbitrum = computed(() => networkId.value === Network.ARBITRUM);
 export const isGnosis = computed(() => networkId.value === Network.GNOSIS);

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -1,4 +1,7 @@
-import { TransactionReceipt } from '@ethersproject/providers';
+import {
+  TransactionReceipt,
+  TransactionResponse,
+} from '@ethersproject/providers';
 import { formatUnits } from '@ethersproject/units';
 import { merge, orderBy } from 'lodash';
 import { computed, ref } from 'vue';
@@ -16,6 +19,7 @@ import { CowswapTransactionDetails } from './swap/useCowswap';
 import { processedTxs } from './useEthers';
 import useNotifications from './useNotifications';
 import useNumbers, { FNumFormats } from './useNumbers';
+import { isPolygon, isZkevm } from './useNetwork';
 
 const WEEK_MS = 86_400_000 * 7;
 // Please update the schema version when making changes to the transaction structure.
@@ -251,6 +255,23 @@ function shouldCheckTx(transaction: Transaction, lastBlockNumber: number) {
     // otherwise every block
     return true;
   }
+}
+
+/**
+ * postConfirmationDelay
+ *
+ * Delay in N confirmations before a transaction is considered finalized for
+ * specific networks.
+ *
+ * @param {TransactionResponse} tx - The transaction to wait N confirmations for.
+ */
+export async function postConfirmationDelay(
+  tx: TransactionResponse
+): Promise<TransactionReceipt> {
+  if (isPolygon.value) return tx.wait(10);
+  if (isZkevm.value) return tx.wait(10);
+
+  return tx.wait(1);
 }
 
 export default function useTransactions() {


### PR DESCRIPTION
# Description

It's possible that zkevm rpc state mismatches/caching are causing problems with submitting transactions before approvals are finalized. Like we had already done for Polygon PoS, this PR introduces a 10 confirmation wait before we consider a tx finalized on zkevm.

Additionally, txListener was being used at two levels in several flows, we only need to listen in BalActionSteps and then emit the events to be handled at a higher level. This has been refactored where relevant.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test zkevm transactions

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
