### PR TITLE
Fix swapFees percentage label

### DIFF
--- a/src/components/contextual/pages/pool/PoolContractDetails.vue
+++ b/src/components/contextual/pages/pool/PoolContractDetails.vue
@@ -79,9 +79,10 @@ const data = computed(() => {
       : null,
     {
       title: t('swapFees'),
-      value: `${fNum(swapFee, { style: 'percent' })} (${formSwapFeesHint(
-        owner || ''
-      )})`,
+      value: `${fNum(swapFee, {
+        style: 'percent',
+        maximumFractionDigits: 4,
+      })} (${formSwapFeesHint(owner || '')})`,
     },
     {
       title: t('poolManager'),


### PR DESCRIPTION
# Description

Adds  `maximumFractionDigits: 4,` to swapFees fNum.

Fixes format for old reported pool

https://beta-app-v2-git-fix-swap-fee-label-balancer.vercel.app/#/ethereum/pool/0x5aee1e99fe86960377de9f88689616916d5dcabe000000000000000000000467

 and new reported pool:

https://beta-app-v2-git-fix-swap-fee-label-balancer.vercel.app/#/ethereum/pool/0x08775ccb6674d6bdceb0797c364c2653ed84f3840002000000000000000004f0




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
