### PR TITLE
Fix: single token exit only allows pool tokens subset when the pool is in recovery mode

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -69,7 +69,8 @@ const hasValidInputs = computed(
 
 // Limit token select modal to a subset.
 const subsetTokens = computed((): string[] => {
-  if (isPreMintedBptType(pool.value.poolType)) return [];
+  if (!pool.value.isInRecoveryMode && isPreMintedBptType(pool.value.poolType))
+    return [];
 
   if (isWrappedNativeAssetPool.value)
     return [nativeAsset.address, ...pool.value.tokensList];


### PR DESCRIPTION
# Description

ComposableStable pools allow exiting with a token swap (in single token tab) but not in recovery mode, which was causing errors.

This fix limits the single exit token list to the tokens in the current pool when the pool is in recovery mode: 

Example with ComposableStable arbitrum pool in recovery mode:
.../#/arbitrum/pool/0xfb5e6d0c1dfed2ba000fbc040ab8df3615ac329c000000000000000000000159



https://github.com/balancer/frontend-v2/assets/1316240/66508731-0ebf-4851-9a19-95fc6d0044e8


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
