### PR TITLE
fix: detect and clean routes without hash

### DIFF
--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -154,10 +154,21 @@ const routes: RouteRecordRaw[] = [
     name: 'home',
     component: HomePage,
     beforeEnter: (to, from, next) => {
-      /* Clean pathname when it does not contain hash to avoid vercel 404
-       when vercel redirects to app.balancer.fi/ethereum/ instead of app.balancer.fi/#/ethereum
-       after deployments */
+      /*
+        - Correct urls:
+        These urls will contain a hash (like app.balancer.fi/# or app.balancer.fi/#/polygon).
+        The hash fragments are not included in window.location.pathname but in window.location.hash
+        so for those cases window.location.pathname === '/'
+
+        - Incorrect urls
+        These urls will not contain the hash (like app.balancer.fi/polygon/).
+        Received when the user does not add the hash symbol when manually typing the url in the browser
+        or when Vercel building a bad redirect without hash after a deployment).
+        In these cases, the window.location.pathname will contain the wrong fragment/s that we won't to discard.
+        Example: app.balancer.fi/polygon/ will have window.location.pathname === '/polygon'
+      */
       if (window.location.pathname !== '/') {
+        // Remove wrong fragments without hash from pathname
         window.location.pathname = '';
       }
       return next();

--- a/src/plugins/router/index.ts
+++ b/src/plugins/router/index.ts
@@ -153,6 +153,15 @@ const routes: RouteRecordRaw[] = [
     path: '/:networkSlug?',
     name: 'home',
     component: HomePage,
+    beforeEnter: (to, from, next) => {
+      /* Clean pathname when it does not contain hash to avoid vercel 404
+       when vercel redirects to app.balancer.fi/ethereum/ instead of app.balancer.fi/#/ethereum
+       after deployments */
+      if (window.location.pathname !== '/') {
+        window.location.pathname = '';
+      }
+      return next();
+    },
   },
   {
     path: '/:pathMatch(.*)*',

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/:path*", "destination": "/index.html" }]
+}


### PR DESCRIPTION
# Description

Avoids a 404 when vercel tries to redirect to a page without hash. 

When detecting a route without hash, it redirects to home page instead (clearing the malformed url path).
I tried to redirect to the intended route instead of to home but I didn't find a solution that doesn't involve a non-trivial router setup refactor. 

Example failing in production: 
https://app.balancer.fi/ethereum/pool/0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080

Same example working in preview:
https://beta-app-v2-git-fix-routes-without-hash-balancer.vercel.app/ethereum/pool/0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
