### PR TITLE
fix: Set lower min tx buffers on L2s

### DIFF
--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -51,7 +51,7 @@ const config: Config = {
     decimals: 18,
     deeplinkId: 'ether',
     logoURI: 'tokens/eth.png',
-    minTransactionBuffer: '0.05',
+    minTransactionBuffer: '0.005',
   },
   thirdParty: {
     coingecko: {

--- a/src/lib/config/base/index.ts
+++ b/src/lib/config/base/index.ts
@@ -50,7 +50,7 @@ const config: Config = {
     decimals: 18,
     deeplinkId: 'ether',
     logoURI: 'tokens/eth.png',
-    minTransactionBuffer: '0.05',
+    minTransactionBuffer: '0.005',
   },
   thirdParty: {
     coingecko: {

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -49,7 +49,7 @@ const config: Config = {
     decimals: 18,
     deeplinkId: 'xdai',
     logoURI: 'tokens/xdai.png',
-    minTransactionBuffer: '0.05',
+    minTransactionBuffer: '0.005',
   },
   thirdParty: {
     coingecko: {

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -46,7 +46,7 @@ const config: Config = {
     decimals: 18,
     deeplinkId: 'ether',
     logoURI: 'tokens/eth.png',
-    minTransactionBuffer: '0.05',
+    minTransactionBuffer: '0.005',
   },
   thirdParty: {
     coingecko: {

--- a/src/lib/config/zkevm/index.ts
+++ b/src/lib/config/zkevm/index.ts
@@ -49,7 +49,7 @@ const config: Config = {
     decimals: 18,
     deeplinkId: 'ether',
     logoURI: 'tokens/eth.png',
-    minTransactionBuffer: '0.05',
+    minTransactionBuffer: '0.005',
   },
   thirdParty: {
     coingecko: {


### PR DESCRIPTION
# Description

Min tx buffers were all the same as mainnet, this PR lowers the buffer for L2s.

## Type of change

- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
