### PR TITLE
chore: extract localstorage utils to its own file

### DIFF
--- a/src/components/cards/SwapCard/SwapCard.vue
+++ b/src/components/cards/SwapCard/SwapCard.vue
@@ -174,7 +174,7 @@ import useBreakpoints from '@/composables/useBreakpoints';
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { useTokens } from '@/providers/tokens.provider';
 import { TOKENS } from '@/constants/tokens';
-import { lsGet } from '@/lib/utils';
+import { lsGet } from '@/lib/utils/localstorage';
 import { WrapType } from '@/lib/utils/balancer/wrapper';
 import { isRequired } from '@/lib/utils/validations';
 import { ApiErrorCodes } from '@/services/cowswap/errors/OperatorError';

--- a/src/composables/pools/usePoolCreation.ts
+++ b/src/composables/pools/usePoolCreation.ts
@@ -7,14 +7,8 @@ import usePoolsQuery from '@/composables/queries/usePoolsQuery';
 import useEthers from '@/composables/useEthers';
 import useTransactions from '@/composables/useTransactions';
 import { POOLS } from '@/constants/pools';
-import {
-  bnum,
-  includesAddress,
-  isSameAddress,
-  lsRemove,
-  lsSet,
-  scale,
-} from '@/lib/utils';
+import { bnum, includesAddress, isSameAddress, scale } from '@/lib/utils';
+import { lsRemove, lsSet } from '@/lib/utils/localstorage';
 import { balancerService } from '@/services/balancer/balancer.service';
 import useWeb3 from '@/services/web3/useWeb3';
 

