### PR TITLE
fix: use prop in prefetch links

### DIFF
--- a/src/components/navs/AppNav/DesktopLinks/DesktopLinkItem.vue
+++ b/src/components/navs/AppNav/DesktopLinks/DesktopLinkItem.vue
@@ -22,7 +22,7 @@ const classes = computed(() => ({
 <template>
   <router-link v-bind="props" :class="['desktop-link-item', classes]">
     <slot />
-    <PrefetchLinks v-if="prefetch" :to="$attrs.to" />
+    <PrefetchLinks v-if="prefetch" :to="props.to" />
   </router-link>
 </template>
 


### PR DESCRIPTION
# Description

Fixes this issue after [bumping vue version](https://github.com/balancer/frontend-v2/pull/4167):

Complex prop types are now handled differently and now we must use `props.to` (we couldn't before due to bad type inference).

Note: This issue was only affecting development env, that's why we didn't catch it in preview.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
