### PR TITLE
hotfix: Make warning dismissable

### DIFF
--- a/src/components/_global/BalAlert/BalAlert.vue
+++ b/src/components/_global/BalAlert/BalAlert.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['bal-alert', classes]">
+  <div :class="['bal-alert relative', classes]">
     <div :class="['bal-alert-container', containerClasses]">
       <div>
         <div :class="['bal-alert-icon', iconClasses]">
@@ -9,12 +9,12 @@
       </div>
       <div :class="['bal-alert-content', contentClasses]">
         <div>
-          <h5 :class="['bal-alert-title mb-1', titleClasses, textSizeClass]">
+          <h5 :class="['bal-alert-title', titleClasses, textSizeClass]">
             <slot name="title">
               {{ title }}
             </slot>
           </h5>
-          <p
+          <div
             v-if="$slots.default || description"
             :class="[
               'bal-alert-description font-normal',
@@ -25,7 +25,7 @@
             <slot>
               {{ description }}
             </slot>
-          </p>
+          </div>
         </div>
         <div v-if="actionLabel" :class="[actionClasses]">
           <BalBtn :color="btnColor" size="xs" @click="$emit('action-click')">
@@ -33,6 +33,15 @@
           </BalBtn>
         </div>
       </div>
+    </div>
+
+    <div v-if="dismissable" class="absolute top-1 right-1">
+      <BalIcon
+        name="x"
+        size="sm"
+        class="cursor-pointer"
+        @click.stop="$emit('close')"
+      />
     </div>
   </div>
 </template>
@@ -68,9 +77,10 @@ export default defineComponent({
     contentClass: { type: String, default: '' },
     square: { type: Boolean, default: false },
     noBorder: { type: Boolean, default: false },
+    dismissable: { type: Boolean, default: false },
   },
 
-  emits: ['action-click'],
+  emits: ['action-click', 'close'],
 
   setup(props, { slots }) {
     const bgColorClass = computed(() => {

--- a/src/constants/local-storage.keys.ts
+++ b/src/constants/local-storage.keys.ts
@@ -20,4 +20,7 @@ export default {
     Toggled: 'tokenLists.toggled',
   },
   Transactions: 'transactions',
+  Alerts: {
+    RecoveryExitDismissed: 'alerts.recoveryExitDismissed',
+  },
 };

--- a/src/pages/recovery-exit/UserInvestedInAffectedPoolAlert.vue
+++ b/src/pages/recovery-exit/UserInvestedInAffectedPoolAlert.vue
@@ -1,23 +1,38 @@
 <script setup lang="ts">
 import useNetwork from '@/composables/useNetwork';
+import { lsGet, lsSet } from '@/lib/utils';
 import { useUserIsDepositedInAffectedPool } from '@/pages/recovery-exit/useUserIsDepositedInAffectedPool';
+import LS_KEYS from '@/constants/local-storage.keys';
+
+/**
+ * STATE
+ */
+const dismissed = ref<boolean>(
+  lsGet(LS_KEYS.Alerts.RecoveryExitDismissed, false)
+);
 
 /**
  * COMPOSABLES
  */
 const { networkSlug } = useNetwork();
-
 const { isUserDepositedInAffectedPool } = useUserIsDepositedInAffectedPool();
+
+function handleClose() {
+  lsSet(LS_KEYS.Alerts.RecoveryExitDismissed, true);
+  dismissed.value = true;
+}
 </script>
 
 <template>
-  <div v-if="isUserDepositedInAffectedPool" class="px-4 xl:px-0">
+  <div v-if="isUserDepositedInAffectedPool && !dismissed" class="px-4 xl:px-0">
     <BalAlert
       type="error"
       title="Pool Vulnerability - August 22, 2023"
       actionLabel="Withdraw now"
       class="mb-4"
       block
+      dismissable
+      @close="handleClose"
       @action-click="
         $router.push({ name: 'recovery-exit', params: { networkSlug } })
       "


### PR DESCRIPTION
# Description

- Makes BalAlert dismissable
- Makes recovery exit warning dismissable and saves in local storage.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
