### PR TITLE
hotfix: Remove pre-minted BPT from withdrawal options

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -10,6 +10,7 @@ import WithdrawPreviewModal from './components/WithdrawPreviewModal/WithdrawPrev
 import { useTokens } from '@/providers/tokens.provider';
 import {
   isPreMintedBptType,
+  tokensListExclBpt,
   usePoolHelpers,
 } from '@/composables/usePoolHelpers';
 import { useI18n } from 'vue-i18n';
@@ -71,15 +72,17 @@ const hasValidInputs = computed(
   (): boolean => validAmounts.value && hasAcceptedHighPriceImpact.value
 );
 
+const tokensList = computed(() => tokensListExclBpt(pool.value));
+
 // Limit token select modal to a subset.
 const subsetTokens = computed((): string[] => {
   if (!pool.value.isInRecoveryMode && isPreMintedBptType(pool.value.poolType))
     return [];
 
   if (isWrappedNativeAssetPool.value)
-    return [nativeAsset.address, ...pool.value.tokensList];
+    return [nativeAsset.address, ...tokensList.value];
 
-  return pool.value.tokensList;
+  return tokensList.value;
 });
 
 const excludedTokens = computed((): string[] => {
@@ -100,7 +103,7 @@ onBeforeMount(() => {
 
   singleAmountOut.address = shouldUseSwapExit.value
     ? wrappedNativeAsset.value.address
-    : pool.value.tokensList[0];
+    : tokensList.value[0];
 });
 </script>
 


### PR DESCRIPTION
# Description

In a fix last week I limited the withdrawal form to the pool.tokensList if the pool is in recovery mode to fix another bug. This caused the single asset exit form to default to withdrawing with the pool's pre-minted BPT which is impossible. This PR ensures the tokensList in the withdrawal form always excludes the pre-minted BPT.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test the default withdrawal token for the top pool on polygon is not the pre-minted BPT token, and that it doesn't appear as an option in the token select modal.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
