### PR TITLE
Fix/unique key voting list

### DIFF
--- a/src/components/_global/BalTable/BalTable.vue
+++ b/src/components/_global/BalTable/BalTable.vue
@@ -30,6 +30,8 @@ const emit = defineEmits<{
 type Props = {
   columns: ColumnDefinition[];
   data: DataProp[];
+  // Sometimes we want to explicitly specify a function to calculate the unique row key (for example, voting pool rows can have repeated ids)
+  rowKey?: (dataItem: DataProp) => string;
   isLoading?: boolean;
   isLoadingMore?: boolean;
   skeletonClass?: string;
@@ -150,6 +152,11 @@ function getAlignProperty(align: 'left' | 'right' | 'center' | undefined) {
     default:
       return 'justify-start';
   }
+}
+
+function getRowKey(dataItem: DataProp, index: number) {
+  if (props.rowKey) return `tableRow-${props.rowKey(dataItem)}`;
+  return `tableRow-${dataItem.id ?? index}`;
 }
 
 onMounted(() => {
@@ -323,7 +330,7 @@ watch([() => props.data, () => props.isLoading], ([newData]) => {
         <PinHeader v-if="pinnedData.length" />
         <BalTableRow
           v-for="(dataItem, index) in pinnedData"
-          :key="`tableRow-${dataItem.id ?? index}`"
+          :key="getRowKey(dataItem, index)"
           :class="getTableRowClass(dataItem, index)"
           :data="dataItem"
           :columns="filteredColumns"
@@ -343,7 +350,7 @@ watch([() => props.data, () => props.isLoading], ([newData]) => {
         <!-- begin data rows -->
         <template
           v-for="(dataItem, index) in unpinnedData"
-          :key="`tableRow-${dataItem.id ?? index}`"
+          :key="getRowKey(dataItem, index)"
         >
           <BalTableRow
             v-if="!renderedRowsIdx || index <= renderedRowsIdx"

--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -212,6 +212,7 @@ function getPickedTokens(tokens: VotingPool['tokens']) {
     <BalTable
       :columns="columns"
       :data="data"
+      :rowKey="(dataItem: VotingPool) => dataItem.gauge.address"
       :isLoading="isLoading"
       skeletonClass="h-64"
       sticky="both"


### PR DESCRIPTION
# Description

There was a rendering problem in the vebal voting list because `BalTable` uses `data.id` as row `key` by default but, in this concrete case, after migrating to the API, we can have 2 pools (with different gauges) with the same id, which leads to weird row duplications when vue re-renders rows based on `key` attribute.

This PR fixes the problem by allowing `BalTable` consumers to pass a prop to calculate the unique key.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Before:

![before](https://github.com/balancer/frontend-v2/assets/1316240/82907cee-dce0-44be-9624-95f9d3fa85d0)


After:
<img width="1205" alt="after" src="https://github.com/balancer/frontend-v2/assets/1316240/febf8699-4ff5-4e52-be5a-ffed7a271907">





## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
