### PR TITLE
fix: Only set single asset exit default to wrapped if swaps possible

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -55,6 +55,7 @@ const {
   hasAmountsOut,
   validAmounts,
   hasBpt,
+  shouldUseSwapExit,
 } = useExitPool();
 
 const { isWrappedNativeAssetPool } = usePoolHelpers(pool);
@@ -97,7 +98,7 @@ onBeforeMount(() => {
   if (!hasBpt.value)
     router.push({ name: 'pool', params: { networkSlug, id: props.pool.id } });
 
-  singleAmountOut.address = isPreMintedBptType(pool.value.poolType)
+  singleAmountOut.address = shouldUseSwapExit.value
     ? wrappedNativeAsset.value.address
     : pool.value.tokensList[0];
 });

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -600,6 +600,7 @@ export const exitPoolProvider = (
     isTxPayloadReady,
     relayerSignature,
     relayerApprovalTx,
+    shouldUseSwapExit,
 
     // methods
     setIsSingleAssetExit,


### PR DESCRIPTION
# Description

We are setting the single asset exit default token to the wrapped native asset in cases where swap exits were not possible. This PR updates the conditional so that it defaults to the first token list token if swaps are not possible.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Try to single asset exit from a composable pool in recovery mode. It should default to one of the linear pool tokens as the exit token.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
