### PR TITLE
Catch metadata collection fetching errors

### DIFF
--- a/src/services/web3/transactions/concerns/contract.concern.ts
+++ b/src/services/web3/transactions/concerns/contract.concern.ts
@@ -104,9 +104,15 @@ export class ContractConcern extends TransactionConcern {
     block: number,
     overrides: any
   ): Promise<WalletErrorMetadata> {
-    const sender = await this.signer.getAddress();
-    const chainId = await this.signer.getChainId();
-    const calldata = contract.interface.encodeFunctionData(action, params);
+    let sender, chainId, calldata;
+    try {
+      sender = await this.signer.getAddress();
+      chainId = await this.signer.getChainId();
+      calldata = contract.interface.encodeFunctionData(action, params);
+    } catch (err) {
+      console.error('Threw second error when collecting error metadata: ', err);
+    }
+
     const msgValue = overrides.value ? overrides.value.toString() : 0;
 
     return {


### PR DESCRIPTION
# Description

In this fatal error: https://balancer-labs.sentry.io/issues/4328790230/events/bd1f6774d328402085a07c2f83c17c33/ when gathering metadata about the error getting the signing account threw an additional error which was then reported to Sentry instead of the original. 

This PR adds a try/catch around this metadata gathering to stop it from re-throwing so that we can see the original error. Also adding a console.error so we can see that in the logs for more info.  It still returns the metadata it can. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
