### PR TITLE
Hotfix: Await next tick when exiting pool

### DIFF
--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import useNumbers from '@/composables/useNumbers';
 import {
   fiatValueOf,
@@ -369,6 +370,7 @@ export const exitPoolProvider = (
 
     console.log('exitHandler:', exitHandlerType.value);
     try {
+      await nextTick();
       const output = await exitPoolService.queryExit({
         exitType: exitType.value,
         bptIn: _bptIn.value,
@@ -419,6 +421,7 @@ export const exitPoolProvider = (
 
     console.log('exitHandler:', exitHandlerType.value);
     try {
+      await nextTick();
       const output = await exitPoolService.queryExit({
         exitType: ExitType.GivenIn,
         bptIn: bptBalance.value,


### PR DESCRIPTION
# Description

When debugging https://balancer-labs.sentry.io/issues/4336208103/events/fb62e964fc49457088b1f6f99168c9bb/ I noticed that the error is that `tokenInfo` doesn't contain the EEE token. However in the error info logged to Sentry (down the bottom) the EEE token is included in the object, so the array was fixed in between calling `queryExit` and logging the error. 

This object is created dynamically from multiple vue reactive objects so my best guess is that the state hadn't fully synced across those vue objects before it was sent to `queryExit`. I've added a await nextTick to ensure that all vue state has synced first which should hopefully fix this. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Nobody has been able to reproduce this bug yet as it's a race condition, but if everything is working with this PR hopefully we won't see it again. 

- Exit a pool, single asset exit. It should work correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
