### PR TITLE
Add Factory for Avalanche FX pools

### DIFF
--- a/src/lib/config/avalanche/pools.ts
+++ b/src/lib/config/avalanche/pools.ts
@@ -49,6 +49,7 @@ const pools: Pools = {
     '0x230a59f4d9adc147480f03b0d3fffecd56c3289a': 'weightedPool',
     '0x3b1eb8eb7b43882b385ab30533d9a2bef9052a98': 'composableStablePool',
     '0xe42ffa682a26ef8f25891db4882932711d42e467': 'composableStablePool',
+    '0x81fe9e5b28da92ae949b705dfdb225f7a7cc5134': 'fx',
   },
   Stakable: {
     VotingGaugePools: [],


### PR DESCRIPTION
# Description

Add Factory for Avalanche FX pools

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Ensure the pool `0x55bec22f8f6c69137ceaf284d9b441db1b9bfedc000200000000000000000011` on Avalanche shows FX pool type instead of unknown

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
