### PR TITLE
Hotfix: Block all access to withdraw page if BPT 0

### DIFF
--- a/src/components/contextual/pages/claim/LegacyClaims.vue
+++ b/src/components/contextual/pages/claim/LegacyClaims.vue
@@ -139,7 +139,7 @@ async function claimAvailableRewards() {
       });
 
       txListener(tx, {
-        onTxConfirmed: () => {
+        onTxConfirmed: async () => {
           isClaiming.value = false;
           userClaimsQuery.refetch();
         },

--- a/src/components/contextual/pages/vebal/cross-chain-boost/SyncNetworkAction.vue
+++ b/src/components/contextual/pages/vebal/cross-chain-boost/SyncNetworkAction.vue
@@ -57,7 +57,7 @@ async function handleTransaction(
   });
 
   txListener(tx, {
-    onTxConfirmed: () => {
+    onTxConfirmed: async () => {
       setSyncTxHashes(network, tx.hash);
     },
     onTxFailed: () => {

--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -14,6 +14,7 @@ import {
 } from '@/composables/usePoolHelpers';
 import { useI18n } from 'vue-i18n';
 import { Pool } from '@/services/pool/types';
+import useNetwork from '@/composables/useNetwork';
 
 type Props = {
   pool: Pool;
@@ -37,7 +38,8 @@ const showPreview = ref(false);
 const { t } = useI18n();
 const { veBalTokenInfo } = useVeBal();
 const { wrappedNativeAsset, nativeAsset } = useTokens();
-
+const router = useRouter();
+const { networkSlug } = useNetwork();
 const { isWalletReady, startConnectWithInjectedProvider, isMismatchedNetwork } =
   useWeb3();
 const {
@@ -52,6 +54,7 @@ const {
   hasAcceptedHighPriceImpact,
   hasAmountsOut,
   validAmounts,
+  hasBpt,
 } = useExitPool();
 
 const { isWrappedNativeAssetPool } = usePoolHelpers(pool);
@@ -90,6 +93,10 @@ const excludedTokens = computed((): string[] => {
  * CALLBACKS
  */
 onBeforeMount(() => {
+  // If user has no BPT when mounting this component, redirect back to pool page
+  if (!hasBpt.value)
+    router.push({ name: 'pool', params: { networkSlug, id: props.pool.id } });
+
   singleAmountOut.address = isPreMintedBptType(pool.value.poolType)
     ? wrappedNativeAsset.value.address
     : pool.value.tokensList[0];

--- a/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/WithdrawPreviewModal.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/components/WithdrawPreviewModal/WithdrawPreviewModal.vue
@@ -42,6 +42,7 @@ const withdrawalConfirmed = ref(false);
 const { t } = useI18n();
 const { getToken } = useTokens();
 const { networkSlug } = useNetwork();
+const router = useRouter();
 
 const {
   bptIn,
@@ -52,6 +53,7 @@ const {
   fiatAmountsOut,
   isSingleAssetExit,
   shouldExitViaInternalBalance,
+  hasBpt,
 } = useExitPool();
 
 /**
@@ -106,7 +108,13 @@ const amountsOutMap = computed((): AmountMap => {
  * METHODS
  */
 function handleClose(): void {
-  emit('close');
+  // If user has withdrawn everything, send back to pool page. Else, close
+  // modal.
+  if (!hasBpt.value) {
+    router.push({ name: 'pool', params: { networkSlug, id: props.pool.id } });
+  } else {
+    emit('close');
+  }
 }
 </script>
 

--- a/src/composables/approvals/useRelayerApprovalTx.ts
+++ b/src/composables/approvals/useRelayerApprovalTx.ts
@@ -100,7 +100,7 @@ export default function useRelayerApprovalTx(
     });
 
     approved.value = await txListener(tx, {
-      onTxConfirmed: () => {
+      onTxConfirmed: async () => {
         approving.value = false;
         relayerApproval.refetch();
       },

--- a/src/composables/approvals/useTokenApproval.ts
+++ b/src/composables/approvals/useTokenApproval.ts
@@ -103,7 +103,7 @@ export default function useTokenApproval(
     });
 
     txListener(tx, {
-      onTxConfirmed: () => {
+      onTxConfirmed: async () => {
         approving.value = false;
         approved.value = true;
       },

--- a/src/composables/swap/useJoinExit.ts
+++ b/src/composables/swap/useJoinExit.ts
@@ -226,7 +226,7 @@ export default function useJoinExit({
       }
 
       await txListener(tx, {
-        onTxConfirmed: () => {
+        onTxConfirmed: async () => {
           confirming.value = false;
           relayerApprovalQuery.refetch();
         },

--- a/src/composables/swap/useSor.ts
+++ b/src/composables/swap/useSor.ts
@@ -591,7 +591,7 @@ export default function useSor({
       toFiat(tokenInAmountInput.value, tokenInAddressInput.value) || '0';
 
     txListener(tx, {
-      onTxConfirmed: () => {
+      onTxConfirmed: async () => {
         trackGoal(Goals.Swapped, bnum(swapUSDValue).times(100).toNumber() || 0);
         swapping.value = false;
         latestTxHash.value = tx.hash;

--- a/src/pages/pool/withdraw.vue
+++ b/src/pages/pool/withdraw.vue
@@ -2,7 +2,6 @@
 import { usePoolHelpers } from '@/composables/usePoolHelpers';
 import { oneSecondInMs } from '@/composables/useTime';
 import { useIntervalFn } from '@vueuse/core';
-import { computed } from 'vue';
 import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
 import WithdrawPage from '@/components/contextual/pages/pool/withdraw/WithdrawPage.vue';
 import { useTokens } from '@/providers/tokens.provider';


### PR DESCRIPTION
# Description

I believe some errors are due to users accessing the withdraw form when they have a 0 BPT balance.

- Before mounting withdraw page, check if user has BPT, if not redirect to pool page
- After a successful withdrawal, if the user tries to close the modal, check if they have any remaining BPT, if not rediect to pool page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
