### PR TITLE
Hotfix: change avalanche native asset

### DIFF
--- a/src/lib/config/avalanche/index.ts
+++ b/src/lib/config/avalanche/index.ts
@@ -44,7 +44,7 @@ const config: Config = {
   blockTime: 2,
   nativeAsset: {
     name: 'AVAX',
-    address: '0x0000000000000000000000000000000000000000',
+    address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
     symbol: 'AVAX',
     decimals: 18,
     deeplinkId: 'avax',

--- a/src/lib/config/avalanche/tokens.ts
+++ b/src/lib/config/avalanche/tokens.ts
@@ -5,11 +5,11 @@ const tokens: TokenConstants = {
     Symbols: ['WBTC', 'WETH', 'DAI', 'USDC', 'BAL', 'AVAX'],
   },
   InitialSwapTokens: {
-    input: '0x0000000000000000000000000000000000000000',
+    input: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
     output: '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E', // USDC
   },
   Addresses: {
-    nativeAsset: '0x0000000000000000000000000000000000000000',
+    nativeAsset: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
     wNativeAsset: '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7',
     WETH: '0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB',
     BAL: '0xE15bCB9E0EA69e6aB9FA080c4c4A5632896298C3',


### PR DESCRIPTION
# Description

Changing the native address on Avalanche to 0xEee as it makes more sense than the zero address (and won't get confused with the burn address). This address is self referential so doesn't matter what it is except for getting the native asset token price from the beets API. It has been changed in the beets API here: https://github.com/beethovenxfi/beethovenx-backend/pull/417 so needs to be changed in this frontend to match. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Use Avalanche Network
- Ensure the native asset has a price on the swap page. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
