### PR TITLE
Add branded redirects for pools on Avalanche

### DIFF
--- a/src/lib/config/avalanche/pools.ts
+++ b/src/lib/config/avalanche/pools.ts
@@ -110,7 +110,12 @@ const pools: Pools = {
   DisabledJoins: [],
   Deprecated: {},
   GaugeMigration: {},
-  BrandedRedirect: {},
+  BrandedRedirect: {
+    FX: 'xave',
+    Gyro2: 'gyro',
+    Gyro3: 'gyro',
+    GyroE: 'gyro',
+  },
   Issues: {},
 };
 


### PR DESCRIPTION
# Description

Makes FX/Gyro pools redirect to their site instead of allowing investing on Balancer site. This should really be a global config option instead of per network but fixing this on Avalanche for now. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Test the pool `0x55bec22f8f6c69137ceaf284d9b441db1b9bfedc000200000000000000000011` on Avalanche shows a link to invest at Xave insetead of an invest/withdraw form. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
