### PR TITLE
fix: Catch errors setting metadata

### DIFF
--- a/src/services/web3/transactions/concerns/contract.concern.ts
+++ b/src/services/web3/transactions/concerns/contract.concern.ts
@@ -68,13 +68,17 @@ export class ContractConcern extends TransactionConcern {
     } catch (err) {
       const error = err as WalletError;
 
-      error.metadata = await this.getErrorMetadata(
-        contractWithSigner,
-        action,
-        params,
-        block,
-        options
-      );
+      try {
+        error.metadata = await this.getErrorMetadata(
+          contractWithSigner,
+          action,
+          params,
+          block,
+          options
+        );
+      } catch (metaErr) {
+        console.error('Failed to set error metadata', metaErr);
+      }
 
       return Promise.reject(error);
     }

--- a/src/services/web3/transactions/concerns/raw.concern.ts
+++ b/src/services/web3/transactions/concerns/raw.concern.ts
@@ -35,7 +35,11 @@ export class RawConcern extends TransactionConcern {
       return await this.signer.sendTransaction(txOptions);
     } catch (err) {
       const error = err as WalletError;
-      error.metadata = await this.getErrorMetadata(options);
+      try {
+        error.metadata = await this.getErrorMetadata(options);
+      } catch (metaErr) {
+        console.error('Failed to set error metadata', metaErr);
+      }
 
       return Promise.reject(error);
     }


### PR DESCRIPTION
# Description

Error types returned from transaction failures can't be relied on, sometimes they're read-only, sometimes just strings. This causes the setting of metadata on the error class to fail. This PR wraps the setting of metadata in a try/catch. These failures are quite rare so the missing metadata shouldn't be a big loss in Sentry.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
