### PR TITLE
Hotfix - fix create pool allowances

### DIFF
--- a/src/components/cards/CreatePool/PreviewPool.vue
+++ b/src/components/cards/CreatePool/PreviewPool.vue
@@ -43,7 +43,7 @@ const {
   goBack,
   setActiveStep,
   sortSeedTokens,
-  getScaledAmounts,
+  getAmounts,
   saveState,
   getPoolSymbol,
 } = usePoolCreation();
@@ -89,7 +89,7 @@ const tokenAddresses = computed((): string[] => {
 });
 
 const tokenAmounts = computed((): string[] => {
-  return getScaledAmounts();
+  return getAmounts();
 });
 
 const hasMissingPoolNameOrSymbol = computed(() => {

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -375,6 +375,13 @@ export default function usePoolCreation() {
     return optimisedLiquidity;
   }
 
+  function getAmounts() {
+    const amounts = poolCreationState.seedTokens.map((token: PoolSeedToken) => {
+      return token.amount;
+    });
+    return amounts;
+  }
+
   function getScaledAmounts() {
     const scaledAmounts: string[] = poolCreationState.seedTokens.map(
       (token: PoolSeedToken) => {
@@ -583,6 +590,7 @@ export default function usePoolCreation() {
     updateTokenColors,
     goBack,
     getPoolSymbol,
+    getAmounts,
     getScaledAmounts,
     createPool,
     joinPool,


### PR DESCRIPTION
# Description

- The token allowance checks in pool creation were using scaled values when the allowance checker wants unscaled values. I noticed this when doing a swap it was checking for `0.5` BAL but when creating a pool it was checking for `500000000000000000` BAL being available. This meant the pool creation UI was only working when users had approved UINT256MAX amounts for their tokens, if they used the Metamask max value it thought they hadn't approved enough. 

Fixes a bug reported in Discord about having allowance issues creating a pool on Arbitrum. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Test creating a new pool in production arbitrum / polygon and only approving the amount of tokens required. It should error that the amount approved wasn't enough and continually ask for approval. 
- Test creating that same pool on this branch, you should now be able to continue and successfully create the pool. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
