### PR TITLE
fix: ignore vue-query errors until third retry

### DIFF
--- a/src/lib/utils/errors.ts
+++ b/src/lib/utils/errors.ts
@@ -316,13 +316,13 @@ export function isUserError(error): boolean {
 }
 
 /**
- * Checks if query has already failed, if more than once, we will ignore the error.
+ * Checks if failing query was already retried 3 times, if not, we will ignore the error.
  */
 export function shouldCaptureQueryError(
   query: UseQueryReturnType<any, any> | undefined
 ): boolean {
   if (!query) return true;
-  return query.failureCount.value <= 1;
+  return query.failureCount.value === 3;
 }
 
 /**


### PR DESCRIPTION
# Description

We have some intermittent vue-query errors (like `Failed to query exit` or `value out-of-bounds`) that randomly happen once in many queries.

Those errors do not impact the user because they are recovered in the first vue-query retry, however, we were capturing those errors in sentry. 

With this PR, we avoid capturing an error unless it kept on happening after the 3 vue-query retries.

Reproduced example:
https://balancer-labs.sentry.io/issues/4385800763/?alert_rule_id=14519929&alert_type=issue&project=5725878&referrer=slack

 One error after 107 successful queries: 
<img width="1346" alt="Screenshot 2023-08-11 at 11 50 39" src="https://github.com/balancer/frontend-v2/assets/1316240/2ce8eed5-09c7-4174-946d-87081b8b1bbb">

The only drawback is that we will stop knowing about this concrete intermittent errors in sentry but we have to chose if we want to reduce the noise.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
