### PR TITLE
Fix values of tokens with a priceRate on pool page

### DIFF
--- a/src/components/contextual/pages/pool/PoolCompositionCard/components/composables/useTokenBreakdown.ts
+++ b/src/components/contextual/pages/pool/PoolCompositionCard/components/composables/useTokenBreakdown.ts
@@ -51,7 +51,7 @@ export function useTokenBreakdown(rootPool: Ref<Pool>) {
     const hasNestedTokens = token?.token?.pool?.tokens;
     const isParentTokenInDeepPool = hasNestedTokens && isDeepPool.value;
 
-    const virtualBalance = calculateBalanceValue();
+    const balanceValue = calculateBalanceValue();
     const fiatValue = calculateFiatValue();
     if (isNumber(fiatValue)) totalFiat += Number(fiatValue);
 
@@ -59,9 +59,9 @@ export function useTokenBreakdown(rootPool: Ref<Pool>) {
     const userFiatLabel = fiatValue === '' ? '' : formatFiatValue(userFiat);
 
     const userBalanceLabel =
-      virtualBalance === ''
+      balanceValue === ''
         ? ''
-        : formatBalanceValue(applyUserPoolPercentageTo(virtualBalance));
+        : formatBalanceValue(applyUserPoolPercentageTo(balanceValue));
 
     const tokenWeightLabel = !token?.weight
       ? ''
@@ -99,14 +99,7 @@ export function useTokenBreakdown(rootPool: Ref<Pool>) {
 
     function calculateBalanceValue() {
       if (isParentTokenInDeepPool) return '';
-      if (token.priceRate && isDeepPool) {
-        const equivMainTokenBalance = bnum(balance)
-          .times(token.priceRate)
-          .toString();
-
-        return equivMainTokenBalance;
-      }
-      return token.balance;
+      return balance;
     }
 
     function formatBalanceValue(value: string | number) {
@@ -117,13 +110,11 @@ export function useTokenBreakdown(rootPool: Ref<Pool>) {
     function calculateFiatValue() {
       if (isParentTokenInDeepPool) return '';
 
-      let value = toFiat(virtualBalance, token.address);
+      let value = toFiat(balance, token.address);
 
       if (value === '0' && token.token?.latestUSDPrice) {
         // Attempt to use latest USD price from subgraph.
-        value = bnum(virtualBalance)
-          .times(token.token.latestUSDPrice)
-          .toString();
+        value = bnum(balance).times(token.token.latestUSDPrice).toString();
       }
       return value;
     }

--- a/src/components/contextual/pages/pool/PoolCompositionCard/components/composables/useTokenBreakdown.ts
+++ b/src/components/contextual/pages/pool/PoolCompositionCard/components/composables/useTokenBreakdown.ts
@@ -51,17 +51,17 @@ export function useTokenBreakdown(rootPool: Ref<Pool>) {
     const hasNestedTokens = token?.token?.pool?.tokens;
     const isParentTokenInDeepPool = hasNestedTokens && isDeepPool.value;
 
+    const virtualBalance = calculateBalanceValue();
     const fiatValue = calculateFiatValue();
     if (isNumber(fiatValue)) totalFiat += Number(fiatValue);
-    const balanceValue = calculateBalanceValue();
 
     const userFiat = applyUserPoolPercentageTo(fiatValue);
     const userFiatLabel = fiatValue === '' ? '' : formatFiatValue(userFiat);
 
     const userBalanceLabel =
-      balanceValue === ''
+      virtualBalance === ''
         ? ''
-        : formatBalanceValue(applyUserPoolPercentageTo(balanceValue));
+        : formatBalanceValue(applyUserPoolPercentageTo(virtualBalance));
 
     const tokenWeightLabel = !token?.weight
       ? ''
@@ -117,11 +117,13 @@ export function useTokenBreakdown(rootPool: Ref<Pool>) {
     function calculateFiatValue() {
       if (isParentTokenInDeepPool) return '';
 
-      let value = toFiat(balance, token.address);
+      let value = toFiat(virtualBalance, token.address);
 
       if (value === '0' && token.token?.latestUSDPrice) {
         // Attempt to use latest USD price from subgraph.
-        value = bnum(balance).times(token.token.latestUSDPrice).toString();
+        value = bnum(virtualBalance)
+          .times(token.token.latestUSDPrice)
+          .toString();
       }
       return value;
     }


### PR DESCRIPTION
# Description

Fixes balances of tokens that have a priceRate. Previously we were multiplying the balance by priceRate when showing it in the UI which didn't make sense and also made the USD value look incorrect. Now we're just showing the raw balances. 

Also fixes a very minor issue that it was returning token.balance instead of token.balance * shareOfPoolInParent for pools that weren't deep + rateProvider. But I believe every composable pool that this effects has a priceRate so it doesn't really change anything. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Visit a metastable pool like ETH/rETH
- Calculate the token value by dividing Value / Balance. This value should equal Coingecko.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
