### PR TITLE
fix: Wait for approval actions in lock modal

### DIFF
--- a/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
+++ b/src/components/forms/lock_actions/LockForm/components/LockPreviewModal/components/LockActions.vue
@@ -57,6 +57,7 @@ const emit = defineEmits<{
 /**
  * STATE
  */
+const isLoadingApprovals = ref(true);
 const lockActionStates = reactive<LockActionState[]>(
   props.lockType.map(() => ({
     init: false,
@@ -213,6 +214,7 @@ onBeforeMount(async () => {
     actionType: ApprovalAction.Locking,
   });
   actions.value.unshift(...approvalActions);
+  isLoadingApprovals.value = false;
 });
 </script>
 
@@ -221,6 +223,7 @@ onBeforeMount(async () => {
     <BalActionSteps
       v-if="!lockActionStatesConfirmed"
       :actions="actions"
+      :isLoading="isLoadingApprovals"
       primaryActionType="extendLock"
     />
     <template v-else>


### PR DESCRIPTION
# Description

We weren't waiting for approval actions to be injecting in lock modal, so it was possible for a user to click the lock action before approvals appeared, which causes failed transactions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test lock flow, should force approvals to load before you can proceed with action steps.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
