### PR TITLE
fix: Limit swap exits

### DIFF
--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -76,6 +76,7 @@ const tokensList = computed(() => tokensListExclBpt(pool.value));
 
 // Limit token select modal to a subset.
 const subsetTokens = computed((): string[] => {
+  // Returning an empty array means all tokens are presented in the modal.
   if (!shouldUseRecoveryExit.value && canSwapExit.value) return [];
 
   if (isWrappedNativeAssetPool.value)

--- a/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
+++ b/src/components/forms/pool_actions/WithdrawForm/WithdrawForm.vue
@@ -9,7 +9,6 @@ import useVeBal from '@/composables/useVeBAL';
 import WithdrawPreviewModal from './components/WithdrawPreviewModal/WithdrawPreviewModal.vue';
 import { useTokens } from '@/providers/tokens.provider';
 import {
-  isPreMintedBptType,
   tokensListExclBpt,
   usePoolHelpers,
 } from '@/composables/usePoolHelpers';
@@ -57,6 +56,7 @@ const {
   validAmounts,
   hasBpt,
   shouldUseRecoveryExit,
+  canSwapExit,
 } = useExitPool();
 
 const { isWrappedNativeAssetPool } = usePoolHelpers(pool);
@@ -76,8 +76,7 @@ const tokensList = computed(() => tokensListExclBpt(pool.value));
 
 // Limit token select modal to a subset.
 const subsetTokens = computed((): string[] => {
-  if (!shouldUseRecoveryExit.value && isPreMintedBptType(pool.value.poolType))
-    return [];
+  if (!shouldUseRecoveryExit.value && canSwapExit.value) return [];
 
   if (isWrappedNativeAssetPool.value)
     return [nativeAsset.address, ...tokensList.value];

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -186,12 +186,15 @@ export const exitPoolProvider = (
     shouldSignRelayer.value ? [relayerApprovalAction.value] : []
   );
 
+  const canSwapExit = computed(
+    (): boolean => isDeep(pool.value) && isPreMintedBptType(pool.value.poolType)
+  );
+
   const shouldUseSwapExit = computed(
     (): boolean =>
       isSingleAssetExit.value &&
-      isDeep(pool.value) &&
-      isPreMintedBptType(pool.value.poolType) &&
-      !includesAddress(pool.value.tokensList, singleAmountOut.address)
+      !includesAddress(pool.value.tokensList, singleAmountOut.address) &&
+      canSwapExit.value
   );
 
   const shouldUseGeneralisedExit = computed(
@@ -604,6 +607,7 @@ export const exitPoolProvider = (
     relayerSignature,
     relayerApprovalTx,
     shouldUseSwapExit,
+    canSwapExit,
     shouldUseRecoveryExit,
 
     // methods


### PR DESCRIPTION
# Description

Limit swap withdrawals to deep pools. Previously we were injecting all the possible swap tokens for withdrawing under different conditions to enable the swap exits. This PR unifies the two conditionals.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] A composable stable pool that is not being considered deep should not give you the option to swap exit in many tokens.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
