### PR TITLE
Fix base bridge URL

### DIFF
--- a/src/lib/config/base/index.ts
+++ b/src/lib/config/base/index.ts
@@ -38,7 +38,7 @@ const config: Config = {
     blocks:
       'https://api.studio.thegraph.com/query/48427/bleu-base-blocks/version/latest',
   },
-  bridgeUrl: 'bridge.base.org',
+  bridgeUrl: 'https://bridge.base.org/',
   supportsEIP1559: false,
   supportsElementPools: false,
   supportsVeBalSync: false,


### PR DESCRIPTION
# Description

Adds https in front of the base bridge URL so that it goes to another website instead of a page on app.balancer.fi

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

- Go to swap page on base
- On the bridge card in the bottom right hand corner, ensure the link goes to the bridge correctly. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
