### PR TITLE
Hotfix - Change the PAT the BumpTag action uses

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -22,7 +22,7 @@ jobs:
           minor-wording: ''
           major-wording: ''
         env:
-          GITHUB_TOKEN: ${{ secrets.TIM_PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BALOPCO_BUMPTAG_PAT }}
       - name: Create tag
         uses: Klemensas/action-autotag@stable
         with:


### PR DESCRIPTION
# Description

Switching the Github Personal Access Token used in the BumpTag action from my personal one to one generated from @balopco user. It has the same permissions. 

## Type of change

- [x] Dependency changes

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
