### PR TITLE
Hotfix: Use JsonRpc provider for initial block number

### DIFF
--- a/src/services/rpc-provider/rpc-provider.service.spec.ts
+++ b/src/services/rpc-provider/rpc-provider.service.spec.ts
@@ -6,7 +6,9 @@ import { StaticJsonRpcBatchProvider } from './static-json-rpc-batch-provider';
 vi.mock('@ethersproject/providers', () => {
   return {
     JsonRpcProvider: vi.fn().mockImplementation(() => {
-      return {};
+      return {
+        once: vi.fn(),
+      };
     }),
     WebSocketProvider: vi.fn().mockImplementation(() => {
       return {

--- a/src/services/rpc-provider/rpc-provider.service.spec.ts
+++ b/src/services/rpc-provider/rpc-provider.service.spec.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider, WebSocketProvider } from '@ethersproject/providers';
+import { JsonRpcProvider } from '@ethersproject/providers';
 
 import RpcProviderService from '@/services/rpc-provider/rpc-provider.service';
 import { StaticJsonRpcBatchProvider } from './static-json-rpc-batch-provider';
@@ -6,11 +6,6 @@ import { StaticJsonRpcBatchProvider } from './static-json-rpc-batch-provider';
 vi.mock('@ethersproject/providers', () => {
   return {
     JsonRpcProvider: vi.fn().mockImplementation(() => {
-      return {
-        once: vi.fn(),
-      };
-    }),
-    WebSocketProvider: vi.fn().mockImplementation(() => {
       return {
         once: vi.fn(),
       };
@@ -32,12 +27,10 @@ describe('RPC provider service', () => {
     StaticJsonRpcBatchProvider,
     true
   );
-  const MockedWebSocketProvider = vi.mocked(WebSocketProvider, true);
 
   beforeEach(() => {
     MockedJsonRpcProvider.mockClear();
     MockedStaticJsonRpcBatchProvider.mockClear();
-    MockedWebSocketProvider.mockClear();
   });
 
   it('Instantiates the provider service', () => {
@@ -52,6 +45,6 @@ describe('RPC provider service', () => {
 
   it('Calls the WebSocketProvider', () => {
     new RpcProviderService().initBlockListener(() => ({}));
-    expect(WebSocketProvider).toHaveBeenCalledTimes(1);
+    expect(MockedJsonRpcProvider).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -1,5 +1,5 @@
 import { Network } from '@/lib/config';
-import { JsonRpcProvider, WebSocketProvider } from '@ethersproject/providers';
+import { JsonRpcProvider } from '@ethersproject/providers';
 
 import { configService } from '@/services/config/config.service';
 
@@ -15,8 +15,8 @@ export default class RpcProviderService {
   ) {}
 
   public initBlockListener(newBlockHandler: NewBlockHandler): void {
-    const wsProvider = new WebSocketProvider(this.config.ws);
-    wsProvider.once('block', newBlockNumber => {
+    const blockProvider = new JsonRpcProvider(this.config.rpc);
+    blockProvider.once('block', newBlockNumber => {
       let currentBlockNumber = newBlockNumber;
       newBlockHandler(currentBlockNumber);
       setInterval(() => {


### PR DESCRIPTION
# Description

zkEVM wasn't running scripts that update on every new block because it didn't have a websocket provider and we initialize our block counter via getting the current block number from the websocket provider (we used to listen to all blocks this way which is why we used websocket provider in the first place, but then we switched to an interval to save on Alchemy costs). 

Switching the provider to the normal RPC provider so blocks update on networks without a websocket provider set. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Ensure that block numbers are increasing via putting a breakpoint in this code on each network. Ensure the current block number is correct from the jsonRPC provider. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
