### PR TITLE
Fix: wallet connect chain options

### DIFF
--- a/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
+++ b/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
@@ -13,15 +13,8 @@ export class WalletConnectConnector extends Connector {
   async connect() {
     const provider = await EthereumProvider.init({
       projectId: 'ee9c0c7e1b8b86ebdfb8fd93bb116ca8',
-      optionalChains: [
-        MAINNET,
-        AVALANCHE,
-        ARBITRUM,
-        BASE,
-        GNOSIS,
-        POLYGON,
-        ZKEVM,
-      ],
+      chains: [MAINNET],
+      optionalChains: [AVALANCHE, ARBITRUM, BASE, GNOSIS, POLYGON, ZKEVM],
       rpcMap: {
         [MAINNET]: configService.getNetworkRpc(MAINNET),
         [ARBITRUM]: configService.getNetworkRpc(ARBITRUM),

--- a/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
+++ b/src/services/web3/connectors/trustwallet/walletconnect.connector.ts
@@ -6,20 +6,29 @@ import { Connector, ConnectorId } from '../connector';
 import { Network } from '@/lib/config/types';
 import useDarkMode from '@/composables/useDarkMode';
 
-const { MAINNET, POLYGON, ARBITRUM, GNOSIS, ZKEVM } = Network;
+const { MAINNET, ARBITRUM, AVALANCHE, BASE, GNOSIS, POLYGON, ZKEVM } = Network;
 
 export class WalletConnectConnector extends Connector {
   id = ConnectorId.WalletConnect;
   async connect() {
     const provider = await EthereumProvider.init({
       projectId: 'ee9c0c7e1b8b86ebdfb8fd93bb116ca8',
-      chains: [MAINNET],
-      optionalChains: [POLYGON, ARBITRUM, GNOSIS],
+      optionalChains: [
+        MAINNET,
+        AVALANCHE,
+        ARBITRUM,
+        BASE,
+        GNOSIS,
+        POLYGON,
+        ZKEVM,
+      ],
       rpcMap: {
         [MAINNET]: configService.getNetworkRpc(MAINNET),
-        [POLYGON]: configService.getNetworkRpc(POLYGON),
         [ARBITRUM]: configService.getNetworkRpc(ARBITRUM),
+        [AVALANCHE]: configService.getNetworkRpc(AVALANCHE),
+        [BASE]: configService.getNetworkRpc(BASE),
         [GNOSIS]: configService.getNetworkRpc(GNOSIS),
+        [POLYGON]: configService.getNetworkRpc(POLYGON),
         [ZKEVM]: configService.getNetworkRpc(ZKEVM),
       },
       showQrModal: true,


### PR DESCRIPTION
# Description

Adds new chains (avalanche and base) to wallet connect optional chains. 

When connecting with ledger live, it is mandatory to check Ethereum checkbox (as well as the other desired networks).

<img width="543" alt="Screenshot 2023-08-23 at 17 24 25" src="https://github.com/balancer/frontend-v2/assets/1316240/c76858cb-0d79-4f34-b7e6-78df73b9a2c3">

https://github.com/balancer/frontend-v2/assets/1316240/0f73c668-8632-42a4-9325-59c18da203c2

We tried removing the mandatory `chains: [MAINNET]` option from wallet connect options but it did not work.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
