### PR TITLE
hotfix: Aura staked risk label

### DIFF
--- a/src/pages/recovery-exit/components/UnstakeTable.vue
+++ b/src/pages/recovery-exit/components/UnstakeTable.vue
@@ -87,6 +87,9 @@ const { darkMode } = useDarkMode();
 
 const poolIds = computed((): string[] => CSP_ISSUE_POOL_IDS[networkId.value]);
 const poolAddresses = computed(() => poolIds.value.map(id => id.slice(0, 42)));
+const addressToPoolIdMap = computed(
+  () => new Map(poolIds.value.map(id => [id.slice(0, 42), id]))
+);
 
 const enableBalanceFetching = computed(() => !!account.value);
 
@@ -269,7 +272,8 @@ function poolIdFor(token: TokenInfo): string {
   const auraGauge = allAuraGauges.value.find(
     gauge => gauge.address.toLowerCase() === token.address.toLowerCase()
   );
-  if (auraGauge) return auraGauge.poolId;
+  if (auraGauge)
+    return addressToPoolIdMap.value.get(auraGauge.lpToken.address) || '';
 
   return '';
 }


### PR DESCRIPTION
# Description

Fixes risk label for staked Aura positions in the recovery exit page. The subgraph is a bit different so we were checking for a poolId against the wrong data.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
