### PR TITLE
fix reward tokens apr breakdown

### DIFF
--- a/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
@@ -6,7 +6,7 @@ import { bnum } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
 import { AprBreakdown } from '@balancer-labs/sdk';
 import { useTokens } from '@/providers/tokens.provider';
-import { hasBalEmissions } from '@/composables/useAPR';
+import { hasBalEmissions, hasStakingRewards } from '@/composables/useAPR';
 
 /**
  * TYPES
@@ -84,13 +84,15 @@ const breakdownItems = computed((): Array<any> => {
   }
 
   if (hasRewardTokens.value) {
-    if (isMinMaxSame.value) {
+    if (isMinMaxSame.value && minBalAPR.value > 0) {
       items.push(['BAL', minBalAPR.value]);
     }
 
     const rewardAprTokens = apr.value?.rewardAprs.breakdown;
     if (rewardAprTokens) {
       Object.keys(rewardAprTokens).forEach(address => {
+        if (rewardAprTokens[address] === 0) return;
+
         items.push([
           getToken(address)?.symbol || 'Rewards',
           rewardAprTokens[address],
@@ -116,7 +118,10 @@ const breakdownItems = computed((): Array<any> => {
       </div>
     </div>
     <template v-else>
-      <BalBreakdown v-if="hasBalEmissions(apr)" :items="breakdownItems">
+      <BalBreakdown
+        v-if="hasBalEmissions(apr) || hasStakingRewards(apr)"
+        :items="breakdownItems"
+      >
         <div class="flex items-center">
           {{ unboostedTotalAPR }}
           <span class="ml-1 text-xs text-secondary">
@@ -134,12 +139,6 @@ const breakdownItems = computed((): Array<any> => {
           </span>
         </template>
       </BalBreakdown>
-      <div v-else-if="hasRewardTokens" class="flex items-center">
-        {{ fNum(rewardTokensAPR, FNumFormats.bp) }}
-        <span class="ml-1 text-xs text-secondary">
-          {{ $t('staking.stakingApr') }}
-        </span>
-      </div>
     </template>
   </div>
 </template>


### PR DESCRIPTION
# Description

Shows the reward tokens APR breakdown for pools that have no BAL emission.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

- [x] Access pools with Staking APR coming from reward tokens and verify the APR tooltip.

## Visual context

Before:

<img width="423" alt="image" src="https://github.com/balancer/frontend-v2/assets/43360747/9dca32bd-9239-43a0-9206-880eb03a2dad">

After:

<img width="460" alt="image" src="https://github.com/balancer/frontend-v2/assets/43360747/c7b82b84-86f0-487b-b994-6fabe341e3f6">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
