### PR TITLE
Hotfix: Add approval check to swap

### DIFF
--- a/src/components/cards/SwapCard/SwapCard.vue
+++ b/src/components/cards/SwapCard/SwapCard.vue
@@ -262,10 +262,10 @@ export default defineComponent({
     });
     const title = computed(() => {
       if (swapping.wrapType.value === WrapType.Wrap) {
-        return `${t('wrap')} ${swapping.tokenIn.value.symbol}`;
+        return `${t('wrap')} ${swapping.tokenIn.value?.symbol}`;
       }
       if (swapping.wrapType.value === WrapType.Unwrap) {
-        return `${t('unwrap')} ${swapping.tokenOut.value.symbol}`;
+        return `${t('unwrap')} ${swapping.tokenOut.value?.symbol}`;
       }
       return t('swap');
     });

--- a/src/components/modals/SwapPreviewModal.vue
+++ b/src/components/modals/SwapPreviewModal.vue
@@ -11,9 +11,12 @@ import useRelayerApproval, {
   RelayerType,
 } from '@/composables/approvals/useRelayerApproval';
 import useRelayerApprovalTx from '@/composables/approvals/useRelayerApprovalTx';
-import useTokenApproval from '@/composables/approvals/useTokenApproval';
+// import useTokenApproval from '@/composables/approvals/useTokenApproval';
+import useTokenApprovalActions from '@/composables/approvals/useTokenApprovalActions';
+import { ApprovalAction } from '@/composables/approvals/types';
 import { UseSwapping } from '@/composables/swap/useSwapping';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
+import useNetwork from '@/composables/useNetwork';
 import { useTokens } from '@/providers/tokens.provider';
 import { useUserSettings } from '@/providers/user-settings.provider';
 import { FiatCurrency } from '@/constants/currency';
@@ -22,7 +25,6 @@ import { isStETH } from '@/lib/utils/balancer/lido';
 import { getWrapAction, WrapType } from '@/lib/utils/balancer/wrapper';
 import useWeb3 from '@/services/web3/useWeb3';
 import { TransactionActionInfo } from '@/types/transactions';
-import { TransactionResponse } from '@ethersproject/abstract-provider';
 
 const PRICE_UPDATE_THRESHOLD = 0.02;
 
@@ -43,9 +45,10 @@ const emit = defineEmits(['swap', 'close']);
  */
 const { t } = useI18n();
 const { fNum, toFiat } = useNumbers();
-const { tokens, balanceFor, approvalRequired } = useTokens();
+const { balanceFor } = useTokens();
 const { blockNumber, account, startConnectWithInjectedProvider } = useWeb3();
 const { slippage } = useUserSettings();
