### PR TITLE
Hotfix: Composable stable v5 factory

### DIFF
--- a/src/lib/config/arbitrum/pools.ts
+++ b/src/lib/config/arbitrum/pools.ts
@@ -98,6 +98,7 @@ const pools: Pools = {
     '0xf1665e19bc105be4edd3739f88315cc699cc5b65': 'weightedPool', // Weighted Pool V3
     '0xc7e5ed1054a24ef31d827e6f86caa58b3bc168d7': 'weightedPool', // weighted pool v4
     '0x2498a2b0d6462d2260eac50ae1c3e03f4829ba95': 'composableStablePool', // ComposableStable V4
+    '0xa8920455934da4d853faac1f94fe7bef72943ef1': 'composableStablePool', // ComposableStable V5
   },
   Stakable: {
     VotingGaugePools: [

--- a/src/lib/config/mainnet/pools.ts
+++ b/src/lib/config/mainnet/pools.ts
@@ -172,6 +172,7 @@ const pools: Pools = {
     '0x81fe9e5b28da92ae949b705dfdb225f7a7cc5134': 'fx', // fx
     '0x897888115ada5773e02aa29f775430bfb5f34c51': 'weightedPool', // weighted pool v4
     '0x5f43fba61f63fa6bff101a0a0458cea917f6b347': 'eulerLinear',
+    '0xdb8d758bcb971e482b2c45f7f8a7740283a1bd3a': 'composableStablePool', // ComposableStable v5
   },
   Stakable: {
     VotingGaugePools: [

--- a/src/lib/config/polygon/pools.ts
+++ b/src/lib/config/polygon/pools.ts
@@ -147,6 +147,7 @@ const pools: Pools = {
     '0x627d759314d5c4007b461a74ebafa7ebc5dfed71': 'fx', // fx
     '0xfc8a407bba312ac761d8bfe04ce1201904842b76': 'weightedPool', // weighted pool v4
     '0x1a79a24db0f73e9087205287761fc9c5c305926b': 'gyroE',
+    '0xe2fa4e1d17725e72dcdafe943ecf45df4b9e285b': 'composableStablePool', // ComposableStable V5
   },
   Stakable: {
     VotingGaugePools: [


### PR DESCRIPTION
# Description

Add Composable Stable V5 factory to pools list so pools created by it show as ComposableStable type instead of unknown type. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Visit recently created Composable Stable pools (See https://github.com/balancer/frontend-v2/pull/3685/files) and ensure they show as ComposableStable type and not Unkonwn Type

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
