### PR TITLE
fix: ethereum pool links in auto allowlist PRs

### DIFF
--- a/.github/workflows/allowlist-manual.yml
+++ b/.github/workflows/allowlist-manual.yml
@@ -11,9 +11,9 @@ on:
           - avalanche
           - arbitrum
           - base
+          - ethereum
           - gnosis-chain
           - goerli
-          - mainnet
           - polygon
           - optimism
           - zkevm

--- a/src/lib/scripts/automatic-prs/allowlist-pool.ts
+++ b/src/lib/scripts/automatic-prs/allowlist-pool.ts
@@ -5,7 +5,7 @@
  * 4. Writes new file content back to file.
  *
  * Example usage:
- * npx vite-node ./src/lib/scripts/automatic-prs/allowlist-pool.ts --network mainnet --poolType=stable --poolId=\"0x...\" --poolDescription=foo/bar/baz
+ * npx vite-node ./src/lib/scripts/automatic-prs/allowlist-pool.ts --network ethereum --poolType=stable --poolId=\"0x...\" --poolDescription=foo/bar/baz
  */
 
 import { cac } from 'cac';
@@ -25,6 +25,8 @@ const poolId = options.poolId.replace(/[^0-9a-fA-Fx]+/g, '') as string;
 const poolType = capitalize(options.poolType);
 let network = options.network as string;
 network = network.toLowerCase();
+// Allow ethereum alias to correctly generate pool link from allowlist-manual.yml
+if (network === 'ethereum') network = 'mainnet';
 const { poolDescription } = options;
 
 validateInput({ poolType, network, poolId });


### PR DESCRIPTION
# Description

Auto-generated PRs like [this one](https://github.com/balancer/frontend-v2/pull/3928) pointed to a broken url in `Link to Pool` link because they were using `mainnet` instead of `ethereum`
 
<img width="578" alt="Screenshot 2023-08-10 at 09 32 53" src="https://github.com/balancer/frontend-v2/assets/1316240/3c9cfeca-e375-4c76-bb42-d8f51bb05d80">

This PR fixes the problem while keeping compatibility with the old `mainnet` value for the `network` option. 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