+const { networkConfig } = useNetwork();
 
 /**
  * STATE
@@ -257,11 +260,8 @@ const isStETHSwap = computed(
     wrapType.value === WrapType.NonWrap
 );
 
-const tokenApproval = useTokenApproval(
-  addressIn,
-  props.swapping.tokenInAmountInput,
-  tokens
-);
+const { getTokenApprovalActions } = useTokenApprovalActions();
+const tokenApprovalActions = ref<TransactionActionInfo[]>([]);
 
 const {
   relayerSignature: batchRelayerSignature,
@@ -281,19 +281,6 @@ const pools = computed<SubgraphPoolBase[]>(() => {
   return props.swapping.sor.pools.value;
 });
 
-const requiresTokenApproval = computed(() => {
-  if (props.swapping.isWrap.value && !props.swapping.isEthSwap.value) {
-    return approvalRequired(
-      props.swapping.tokenIn.value.address,
-      props.swapping.tokenInAmountInput.value,
-      props.swapping.tokenOut.value.address
-    );
-  } else if (props.swapping.requiresTokenApproval.value) {
-    return !tokenApproval.isUnlockedV2.value;
-  }
-  return false;
-});
-
 const requiresBatchRelayerApproval = computed(
   () =>
     props.swapping.isJoinExitSwap.value &&
@@ -311,13 +298,6 @@ const requiresCowswapRelayerApproval = computed(
 const requiresLidoRelayerApproval = computed(
   () =>
     props.swapping.isBalancerSwap.value && !lidoRelayerApproval.isUnlocked.value
-);
-
-const showTokenApprovalStep = computed(
-  () =>
-    requiresTokenApproval.value ||
-    tokenApproval.approved.value ||
-    tokenApproval.approving.value
 );
 
 const showBatchRelayerApprovalStep = computed(
@@ -347,8 +327,7 @@ const requiresApproval = computed(
   () =>
     requiresBatchRelayerApproval.value ||
     requiresCowswapRelayerApproval.value ||
-    requiresLidoRelayerApproval.value ||
-    requiresTokenApproval.value
+    requiresLidoRelayerApproval.value
 );
 
 const showPriceUpdateError = computed(
@@ -367,18 +346,8 @@ const actions = computed((): TransactionActionInfo[] => {
     actions.push(batchRelayerApprovalAction.value);
   }
 
-  if (showTokenApprovalStep.value) {
-    actions.push({
-      label: t('transactionSummary.approveForSwapping', [
-        props.swapping.tokenIn.value.symbol,
-      ]),
-      loadingLabel: t('actionSteps.approve.loadingLabel'),
-      confirmingLabel: t('confirming'),
-      action: approveToken,
-      stepTooltip: t(
-        'swapSummary.transactionTypesTooltips.tokenApproval.content'
-      ),
-    });
+  if (tokenApprovalActions.value.length > 0) {
+    actions.push(tokenApprovalActions.value[0]);
   }
 
   actions.push({
@@ -466,21 +435,37 @@ function handlePriceUpdate() {
   }
 }
 
-async function approveToken(): Promise<TransactionResponse> {
+const tokenApprovalSpender = computed<string>(() => {
   if (props.swapping.isWrap.value && !props.swapping.isEthSwap.value) {
     // If we're wrapping a token other than native ETH
     // we need to approve the underlying on the wrapper
-    return tokenApproval.approveSpender(props.swapping.tokenOut.value.address);
+    return props.swapping.tokenOut.value.address;
   } else {
-    return tokenApproval.approveV2();
+    return networkConfig.addresses.vault;
   }
-}
+});
 
 /**
  * WATCHERS
  */
 watch(blockNumber, () => {
   handlePriceUpdate();
+});
+
+/**
+ * LIFECYCLE
+ */
+onBeforeMount(async () => {
+  tokenApprovalActions.value = await getTokenApprovalActions({
+    amountsToApprove: [
+      {
+        address: addressIn.value,
+        amount: props.swapping.tokenInAmountInput.value,
+      },
+    ],
+    spender: tokenApprovalSpender.value,
+    actionType: ApprovalAction.Swapping,
+  });
 });
 </script>
 

