### PR TITLE
hotfix: Single asset exit options

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -10,6 +10,7 @@ import WithdrawPreviewModal from './components/WithdrawPreviewModal/WithdrawPrev
 import { useTokens } from '@/providers/tokens.provider';
 import {
   isPreMintedBptType,
+  tokensListExclBpt,
   usePoolHelpers,
 } from '@/composables/usePoolHelpers';
 import { useI18n } from 'vue-i18n';
@@ -71,15 +72,17 @@ const hasValidInputs = computed(
   (): boolean => validAmounts.value && hasAcceptedHighPriceImpact.value
 );
 
+const tokensList = computed(() => tokensListExclBpt(pool.value));
+
 // Limit token select modal to a subset.
 const subsetTokens = computed((): string[] => {
   if (!pool.value.isInRecoveryMode && isPreMintedBptType(pool.value.poolType))
     return [];
 
   if (isWrappedNativeAssetPool.value)
-    return [nativeAsset.address, ...pool.value.tokensList];
+    return [nativeAsset.address, ...tokensList.value];
 
-  return pool.value.tokensList;
+  return tokensList.value;
 });
 
 const excludedTokens = computed((): string[] => {
@@ -100,7 +103,7 @@ onBeforeMount(() => {
 
   singleAmountOut.address = shouldUseSwapExit.value
     ? wrappedNativeAsset.value.address
-    : pool.value.tokensList[0];
+    : tokensList.value[0];
 });
 </script>
 

--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -56,7 +56,7 @@ const {
   hasAmountsOut,
   validAmounts,
   hasBpt,
-  shouldUseSwapExit,
+  shouldUseRecoveryExit,
 } = useExitPool();
 
 const { isWrappedNativeAssetPool } = usePoolHelpers(pool);
@@ -76,7 +76,7 @@ const tokensList = computed(() => tokensListExclBpt(pool.value));
 
 // Limit token select modal to a subset.
 const subsetTokens = computed((): string[] => {
-  if (!pool.value.isInRecoveryMode && isPreMintedBptType(pool.value.poolType))
+  if (!shouldUseRecoveryExit.value && isPreMintedBptType(pool.value.poolType))
     return [];
 
   if (isWrappedNativeAssetPool.value)
@@ -101,9 +101,10 @@ onBeforeMount(() => {
   if (!hasBpt.value)
     router.push({ name: 'pool', params: { networkSlug, id: props.pool.id } });
 
-  singleAmountOut.address = shouldUseSwapExit.value
-    ? wrappedNativeAsset.value.address
-    : tokensList.value[0];
+  singleAmountOut.address =
+    subsetTokens.value.length === 0
+      ? wrappedNativeAsset.value.address
+      : tokensList.value[0];
 });
 </script>
 

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -601,6 +601,7 @@ export const exitPoolProvider = (
     relayerSignature,
     relayerApprovalTx,
     shouldUseSwapExit,
+    shouldUseRecoveryExit,
 
     // methods
     setIsSingleAssetExit,


### PR DESCRIPTION
# Description

We were preventing single asset swap exits from composable stable pools in non-pool tokens if the pool was in recovery mode. I think this should be changed to if the pool is in recovery mode and is paused. It's possible to swap exit from pools in recovery mode, so I don't think we should block it for some edge cases where this might break.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test swap exits from the top pool on polygon.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
