### PR TITLE
Hotfix: allow all tokens on testnet

### DIFF
--- a/src/composables/useDisabledJoinPool.spec.ts
+++ b/src/composables/useDisabledJoinPool.spec.ts
@@ -1,6 +1,6 @@
 import { initDependenciesWithDefaultMocks } from '@/dependencies/default-mocks';
 import { Pool, PoolType } from '@/services/pool/types';
-import { BoostedPoolMock } from '@/__mocks__/boosted-pool';
+import { aBoostedPool } from '@/__mocks__/boosted-pool';
 import { aPoolToken } from '@/__mocks__/weighted-pool';
 import { mountComposableWithFakeTokensProvider as mountComposable } from '@tests/mount-helpers';
 import {
@@ -21,7 +21,7 @@ async function mountVettedTokensInPool(pool: Pool) {
 }
 
 it('disables joins for pools with no initial liquidity', async () => {
-  const pool = { ...BoostedPoolMock };
+  const pool = aBoostedPool();
   pool.totalShares = '0';
   const { disableJoinsReason, shouldDisableJoins } =
     await mountVettedTokensInPool(pool);
@@ -34,7 +34,7 @@ it('disables joins for pools created after timestamp (2023-03-29) with non vette
   const { networkId } = useNetwork();
   networkId.value = 1;
 
-  const pool = { ...BoostedPoolMock };
+  const pool = aBoostedPool();
   pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
   const { disableJoinsReason, shouldDisableJoins, nonAllowedSymbols } =
     await mountVettedTokensInPool(pool);
@@ -52,7 +52,7 @@ it('allows joins for pools on test networks with non vetted tokens', async () =>
   const { networkId } = useNetwork();
   networkId.value = 5;
 
-  const pool = { ...BoostedPoolMock };
+  const pool = aBoostedPool();
   pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
   const { disableJoinsReason, shouldDisableJoins } =
     await mountVettedTokensInPool(pool);
@@ -67,7 +67,7 @@ it('disables joins for weighted pools created after timestamp (2023-03-29) that 
   const { networkId } = useNetwork();
   networkId.value = 1;
 
-  const pool = { ...BoostedPoolMock };
+  const pool = aBoostedPool();
   pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
   pool.poolType = PoolType.Weighted;
   const { disableJoinsReason, shouldDisableJoins } =
@@ -85,7 +85,7 @@ it('allows joins for weighted pools on test networks created after timestamp (20
   const { networkId } = useNetwork();
   networkId.value = 5;
 
-  const pool = { ...BoostedPoolMock };
+  const pool = aBoostedPool();
   pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
   pool.poolType = PoolType.Weighted;
   const { disableJoinsReason } = await mountVettedTokensInPool(pool);
@@ -98,7 +98,7 @@ it('allows joins for weighted pools on test networks created after timestamp (20
 });
 
 it('does not disables joins for pools created before 29 march', async () => {
-  const pool = { ...BoostedPoolMock };
+  const pool = aBoostedPool();
   pool.createTime = dateToUnixTimestamp('2023-03-28'); //Created before 29 March
   pool.totalShares = '100';
   const { shouldDisableJoins, disableJoinsReason } =

--- a/src/composables/useDisabledJoinPool.spec.ts
+++ b/src/composables/useDisabledJoinPool.spec.ts
@@ -21,7 +21,7 @@ async function mountVettedTokensInPool(pool: Pool) {
 }
 
 it('disables joins for pools with no initial liquidity', async () => {
-  const pool = BoostedPoolMock;
+  const pool = { ...BoostedPoolMock };
   pool.totalShares = '0';
   const { disableJoinsReason, shouldDisableJoins } =
     await mountVettedTokensInPool(pool);
@@ -31,7 +31,10 @@ it('disables joins for pools with no initial liquidity', async () => {
 });
 
 it('disables joins for pools created after timestamp (2023-03-29) with non vetted tokens', async () => {
-  const pool = BoostedPoolMock;
+  const { networkId } = useNetwork();
+  networkId.value = 1;
+
+  const pool = { ...BoostedPoolMock };
   pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
   const { disableJoinsReason, shouldDisableJoins, nonAllowedSymbols } =
     await mountVettedTokensInPool(pool);
@@ -45,11 +48,26 @@ it('disables joins for pools created after timestamp (2023-03-29) with non vette
   );
 });
 
+it('allows joins for pools on test networks with non vetted tokens', async () => {
+  const { networkId } = useNetwork();
+  networkId.value = 5;
+
+  const pool = { ...BoostedPoolMock };
+  pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
+  const { disableJoinsReason, shouldDisableJoins } =
+    await mountVettedTokensInPool(pool);
+
+  pool.tokens[0].address = randomAddress();
+
+  console.log('Reason: ', disableJoinsReason.value);
+  expect(shouldDisableJoins.value).toBeFalse();
+});
+
 it('disables joins for weighted pools created after timestamp (2023-03-29) that are not in the weighted allow list', async () => {
   const { networkId } = useNetwork();
   networkId.value = 1;
 
-  const pool = BoostedPoolMock;
+  const pool = { ...BoostedPoolMock };
   pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
   pool.poolType = PoolType.Weighted;
   const { disableJoinsReason, shouldDisableJoins } =
@@ -67,7 +85,7 @@ it('allows joins for weighted pools on test networks created after timestamp (20
   const { networkId } = useNetwork();
   networkId.value = 5;
 
-  const pool = BoostedPoolMock;
+  const pool = { ...BoostedPoolMock };
   pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
   pool.poolType = PoolType.Weighted;
   const { disableJoinsReason } = await mountVettedTokensInPool(pool);
@@ -80,7 +98,7 @@ it('allows joins for weighted pools on test networks created after timestamp (20
 });
 
 it('does not disables joins for pools created before 29 march', async () => {
-  const pool = BoostedPoolMock;
+  const pool = { ...BoostedPoolMock };
   pool.createTime = dateToUnixTimestamp('2023-03-28'); //Created before 29 March
   pool.totalShares = '100';
   const { shouldDisableJoins, disableJoinsReason } =

--- a/src/composables/useDisabledJoinPool.ts
+++ b/src/composables/useDisabledJoinPool.ts
@@ -47,7 +47,11 @@ export function useDisabledJoinPool(pool: Pool) {
   });
 
   const nonVettedTokensAfterTimestamp = computed(() => {
-    return createdAfterTimestamp(pool) && notVettedTokens.value.length > 0;
+    return (
+      !isTestnet.value &&
+      createdAfterTimestamp(pool) &&
+      notVettedTokens.value.length > 0
+    );
   });
 
   const nonAllowedWeightedPoolAfterTimestamp = computed(() => {


### PR DESCRIPTION
# Description

We shouldn't show the "Tokens not on allowlist" message on testnets, so that other teams can quickly test pools with their own test tokens without waiting on us to add them to the tokenlist. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Visit a sepolia pool like `0x2ea0b1475f2864de2c6de25fc93ed588b99a625700000000000000000000002a`. It should not give any warnings about missing tokens. 
- Pools with unverified tokens on normal networks should still show the warning. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
