### PR TITLE
Wait for pool-staking to finish loading before allowing unstaking

### DIFF
--- a/src/components/contextual/pages/pool/staking/StakePreview.vue
+++ b/src/components/contextual/pages/pool/staking/StakePreview.vue
@@ -28,7 +28,7 @@ const { isMismatchedNetwork } = useWeb3();
 const {
   isActionConfirmed,
   confirmationReceipt,
-  isLoadingApprovalsForGauge,
+  isLoading,
   currentShares,
   stakeActions,
   totalUserPoolSharePct,
@@ -84,7 +84,7 @@ const assetRowWidth = computed(
       v-if="!isActionConfirmed"
       :actions="stakeActions"
       :primaryActionType="action"
-      :isLoading="isLoadingApprovalsForGauge"
+      :isLoading="isLoading"
       :disabled="isStakeAndZero || isMismatchedNetwork"
       @success="handleSuccess"
     />

--- a/src/components/contextual/pages/pool/staking/composables/useStakePreview.ts
+++ b/src/components/contextual/pages/pool/staking/composables/useStakePreview.ts
@@ -42,6 +42,7 @@ export function useStakePreview(props: StakePreviewProps, emit) {
   const { addTransaction } = useTransactions();
   const { getTokenApprovalActions } = useTokenApprovalActions();
   const {
+    isLoading: isPoolStakingLoading,
     stake,
     unstake,
     stakedShares,
@@ -97,6 +98,10 @@ export function useStakePreview(props: StakePreviewProps, emit) {
       amount: currentShares,
     },
   ]);
+
+  const isLoading = computed(
+    () => isLoadingApprovalsForGauge.value || isPoolStakingLoading.value
+  );
 
   /**
    * METHODS
@@ -190,7 +195,7 @@ export function useStakePreview(props: StakePreviewProps, emit) {
     //state
     isActionConfirmed,
     confirmationReceipt,
-    isLoadingApprovalsForGauge,
+    isLoading,
     currentShares,
     stakeActions,
     totalUserPoolSharePct,


### PR DESCRIPTION
# Description

In https://balancer-labs.sentry.io/issues/4366114128/events/cd83eac018dc40009a09ddbe5d07ee25/ the user went to unstake but it errored that there were no gauges available. This is because the `poolGaugesQuery` was still loading and `useStakePreview` doesn't wait for it. 

This PR makes `useStakePreview` check if `pool-staking` is still loading and doesn't allow the BalActionSteps to continue if it is loading. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Test staking / unstaking pool BPT. It should allow both. It may show loading for longer now than in production because it's waiting for that subgraph query to return, but that's ok. 
 
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
