### PR TITLE
Hotfix: Downgrade testnet failures to 'error' instead of 'fatal

### DIFF
--- a/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
+++ b/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
@@ -189,8 +189,9 @@ async function submit(lockType: LockType, actionIndex: number) {
     // An exception is already logged in balancerContractsService, but we should
     // log another here in case any exceptions are thrown before it's sent
     if (!isUserError(error)) {
+      const level = networkConfig.testNetwork ? 'error' : 'fatal';
       captureException(error, {
-        level: 'fatal',
+        level,
         extra: {
           lockType,
           props,

--- a/src/composables/swap/useJoinExit.ts
+++ b/src/composables/swap/useJoinExit.ts
@@ -239,8 +239,9 @@ export default function useJoinExit({
       if (!isUserError(error)) {
         console.trace(error);
         state.submissionError = t('swapException', ['Relayer']);
+        const level = configService.network.testNetwork ? 'error' : 'fatal';
         captureException(new Error(state.submissionError, { cause: error }), {
-          level: 'fatal',
+          level,
           extra: {
             sender: account.value,
             swapInfo: swapInfo.value,

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -45,6 +45,7 @@ import { safeInject } from '../inject';
 import { useApp } from '@/composables/useApp';
 import { POOLS } from '@/constants/pools';
 import { shouldIgnoreError } from '@/lib/utils/vue-query';
+import { configService } from '@/services/config/config.service';
 
 /**
  * TYPES
@@ -487,8 +488,9 @@ export const exitPoolProvider = (
     // Ignore error when queryExit fails once the tx has been confirmed
     if (txState.confirmed && queryError.value) return;
     const sender = await getSigner().getAddress();
+    const level = configService.network.testNetwork ? 'error' : 'fatal';
     captureException(error, {
-      level: 'fatal',
+      level,
       extra: {
         exitHandler: exitHandlerType.value,
         params: JSON.stringify(

--- a/src/providers/local/join-pool.provider.ts
+++ b/src/providers/local/join-pool.provider.ts
@@ -390,8 +390,9 @@ export const joinPoolProvider = (
     if (isUserError(error)) return;
 
     const sender = await getSigner().getAddress();
+    const level = appNetworkConfig.testNetwork ? 'error' : 'fatal';
     captureException(error, {
-      level: 'fatal',
+      level,
       extra: {
         joinHandler: joinHandlerType.value,
         params: JSON.stringify(

--- a/src/services/web3/transactions/concerns/contract.concern.ts
+++ b/src/services/web3/transactions/concerns/contract.concern.ts
@@ -16,6 +16,7 @@ import {
   EthersContract,
   getEthersContract,
 } from '@/dependencies/EthersContract';
+import { configService } from '@/services/config/config.service';
 
 export type SendTransactionOpts = {
   contractAddress: string;
@@ -115,9 +116,10 @@ export class ContractConcern extends TransactionConcern {
     const calldata = contract.interface.encodeFunctionData(action, params);
     const msgValue = overrides.value ? overrides.value.toString() : 0;
     const simulate = `https://dashboard.tenderly.co/balancer/v2/simulator/new?rawFunctionInput=${calldata}&block=${block}&blockIndex=0&from=${sender}&gas=8000000&gasPrice=0&value=${msgValue}&contractAddress=${contract.address}&network=${chainId}`;
+    const level = configService.network.testNetwork ? 'error' : 'fatal';
 
     captureException(error, {
-      level: 'fatal',
+      level,
       extra: {
         action,
         sender,

--- a/src/services/web3/transactions/concerns/raw.concern.ts
+++ b/src/services/web3/transactions/concerns/raw.concern.ts
@@ -11,6 +11,7 @@ import {
 } from '@ethersproject/providers';
 import { captureException } from '@sentry/browser';
 import { TransactionConcern } from './transaction.concern';
+import { configService } from '@/services/config/config.service';
 
 export class RawConcern extends TransactionConcern {
   constructor(private readonly signer: JsonRpcSigner) {
@@ -60,8 +61,10 @@ export class RawConcern extends TransactionConcern {
     const block = await this.signer.provider.getBlockNumber();
     const msgValue = options.value ? options.value.toString() : 0;
     const simulate = `https://dashboard.tenderly.co/balancer/v2/simulator/new?contractAddress=${options.to}&rawFunctionInput=${options.data}&block=${block}&blockIndex=0&from=${sender}&gas=8000000&gasPrice=0&value=${msgValue}&network=${chainId}`;
+    const level = configService.network.testNetwork ? 'error' : 'fatal';
+
     captureException(error, {
-      level: 'fatal',
+      level,
       extra: {
         sender,
         simulate,


### PR DESCRIPTION
# Description

We log out Goerli errors as fatal, when no one is losing money on them and they could be due to all kinds of bad state issues. 

I was thinking we could ignore them entirely but we might want to keep track of them to ensure *everyone* isn't having issues. So instead just make them error instead of fatal. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Perform normal transactions on Goerli / Mainnet and ensure they work as expected

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
