### PR TITLE
Bump SDK. Adds 4pool_BPT/wstEth mid pool for Gnosis to open more paths.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sdk": "^1.1.5-beta.0",
+        "@balancer-labs/sdk": "^1.1.5-beta.2",
         "@balancer-labs/typechain": "^1.0.0",
         "@balancer-labs/v2-deployments": "^3.2.0",
         "@cowprotocol/contracts": "^1.3.1",
@@ -1526,9 +1526,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.1.5-beta.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.1.5-beta.0.tgz",
-      "integrity": "sha512-Oa/ZKutXVTKRnGx3L3Ww2VQbjBbpPQjCaSB5g1QVBGAURYnztMFP+Zbe0l+esLDnTQVQs9ng9N/HPOwb1hzWRg==",
+      "version": "1.1.5-beta.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.1.5-beta.2.tgz",
+      "integrity": "sha512-/sLUl6Zn+e3mgR+0aTaOiDYxE9KNg8XEUMjvhRyNjOn68rM3JivEYTrYS656+9fsLiAx+K797oGHI9dp5UGArw==",
       "dev": true,
       "dependencies": {
         "@balancer-labs/sor": "^4.1.1-beta.16",
@@ -29612,9 +29612,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.1.5-beta.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.1.5-beta.0.tgz",
-      "integrity": "sha512-Oa/ZKutXVTKRnGx3L3Ww2VQbjBbpPQjCaSB5g1QVBGAURYnztMFP+Zbe0l+esLDnTQVQs9ng9N/HPOwb1hzWRg==",
+      "version": "1.1.5-beta.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.1.5-beta.2.tgz",
+      "integrity": "sha512-/sLUl6Zn+e3mgR+0aTaOiDYxE9KNg8XEUMjvhRyNjOn68rM3JivEYTrYS656+9fsLiAx+K797oGHI9dp5UGArw==",
       "dev": true,
       "requires": {
         "@balancer-labs/sor": "^4.1.1-beta.16",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@aave/protocol-js": "^4.3.0",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sdk": "^1.1.5-beta.0",
+    "@balancer-labs/sdk": "^1.1.5-beta.2",
     "@balancer-labs/typechain": "^1.0.0",
     "@balancer-labs/v2-deployments": "^3.2.0",
     "@cowprotocol/contracts": "^1.3.1",


### PR DESCRIPTION
# Description

Bump SDK. Adds 4pool_BPT/wstEth mid pool to config for Gnosis to open more paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

DAI>WETH currently shows high price impact. After this change it should find a path through higher liquidity 4Pool/wstETH pool and reduce PI.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
