### PR TITLE
Hotfix: update wallet network on switch

### DIFF
--- a/src/providers/wallet.provider.ts
+++ b/src/providers/wallet.provider.ts
@@ -252,6 +252,10 @@ export const wallets = () => {
     connectWallet(alreadyConnectedProvider.value);
   }
 
+  watch(chainId, () => {
+    setTag('walletNetwork', config[chainId.value].network);
+  });
+
   return {
     connectWallet,
     disconnectWallet,

--- a/src/providers/wallet.provider.ts
+++ b/src/providers/wallet.provider.ts
@@ -202,7 +202,10 @@ export const wallets = () => {
 
       setTag('wallet', wallet);
       if (connector?.chainId.value) {
-        setTag('walletNetwork', config[connector.chainId.value].network);
+        const network = config[connector.chainId.value]
+          ? config[connector.chainId.value].slug
+          : connector.chainId.value;
+        setTag('walletNetwork', network);
       }
 
       // listens to wallet/chain changed and disconnect events
@@ -253,7 +256,10 @@ export const wallets = () => {
   }
 
   watch(chainId, () => {
-    setTag('walletNetwork', config[chainId.value].network);
+    const network = config[chainId.value]
+      ? config[chainId.value].slug
+      : chainId.value;
+    setTag('walletNetwork', network);
   });
 
   return {


### PR DESCRIPTION
# Description

When testing with walletconnect I noticed the walletNetwork tag was not being updated when changing network in your wallet. This is causing the users wallet network to be reported incorrectly. 

Also switches it to network slug to be consistent with appNetwork, and fixes a bug where this would error if the user is connected to a network we don't support. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

- Add a breakpoint in the watch statement
- Change networks in your wallet and ensure it hits the breakpoint and switches correctly. 
- Switch to an unsupported network and ensure it sets the walletNetwork to the chainId and doesn't error. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
