### PR TITLE
fix: Original error recording

### DIFF
--- a/src/components/_global/BalActionSteps/BalActionSteps.vue
+++ b/src/components/_global/BalActionSteps/BalActionSteps.vue
@@ -208,7 +208,11 @@ async function submit(
     state.init = false;
     state.confirming = false;
     state.error = formatErrorMsg(error);
-    captureBalancerException({ error, action: props.primaryActionType });
+    captureBalancerException({
+      error,
+      action: props.primaryActionType,
+      context: { level: 'fatal' },
+    });
   }
 }
 


### PR DESCRIPTION
# Description

Improves original error reporting to Sentry and ensures all BalActionStep errors are recorded as `fatal`.

## Type of change

- [x] Code refactor / cleanup

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
