### PR TITLE
fix: Selected token in add liquidity form

### DIFF
--- a/src/components/forms/pool_actions/AddLiquidityForm/AddLiquidityForm.vue
+++ b/src/components/forms/pool_actions/AddLiquidityForm/AddLiquidityForm.vue
@@ -120,6 +120,8 @@ function getTokenInputLabel(address: string): string | undefined {
  * the native asset instead.
  */
 function tokenOptions(address: string): string[] {
+  if (isSingleAssetJoin.value) return [];
+
   return includesAddress(
     [wrappedNativeAsset.value.address, nativeAsset.address],
     address

--- a/src/components/inputs/TokenInput/TokenInput.vue
+++ b/src/components/inputs/TokenInput/TokenInput.vue
@@ -75,7 +75,6 @@ const props = withDefaults(defineProps<Props>(), {
   balanceLabel: '',
   hint: '',
   excludedTokens: () => [],
-  subsetTokens: () => [],
   placeholder: '',
   tokenSelectProps: () => ({}),
   slider: false,


### PR DESCRIPTION
# Description

Single asset joins in the add-liquidity flow are only ever available when the pool is a composable stable and you have the option to swap join with any tokens. The options passed into TokenInput are only relevant when it's the pool token input flow, where you want to give the user the option to toggle between native asset and wrapped. If you pass these options when it's the single asset flow, it messes with the logic and prevents the token icon from displaying if the default asset is the wrapped native asset.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] On production go to the single asset join flow of the top pool on polygon, you should see the "Select token" button in blue, but the balance suggests the current selected token in WMATIC.
- [ ] In the preview it should render as expected, with WMATIC selected.

## Visual context

Before: 
<img width="474" alt="Screenshot 2023-07-24 at 11 53 38" src="https://github.com/balancer/frontend-v2/assets/2406506/25c943a4-e464-481d-b9a4-746f8735bc16">

After:
<img width="470" alt="Screenshot 2023-07-24 at 11 53 28" src="https://github.com/balancer/frontend-v2/assets/2406506/e133b7e4-d73d-4151-8858-45148fa80efa">


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
