### PR TITLE
Fix: use stack instead of captureStackTrace

### DIFF
--- a/src/lib/utils/errors.ts
+++ b/src/lib/utils/errors.ts
@@ -134,8 +134,8 @@ class SentryError extends Error {
   constructor(name: string, message: string, cause: Error | unknown) {
     super(message);
 
-    if (Error.captureStackTrace && cause instanceof Error) {
-      Error.captureStackTrace(cause, SentryError);
+    if (cause instanceof Error && cause.stack) {
+      this.stack = cause.stack;
     }
 
     this.name = name;


### PR DESCRIPTION
# Description

After multiple tests I found that using `error.stack` instead of `captureStackTrace` works better to keep the stack trace in our sentry errors. 

Tested with chrome, firefox, edge and safari with a real vite build.

This is the issue stacktrace where I manually triggered an ether's `division by zero` inside `contract.concern.ts`:

<img width="1098" alt="error-with-stack" src="https://github.com/balancer/frontend-v2/assets/1316240/9fe3db64-fab4-4d01-a24f-a12b1f7379f6">

It adds the original's error stack trace but excludes the `captureBalancerException` which will be common to all `SentryError's` so IMO is not worthy no be included. 

I would merge this PR and start checking if it groups issues better than the old system (I just tested it with some trivial examples). If not, maybe we can try to fine tune them in sentry setup. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
