### PR TITLE
fix: use exact amount in recovery approval

### DIFF
--- a/src/pages/recovery-exit/components/TokenUnwrapTable.vue
+++ b/src/pages/recovery-exit/components/TokenUnwrapTable.vue
@@ -221,6 +221,7 @@ async function approve(token: TokenInfo) {
     normalizedAmount: balancerFor(token.address),
     spender: configService.network.addresses.vault,
     actionType: ApprovalAction.Unwrapping,
+    forceMax: false,
   });
 }
 


### PR DESCRIPTION
# Description

It seems that metamask (and potentially other wallets) are losing some precision when the users clicks `maximum` in the allowance input. That can lead to problems because they approve a bit less than needed.
[For example in this issue reported in discord](https://discord.com/channels/638460494168064021/1144180043430494248/1144373476443029565) the user had `0.014594891442040555` but metamask was setting maximum to `0.01459489144204` losing those trailing `0555` decimals. 

We cannot prevent users from clicking `maximum` in their wallets but, it is better passing the exact amount (i.e. 0.014594891442040555) instead of the default MaxUint256 (that apparently leads to an empty allowance input in metamask).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