--- a/src/composables/swap/useSwapAssets.ts
+++ b/src/composables/swap/useSwapAssets.ts
@@ -1,5 +1,5 @@
 import { networkId } from '@/composables/useNetwork';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 import { configService } from '@/services/config/config.service';
 
 const inputAsset = ref(

--- a/src/composables/swap/useSwapping.ts
+++ b/src/composables/swap/useSwapping.ts
@@ -3,7 +3,8 @@ import { parseFixed } from '@ethersproject/bignumber';
 
 import LS_KEYS from '@/constants/local-storage.keys';
 import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
-import { bnum, lsGet, lsSet } from '@/lib/utils';
+import { bnum } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 import { getWrapAction, WrapType } from '@/lib/utils/balancer/wrapper';
 import { COW_SUPPORTED_NETWORKS } from '@/services/cowswap/constants';
 import {

--- a/src/composables/useAlerts.ts
+++ b/src/composables/useAlerts.ts
@@ -1,7 +1,7 @@
 import { orderBy } from 'lodash';
 import { computed, ref } from 'vue';
 
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 
 export enum AlertType {
   ERROR = 'error',

--- a/src/composables/useApp.ts
+++ b/src/composables/useApp.ts
@@ -1,5 +1,5 @@
 import LS_KEYS from '@/constants/local-storage.keys';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 import i18n from '@/plugins/i18n';
 export { version } from '../../package.json';
 

--- a/src/composables/useDarkMode.ts
+++ b/src/composables/useDarkMode.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue';
 
 import LS_KEYS from '@/constants/local-storage.keys';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 
 const osDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
 const lsDarkMode =

--- a/src/composables/useEthereumTxType.ts
+++ b/src/composables/useEthereumTxType.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue';
 
 import LS_KEYS from '@/constants/local-storage.keys';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 
 export enum EthereumTxType {
   LEGACY = 'Legacy',

--- a/src/composables/useTransactions.ts
+++ b/src/composables/useTransactions.ts
@@ -8,7 +8,7 @@ import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import LS_KEYS from '@/constants/local-storage.keys';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 import { configService } from '@/services/config/config.service';
 import { cowswapExplorer } from '@/services/cowswap/explorer.service';
 import { cowswapProtocolService } from '@/services/cowswap/cowswapProtocol.service';

--- a/src/composables/watchers/usePoolCreationWatcher.ts
+++ b/src/composables/watchers/usePoolCreationWatcher.ts
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router';
 
 import useNetwork from '@/composables/useNetwork';
 
-import { lsGet } from '@/lib/utils';
+import { lsGet } from '@/lib/utils/localstorage';
 
 import {
   POOL_CREATION_STATE_KEY,

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -4,7 +4,6 @@ import { initial } from 'lodash';
 import { Ref } from 'vue';
 import { Path } from 'vue-i18n';
 
-import pkg from '@/../package.json';
 import { NATIVE_ASSET_ADDRESS } from '@/constants/tokens';
 import { POOLS } from '@/constants/pools';
 
@@ -16,49 +15,6 @@ export async function sleep(time) {
   return new Promise(resolve => {
     setTimeout(resolve, time);
   });
-}
-
-function lsAddVersion(value: any, version: string) {
-  return {
-    data: value,
-    _version: version,
-  };
-}
-
-function lsGetKey(key: string) {
-  return `${pkg.name}.${key}`;
-}
-
-export function lsSet(key: string, value: any, version?: string) {
-  const data = version != null ? lsAddVersion(value, version) : value;
-
-  return localStorage.setItem(lsGetKey(key), JSON.stringify(data));
-}
-
-export function lsGet<T = any>(
-  key: string,
-  defaultValue: any = null,
-  version?: string
-): T {
-  const rawValue = localStorage.getItem(lsGetKey(key));
-
-  if (rawValue != null) {
-    try {
-      const value = JSON.parse(rawValue);
-      if (version != null) {
-        return value._version === version ? value.data : defaultValue;
-      }
-      return value;
-    } catch (e) {
-      return defaultValue;
-    }
-  }
-
-  return defaultValue;
-}
-
-export function lsRemove(key: string) {
-  return localStorage.removeItem(lsGetKey(key));
 }
 
 export function getCurrentTs() {

--- a/src/lib/utils/localstorage.ts
+++ b/src/lib/utils/localstorage.ts
@@ -1,0 +1,44 @@
+import pkg from '@/../package.json';
+
+function lsAddVersion(value: any, version: string) {
+  return {
+    data: value,
+    _version: version,
+  };
+}
+
+function lsGetKey(key: string) {
+  return `${pkg.name}.${key}`;
+}
+
+export function lsSet(key: string, value: any, version?: string) {
+  const data = version != null ? lsAddVersion(value, version) : value;
+
+  return localStorage.setItem(lsGetKey(key), JSON.stringify(data));
+}
+
+export function lsGet<T = any>(
+  key: string,
+  defaultValue: any = null,
+  version?: string
+): T {
+  const rawValue = localStorage.getItem(lsGetKey(key));
+
+  if (rawValue != null) {
+    try {
+      const value = JSON.parse(rawValue);
+      if (version != null) {
+        return value._version === version ? value.data : defaultValue;
+      }
+      return value;
+    } catch (e) {
+      return defaultValue;
+    }
+  }
+
+  return defaultValue;
+}
+
+export function lsRemove(key: string) {
+  return localStorage.removeItem(lsGetKey(key));
+}

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -9,7 +9,7 @@ import usePoolFilters from '@/composables/pools/usePoolFilters';
 import useBreakpoints from '@/composables/useBreakpoints';
 import useNetwork from '@/composables/useNetwork';
 import usePools from '@/composables/pools/usePools';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 import LS_KEYS from '@/constants/local-storage.keys';
 import { useIntersectionObserver } from '@vueuse/core';
 import { PoolType } from '@/services/pool/types';

--- a/src/pages/pool/create.vue
+++ b/src/pages/pool/create.vue
@@ -22,7 +22,8 @@ import usePoolCreation, {
 import useAlerts from '@/composables/useAlerts';
 import useBreakpoints from '@/composables/useBreakpoints';
 import { useTokens } from '@/providers/tokens.provider';
-import { lsGet, selectByAddress } from '@/lib/utils';
+import { lsGet } from '@/lib/utils/localstorage';
+import { selectByAddress } from '@/lib/utils';
 import useWeb3 from '@/services/web3/useWeb3';
 import { StepState } from '@/types';
 import IntroModal from '@/components/contextual/pages/pool/create/IntroModal.vue';

--- a/src/pages/recovery-exit/UserInvestedInAffectedPoolAlert.vue
+++ b/src/pages/recovery-exit/UserInvestedInAffectedPoolAlert.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import useNetwork from '@/composables/useNetwork';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 import { useUserIsDepositedInAffectedPool } from '@/pages/recovery-exit/useUserIsDepositedInAffectedPool';
 import LS_KEYS from '@/constants/local-storage.keys';
 

--- a/src/providers/token-lists.provider.ts
+++ b/src/providers/token-lists.provider.ts
@@ -13,7 +13,7 @@ import {
 import useNetwork from '@/composables/useNetwork';
 import localStorageKeys from '@/constants/local-storage.keys';
 import symbolKeys from '@/constants/symbol.keys';
-import { lsSet } from '@/lib/utils';
+import { lsSet } from '@/lib/utils/localstorage';
 import TokenListService, {
   tokenListService,
 } from '@/services/token-list/token-list.service';

--- a/src/providers/user-settings.provider.ts
+++ b/src/providers/user-settings.provider.ts
@@ -4,7 +4,7 @@ import { computed, inject, InjectionKey, provide, reactive, toRefs } from 'vue';
 import { FiatCurrency } from '@/constants/currency';
 import LS_KEYS from '@/constants/local-storage.keys';
 import symbolKeys from '@/constants/symbol.keys';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 
 /**
  * TYPES

--- a/src/providers/wallet.provider.spec.ts
+++ b/src/providers/wallet.provider.spec.ts
@@ -19,7 +19,7 @@ import { initTallyConnectorForTesting } from '@/dependencies/wallets/tally';
 import { initWalletconnectConnectorForTesting } from '@/dependencies/wallets/walletconnect';
 import { initWalletLinkConnectorForTesting } from '@/dependencies/wallets/walletlink';
 import { initWeb3Provider } from '@/dependencies/wallets/Web3Provider';
-import { lsGet } from '@/lib/utils';
+import { lsGet } from '@/lib/utils/localstorage';
 import { mountComposable } from '@tests/mount-helpers';
 import { SANCTIONED_ADDRESS } from '@tests/msw/rest-handlers';
 import { isBlockedAddress, useWallets } from './wallet.provider';

--- a/src/providers/wallet.provider.ts
+++ b/src/providers/wallet.provider.ts
@@ -12,7 +12,7 @@ import axios from 'axios';
 
 import useFathom, { Goals, trackGoal } from '@/composables/useFathom';
 import { WALLET_SCREEN_ENDPOINT } from '@/constants/exploits';
-import { lsGet, lsSet } from '@/lib/utils';
+import { lsGet, lsSet } from '@/lib/utils/localstorage';
 
 import { networkId } from '@/composables/useNetwork';
 import { configService } from '@/services/config/config.service';

--- a/src/services/web3/connectors/connector.ts
+++ b/src/services/web3/connectors/connector.ts
@@ -1,6 +1,5 @@
 import { getAddress } from '@ethersproject/address';
 import { Ref, ref } from 'vue';
-import pkg from '@/../package.json';
 
 export type ConnectorPayload = {
   provider: unknown;
@@ -91,5 +90,5 @@ function lsRemove(key: string) {
 }
 
 function lsGetKey(key: string) {
-  return `${pkg.name}.${key}`;
+  return `@balancer/frontend-v2.${key}`;
 }

--- a/src/services/web3/connectors/connector.ts
+++ b/src/services/web3/connectors/connector.ts
@@ -1,7 +1,7 @@
 import { getAddress } from '@ethersproject/address';
 import { Ref, ref } from 'vue';
 
-import { lsRemove } from '@/lib/utils';
+import { lsRemove } from '@/lib/utils/localstorage';
 
 export type ConnectorPayload = {
   provider: unknown;

--- a/src/services/web3/connectors/connector.ts
+++ b/src/services/web3/connectors/connector.ts
@@ -1,7 +1,6 @@
 import { getAddress } from '@ethersproject/address';
 import { Ref, ref } from 'vue';
-
-import { lsRemove } from '@/lib/utils/localstorage';
+import pkg from '@/../package.json';
 
 export type ConnectorPayload = {
   provider: unknown;
@@ -84,4 +83,13 @@ export abstract class Connector {
     this.provider.on('accountsChanged', this.handleAccountsChanged);
     this.provider.on('chainChanged', this.handleChainChanged);
   }
+}
+
+//Inline lsRemove to avoid rollup including connectors together with useDakMode in the bundle, affecting initial JS execution time
+function lsRemove(key: string) {
+  return localStorage.removeItem(lsGetKey(key));
+}
+
+function lsGetKey(key: string) {
+  return `${pkg.name}.${key}`;
 }


### PR DESCRIPTION
# Description

useDarkMode was importing lsGet and lsSet from index.ts in utils which, in turn, imported unrelated localstorage imports that affect to the initial JS execution time. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
