### PR TITLE
hotfix: Use lowercase for comparison to find pool ID

### DIFF
--- a/src/pages/recovery-exit/components/UnstakeTable.vue
+++ b/src/pages/recovery-exit/components/UnstakeTable.vue
@@ -262,12 +262,12 @@ function refetchBalances() {
 
 function poolIdFor(token: TokenInfo): string {
   const liquidityGauge = allLiquidityGauges.value.find(
-    gauge => gauge.id === token.address
+    gauge => gauge.id.toLowerCase() === token.address.toLowerCase()
   );
   if (liquidityGauge) return liquidityGauge.poolId;
 
   const auraGauge = allAuraGauges.value.find(
-    gauge => gauge.address === token.address
+    gauge => gauge.address.toLowerCase() === token.address.toLowerCase()
   );
   if (auraGauge) return auraGauge.poolId;
 


### PR DESCRIPTION
# Description

Some pools in the unstake list were appearing as 'mitigated' when they should have been labelled 'high risk'. The only way this can happen is if the `poolIdFor` function doesn't return the correct pool ID for the gauge token. I believe the only way that could happen is if we're comparing checksum vs lowercase addresses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
