### PR TITLE
fix: Exact out handler

### DIFF
--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -24,6 +24,7 @@ import { hasFetchedPoolsForSor } from '@/lib/balancer.sdk';
 import {
   bnSum,
   bnum,
+  includesAddress,
   isSameAddress,
   removeAddress,
   selectByAddress,
@@ -188,7 +189,8 @@ export const exitPoolProvider = (
     (): boolean =>
       isSingleAssetExit.value &&
       isDeep(pool.value) &&
-      isPreMintedBptType(pool.value.poolType)
+      isPreMintedBptType(pool.value.poolType) &&
+      !includesAddress(pool.value.tokensList, singleAmountOut.address)
   );
 
   const shouldUseGeneralisedExit = computed(

--- a/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
+++ b/src/services/balancer/pools/exits/handlers/exact-out-exit.handler.ts
@@ -14,6 +14,7 @@ import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { formatFixed, parseFixed } from '@ethersproject/bignumber';
 import { Ref } from 'vue';
 import { ExitParams, ExitPoolHandler, QueryOutput } from './exit-pool.handler';
+import { tokensListExclBpt } from '@/composables/usePoolHelpers';
 
 export type ExitExactOutResponse = ReturnType<
   PoolWithMethods['buildExitExactTokensOut']
@@ -62,7 +63,7 @@ export class ExactOutExitHandler implements ExitPoolHandler {
 
     const poolTokensList = nativeAssetExit
       ? this.replaceWethWithEth(this.pool.value.tokensList)
-      : this.pool.value.tokensList;
+      : tokensListExclBpt(this.pool.value);
     const tokenOutIndex = indexOfAddress(poolTokensList, tokenOutAddress);
 
     const amountOut = amountsOut[0].value;


### PR DESCRIPTION
# Description

If the single asset to withdraw with is one of the high-level pool tokens, we shouldn't be using swap exits. This PR also fixes and underlying issue with the exact out handler where `buildExitExactTokensOut` needs to have the BPT removed from the `pool.tokensList` attribute.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test single asset exist with high level pool tokens in deep pools don't use swap exits.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
