### PR TITLE
chore: udpate node version to 18

### DIFF
--- a/.github/workflows/allowlist.yml
+++ b/.github/workflows/allowlist.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Install deps
         run: npm install cac
       - name: Run allowlist script

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Install deps
         run: npm install -g npm@7 && npm ci
       - name: Run build
@@ -31,7 +31,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Install deps
         run: npm install -g npm@7 && npm ci
       - name: Run lint
@@ -48,7 +48,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Install deps
         run: npm install -g npm@7 && npm ci
       - name: Run typecheck

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@balancer/frontend-v2",
   "version": "1.120.14",
   "engines": {
-    "node": "=16",
+    "node": "18.x",
     "npm": ">=8"
   },
   "scripts": {


### PR DESCRIPTION
# Description

The end of life of node 16 is next 11th of September.
Vercel already [deprecated it](https://vercel.com/changelog/node-js-14-and-16-are-being-deprecated) last 15th of August. 

MSW [next version is finally ready](https://github.com/mswjs/msw/issues/1388#issuecomment-1617573863) for node 18 since last July.

This PR: 
- Adds node 18 to engines and to github action workflows. 
- Migrates MSW tests to next version.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
