### PR TITLE
Fix: reload pool details when pool id changes in url

### DIFF
--- a/src/pages/_layouts/PoolLayout.vue
+++ b/src/pages/_layouts/PoolLayout.vue
@@ -1,15 +1,31 @@
 <script setup lang="ts">
-import FocussedLayout from '@/components/layouts/FocussedLayout.vue';
 import DefaultLayout from '@/components/layouts/DefaultLayout.vue';
-import { providePoolStaking } from '@/providers/local/pool-staking.provider';
+import FocussedLayout from '@/components/layouts/FocussedLayout.vue';
+import { createProviderComponent } from '@/providers/createProviderComponent';
 import { providePool } from '@/providers/local/pool.provider';
+import { providePoolStaking } from '@/providers/local/pool-staking.provider';
 import { provideUserTokens } from '@/providers/local/user-tokens.provider';
 
 /**
  * STATE
  */
 const route = useRoute();
-const poolId = (route.params.id as string).toLowerCase();
+
+/**
+ * We need this explicit PoolProvider wrapper component to refresh the provided pool details when the pool route params change.
+ * Example:
+ * If the poolId param changes in the url, then <router-view v-slot="{ Component }" :key="$route.path"> will reload its contents
+ * because the route key ($route.path) changed.
+ * That means that PoolProvider wrapper component will be rerendered providing the data for the new pool.
+ */
+const PoolProvider = createProviderComponent(() => {
+  const route = useRoute();
+  const poolId = (route.params.id as string).toLowerCase();
+
+  providePool(poolId);
+  providePoolStaking(poolId);
+  provideUserTokens();
+});
 
 /**
  * COMPUTED
@@ -21,21 +37,16 @@ const isJoinOrExitPath = computed(
 const layoutComponent = computed(() =>
   isJoinOrExitPath.value ? FocussedLayout : DefaultLayout
 );
-
-/**
- * PROVIDERS
- */
-providePool(poolId);
-providePoolStaking(poolId);
-provideUserTokens();
 </script>
 
 <template>
   <component :is="layoutComponent">
     <router-view v-slot="{ Component }" :key="$route.path">
-      <transition appear name="appear">
-        <component :is="Component" />
-      </transition>
+      <PoolProvider>
+        <transition appear name="appear">
+          <component :is="Component" />
+        </transition>
+      </PoolProvider>
     </router-view>
   </component>
 </template>


### PR DESCRIPTION
# Description

The pool provider was not being refreshed when the poolId parameter was changed in the url.

This PR enforces that the pool providers are reloaded when the route path is changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
