### PR TITLE
Hotfix: Disable investing in USD overnight pool

### DIFF
--- a/src/lib/config/arbitrum/pools.ts
+++ b/src/lib/config/arbitrum/pools.ts
@@ -339,7 +339,9 @@ const pools: Pools = {
   },
   GaugeMigration: {},
   BoostedApr: [],
-  DisabledJoins: [],
+  DisabledJoins: [
+    '0xa8af146d79ac0bb981e4e0d8b788ec5711b1d5d000000000000000000000047b',
+  ],
   Issues: {
     [PoolWarning.PoolOwnerVulnWarningGovernance]: [
       '0x5a5884fc31948d59df2aeccca143de900d49e1a300000000000000000000006f',


### PR DESCRIPTION
@Tritium-VLK mentioned some users were having issues with this pool, temporarily disabling investing until they're resolved. 