### PR TITLE
chore: Set two separate tags for wallet vs app network

### DIFF
--- a/src/lib/utils/errors.ts
+++ b/src/lib/utils/errors.ts
@@ -7,6 +7,7 @@ import { TransactionAction } from '@/composables/useTransactions';
 import { UseQueryReturnType } from '@tanstack/vue-query';
 import { WalletError, WalletErrorMetadata } from '@/types';
 import { configService } from '@/services/config/config.service';
+import { getNetworkSlug, networkId } from '@/composables/useNetwork';
 
 interface Params {
   error: Error | unknown;
@@ -115,12 +116,10 @@ function getTags(
     action,
   };
 
+  tags.appNetwork = getNetworkSlug(networkId.value);
+
   if (balError) {
     tags.balError = balError;
-  }
-
-  if (metadata?.chainId) {
-    tags.chainId = `${metadata.chainId}`;
   }
 
   if (metadata.action) {

--- a/src/providers/wallet.provider.ts
+++ b/src/providers/wallet.provider.ts
@@ -202,7 +202,7 @@ export const wallets = () => {
 
       setTag('wallet', wallet);
       if (connector?.chainId.value) {
-        setTag('network', config[connector.chainId.value].network);
+        setTag('walletNetwork', config[connector.chainId.value].network);
       }
 
       // listens to wallet/chain changed and disconnect events


### PR DESCRIPTION
# Description

We were only setting the user's wallet network as a tag. This PR now sets two tags, one for `walletNetwork` and one for `appNetwork`.

## Type of change

- [x] Code refactor / cleanup

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
