### PR TITLE
Remove bnum parse, creates an issue with small number 1e-7 or smaller

### DIFF
--- a/src/composables/swap/useSor.ts
+++ b/src/composables/swap/useSor.ts
@@ -369,8 +369,6 @@ export default function useSor({
       return;
     }
 
-    amount = bnum(amount).toString();
-
     const tokenInAddress = tokenInAddressInput.value;
     const tokenOutAddress = tokenOutAddressInput.value;
 


### PR DESCRIPTION
# Description

When doing the bnum() parse on small numbers 1e-7 or less, the output is exponential notation, which causes errors in the parse. This parse is not needed, there is a check further down to ensure the amount does not exceed decimals

<img width="661" alt="Screenshot 2023-07-20 at 12 09 34" src="https://github.com/balancer/frontend-v2/assets/91405705/fb328097-3ae9-4614-9e16-ad791dee6791">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
