### PR TITLE
Hotfix: Re-trigger exit queries on wallet change

### DIFF
--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -91,6 +91,7 @@ const QUERY_KEYS = {
     },
     Exits: {
       QueryExit: (
+        account: Ref<string>,
         bptIn: Ref<unknown>,
         hasFetchedPoolsForSor: Ref<unknown>,
         isSingleAssetExit: Ref<unknown>,
@@ -99,6 +100,7 @@ const QUERY_KEYS = {
       ) => [
         ...QUERY_EXIT_ROOT_KEY,
         {
+          account,
           bptIn,
           hasFetchedPoolsForSor,
           isSingleAssetExit,
@@ -107,6 +109,7 @@ const QUERY_KEYS = {
         },
       ],
       SingleAssetMax: (
+        account: Ref<string>,
         hasFetchedPoolsForSor: Ref<unknown>,
         isSingleAssetExit: Ref<unknown>,
         singleAmountOut: unknown
@@ -114,6 +117,7 @@ const QUERY_KEYS = {
         POOLS_ROOT_KEY,
         'singleAssetMax',
         {
+          account,
           hasFetchedPoolsForSor,
           isSingleAssetExit,
           singleAmountOut,

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -109,7 +109,7 @@ const QUERY_KEYS = {
         },
       ],
       SingleAssetMax: (
-        account: Ref<string>,
+        bptBalance: Ref<string>,
         hasFetchedPoolsForSor: Ref<unknown>,
         isSingleAssetExit: Ref<unknown>,
         singleAmountOut: unknown
@@ -117,7 +117,7 @@ const QUERY_KEYS = {
         POOLS_ROOT_KEY,
         'singleAssetMax',
         {
-          account,
+          bptBalance,
           hasFetchedPoolsForSor,
           isSingleAssetExit,
           singleAmountOut,

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -104,12 +104,18 @@ export const exitPoolProvider = (
   const debounceQueryExit = debounce(queryExit, debounceQueryExitMillis);
   const debounceGetSingleAssetMax = debounce(
     getSingleAssetMax,
-    debounceGetSingleAssetMaxMillis
+    debounceGetSingleAssetMaxMillis,
+    {
+      leading: true,
+    }
   );
 
   const queriesEnabled = computed(
     (): boolean => isMounted.value && !txInProgress.value
   );
+
+  // The user's BPT balance.
+  const bptBalance = computed((): string => balanceFor(pool.value.address));
 
   const queryExitQuery = useQuery<
     Awaited<ReturnType<typeof debounceQueryExit>>,
@@ -132,7 +138,7 @@ export const exitPoolProvider = (
     Error
   >(
     QUERY_KEYS.Pools.Exits.SingleAssetMax(
-      account,
+      bptBalance,
       hasFetchedPoolsForSor,
       isSingleAssetExit,
       toRef(singleAmountOut, 'address')
@@ -301,9 +307,6 @@ export const exitPoolProvider = (
 
     return bptIn.value;
   });
-
-  // The user's BPT balance.
-  const bptBalance = computed((): string => balanceFor(pool.value.address));
 
   // User has a balance of BPT.
   const hasBpt = computed(() => bnum(bptBalance.value).gt(0));


### PR DESCRIPTION
# Description

We should re-trigger exit queries, in particular, the single exit max query, when the user's wallet changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Switch wallets in the single asset exit flow and check if the max amount to withdraw updates.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