--- a/src/components/modals/SwapPreviewModal.vue
+++ b/src/components/modals/SwapPreviewModal.vue
@@ -58,6 +58,7 @@ const lastQuote = ref<SwapQuote | null>(
 const priceUpdated = ref(false);
 const priceUpdateAccepted = ref(false);
 const showSummaryInFiat = ref(false);
+const loadingApprovals = ref(true);
 
 /**
  * COMPUTED
@@ -104,7 +105,7 @@ const exceedsBalance = computed(() => {
 });
 
 const disableSubmitButton = computed(() => {
-  return !!exceedsBalance.value || !!props.error;
+  return !!exceedsBalance.value || !!props.error || !!loadingApprovals.value;
 });
 
 const summary = computed(() => {
@@ -465,6 +466,7 @@ onBeforeMount(async () => {
     spender: tokenApprovalSpender.value,
     actionType: ApprovalAction.Swapping,
   });
+  loadingApprovals.value = false;
 });
 </script>
 

--- a/src/components/modals/SwapPreviewModal.vue
+++ b/src/components/modals/SwapPreviewModal.vue
@@ -11,7 +11,6 @@ import useRelayerApproval, {
   RelayerType,
 } from '@/composables/approvals/useRelayerApproval';
 import useRelayerApprovalTx from '@/composables/approvals/useRelayerApprovalTx';
-// import useTokenApproval from '@/composables/approvals/useTokenApproval';
 import useTokenApprovalActions from '@/composables/approvals/useTokenApprovalActions';
 import { ApprovalAction } from '@/composables/approvals/types';
 import { UseSwapping } from '@/composables/swap/useSwapping';
@@ -436,7 +435,7 @@ function handlePriceUpdate() {
 }
 
 const tokenApprovalSpender = computed<string>(() => {
-  if (props.swapping.isWrap.value && !props.swapping.isEthSwap.value) {
+  if (props.swapping.isWrap.value && !props.swapping.isNativeAssetSwap.value) {
     // If we're wrapping a token other than native ETH
     // we need to approve the underlying on the wrapper
     return props.swapping.tokenOut.value.address;

--- a/src/composables/approvals/types.ts
+++ b/src/composables/approvals/types.ts
@@ -2,4 +2,5 @@ export enum ApprovalAction {
   AddLiquidity,
   Locking,
   Staking,
+  Swapping,
 }

--- a/src/composables/approvals/useTokenApprovalActions.ts
+++ b/src/composables/approvals/useTokenApprovalActions.ts
@@ -58,6 +58,8 @@ export default function useTokenApprovalActions() {
         return t('transactionSummary.approveForLocking', [symbol]);
       case ApprovalAction.Staking:
         return t('transactionSummary.approveForStaking', [symbol]);
+      case ApprovalAction.Swapping:
+        return t('transactionSummary.approveForSwapping', [symbol]);
       default:
         return t('transactionSummary.approveForInvesting', [symbol]);
     }
@@ -69,6 +71,8 @@ export default function useTokenApprovalActions() {
         return t('transactionSummary.tooltips.approveForLocking', [symbol]);
       case ApprovalAction.Staking:
         return t('transactionSummary.tooltips.approveForStaking', [symbol]);
+      case ApprovalAction.Swapping:
+        return t('transactionSummary.tooltips.approveForSwapping', [symbol]);
       default:
         return t('transactionSummary.tooltips.approveForInvesting', [symbol]);
     }
@@ -82,6 +86,10 @@ export default function useTokenApprovalActions() {
         ]);
       case ApprovalAction.Staking:
         return t('transactionSummary.approveForStaking', [
+          getToken(address)?.symbol,
+        ]);
+      case ApprovalAction.Swapping:
+        return t('transactionSummary.approveForSwapping', [
           getToken(address)?.symbol,
         ]);
       default:

--- a/src/composables/swap/useSwapping.ts
+++ b/src/composables/swap/useSwapping.ts
@@ -57,7 +57,7 @@ export default function useSwapping(
 
   const tokenOut = computed(() => getToken(tokenOutAddressInput.value));
 
-  const isEthSwap = computed(
+  const isNativeAssetSwap = computed(
     () => tokenInAddressInput.value === NATIVE_ASSET_ADDRESS
   );
 
@@ -70,7 +70,7 @@ export default function useSwapping(
   );
 
   const requiresTokenApproval = computed(() => {
-    if (wrapType.value === WrapType.Unwrap || isEthSwap.value) {
+    if (wrapType.value === WrapType.Unwrap || isNativeAssetSwap.value) {
       return false;
     }
     return true;
@@ -105,7 +105,7 @@ export default function useSwapping(
   const swapRoute = computed<SwapRoute>(() => {
     if (wrapType.value !== WrapType.NonWrap) {
       return 'wrapUnwrap';
-    } else if (isEthSwap.value) {
+    } else if (isNativeAssetSwap.value) {
       return 'balancer';
     }
 
@@ -145,7 +145,7 @@ export default function useSwapping(
   const isWrapUnwrapSwap = computed(() => swapRoute.value === 'wrapUnwrap');
 
   const isGaslessSwappingDisabled = computed(
-    () => isEthSwap.value || isWrapUnwrapSwap.value
+    () => isNativeAssetSwap.value || isWrapUnwrapSwap.value
   );
 
   const hasSwapQuote = computed(
@@ -349,7 +349,7 @@ export default function useSwapping(
     // computed
     isWrap,
     isUnwrap,
-    isEthSwap,
+    isNativeAssetSwap,
     tokenIn,
     tokenOut,
     tokenInAmountScaled,

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -1547,7 +1547,8 @@
     "tooltips": {
       "approveForInvesting": "You must approve {0} to add liquidity for this token on Balancer. Approvals are required once per token, per wallet.",
       "approveForLocking": "You must approve {0} to lock this token. Approvals are required once per token, per wallet.",
-      "approveForStaking": "You must approve {0} to stake this token on Balancer. Approvals are required once per token, per wallet."
+      "approveForStaking": "You must approve {0} to stake this token on Balancer. Approvals are required once per token, per wallet.",
+      "approveForSwapping": "You must approve {0} to swap this token on Balancer. Approvals are required once per token, per wallet."
     }
   },
   "transactionType": "Transaction type",


### PR DESCRIPTION
# Description

Refactor swapping to use TokenApprovalActions so that it checks the user has made their allowance high enough to swap their token. Tested on Goerli and Polygon and it appears to work for me. 

Also tested wrapping/unwrapping stETH/wstETH on Goerli and it worked correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Test swapping when not enough is approved, it should ask for approval
- Test approving not enough, it should error that the amount approved wasn't high enough
- Test approving enough to swap, it should allow you to swap correctly. 
- Test wrapping/unwrapping stETH / wstETH to ensure it works correctly (approval should go to the wstETH contract). 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
