### PR TITLE
feat: Alternate between promos

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -13,6 +13,7 @@ import { lsGet, lsSet } from '@/lib/utils';
 import LS_KEYS from '@/constants/local-storage.keys';
 import { useIntersectionObserver } from '@vueuse/core';
 import BasePromo from '@/components/contextual/pages/pools/BasePromo.vue';
+import AvalanchePromo from '@/components/contextual/pages/pools/AvalanchePromo.vue';
 
 const featuredProtocolsSentinel = ref<HTMLDivElement | null>(null);
 const isFeaturedProtocolsVisible = ref(false);
@@ -61,13 +62,18 @@ function onColumnSort(columnId: string) {
   poolsSortField.value = columnId;
   lsSet(LS_KEYS.App.PoolSorting, columnId);
 }
+
+function showBasePromo(): boolean {
+  return Math.random() < 0.5;
+}
 </script>
 
 <template>
   <div>
     <HomePageHero />
     <div class="xl:container xl:px-4 pt-10 md:pt-8 xl:mx-auto">
-      <BasePromo />
+      <BasePromo v-if="showBasePromo()" />
+      <AvalanchePromo v-else />
       <BalStack vertical>
         <div class="px-4 xl:px-0">
           <div class="flex justify-between items-end mb-2">


### PR DESCRIPTION
# Description

Adds 50/50 function to decide whether to display base or avalanche promos.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
