### PR TITLE
hotfix: Don't query exit if invalid amounts out

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
@@ -28,6 +28,7 @@ const priceImpactClasses = computed(() => ({
       <div class="data-table-number-col">
         <div class="flex items-center">
           <BalLoadingBlock v-if="isLoadingQuery" class="w-10 h-6" />
+          <span v-else-if="priceImpact === -1">-</span>
           <span v-else>{{ fNum(priceImpact, FNumFormats.percent) }}</span>
 
           <BalTooltip :text="$t('withdraw.tooltips.priceImpact')">

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawTotals.vue
@@ -8,7 +8,8 @@ import { useExitPool } from '@/providers/local/exit-pool.provider';
  */
 const { fNum } = useNumbers();
 
-const { priceImpact, highPriceImpact, isLoadingQuery } = useExitPool();
+const { priceImpact, priceImpactValid, highPriceImpact, isLoadingQuery } =
+  useExitPool();
 
 /**
  * COMPUTED
@@ -28,7 +29,7 @@ const priceImpactClasses = computed(() => ({
       <div class="data-table-number-col">
         <div class="flex items-center">
           <BalLoadingBlock v-if="isLoadingQuery" class="w-10 h-6" />
-          <span v-else-if="priceImpact === -1">-</span>
+          <span v-else-if="!priceImpactValid">-</span>
           <span v-else>{{ fNum(priceImpact, FNumFormats.percent) }}</span>
 
           <BalTooltip :text="$t('withdraw.tooltips.priceImpact')">

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -322,7 +322,7 @@ export const exitPoolProvider = (
   // Are amounts valid for transaction? That is bptIn and amountsOut.
   const validAmounts = computed((): boolean => {
     return isSingleAssetExit.value
-      ? amountsOut.value.every(ao => ao.valid)
+      ? amountsOut.value.every(ao => ao.valid && bnum(ao.value).gt(0))
       : bptInValid.value && bnum(bptIn.value).gt(0);
   });
 
@@ -351,10 +351,13 @@ export const exitPoolProvider = (
    * Simulate exit transaction to get expected output and calculate price impact.
    */
   async function queryExit() {
+    // This is so we can render - in UI instead of 0. If we set to 0 then it can be misleading.
+    priceImpact.value = -1;
+
     if (!hasFetchedPoolsForSor.value) return null;
 
     // Single asset exit, and token out amount is 0 or less
-    if (isSingleAssetExit.value && !hasAmountsOut.value) return null;
+    if (isSingleAssetExit.value && !validAmounts.value) return null;
 
     // Proportional exit, and BPT in is 0 or less
     if (!isSingleAssetExit.value && !hasBptIn.value) return null;

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -71,6 +71,7 @@ export const exitPoolProvider = (
   const isMounted = ref(false);
   const isSingleAssetExit = ref<boolean>(false);
   const priceImpact = ref<number>(0);
+  const priceImpactValid = ref<boolean>(true);
   const highPriceImpactAccepted = ref<boolean>(false);
   const bptIn = ref<string>('0');
   const bptInValid = ref<boolean>(true);
@@ -352,7 +353,7 @@ export const exitPoolProvider = (
    */
   async function queryExit() {
     // This is so we can render - in UI instead of 0. If we set to 0 then it can be misleading.
-    priceImpact.value = -1;
+    priceImpactValid.value = false;
 
     if (!hasFetchedPoolsForSor.value) return null;
 
@@ -388,6 +389,8 @@ export const exitPoolProvider = (
         valid: true,
       }));
       isTxPayloadReady.value = output.txReady;
+
+      priceImpactValid.value = true;
       return output;
     } catch (error) {
       logExitException(error as Error, queryExitQuery);
@@ -565,6 +568,7 @@ export const exitPoolProvider = (
     isSingleAssetExit: readonly(isSingleAssetExit),
     propAmountsOut: readonly(propAmountsOut),
     priceImpact: readonly(priceImpact),
+    priceImpactValid: readonly(priceImpactValid),
     exitPoolService,
 
     // computed


### PR DESCRIPTION
# Description

We were allowing exit queries for invalid amounts out like 0 or amounts greater than the user's balance and therefore greater than the pool balance for that token. This allowed failed to construct exit errors. This PR prevents the queryExit function from running if single asset exits have invalid amounts and provides a mechanism for setting the price impact to `-` instead of 0 unless a value is explicitly returned from a queryExit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Try to single asset exit and input a value greater than your balance, no errors should be thrown in the console.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
