### PR TITLE
fix: add enabled default option to usePoolsQuery

### DIFF
--- a/src/composables/queries/usePoolsQuery.ts
+++ b/src/composables/queries/usePoolsQuery.ts
@@ -27,7 +27,7 @@ type PoolsQueryResponse = {
 
 export default function usePoolsQuery(
   filterOptions: PoolFilterOptions,
-  options: UseInfiniteQueryOptions<PoolsQueryResponse> = {}
+  options: UseInfiniteQueryOptions<PoolsQueryResponse> = { enabled: true }
 ) {
   /**
    * COMPOSABLES


### PR DESCRIPTION
# Description

[This code ](https://github.com/balancer/frontend-v2/blob/7b60d27d0765fd0e42d20bf2e7b5ec6a631c0b3d/src/composables/queries/usePoolsQuery.ts#L222)disables pools query when `!options.enabled` so we need a default value when enabled option is not provided from the consumer like in [this case](https://github.com/balancer/frontend-v2/blob/7b60d27d0765fd0e42d20bf2e7b5ec6a631c0b3d/src/composables/pools/usePools.ts#L37).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
