### PR TITLE
hotfix: Minor RPC init optimization

### DIFF
--- a/src/services/rpc-provider/rpc-provider.service.spec.ts
+++ b/src/services/rpc-provider/rpc-provider.service.spec.ts
@@ -1,11 +1,9 @@
-import { JsonRpcProvider } from '@ethersproject/providers';
-
 import RpcProviderService from '@/services/rpc-provider/rpc-provider.service';
 import { StaticJsonRpcBatchProvider } from './static-json-rpc-batch-provider';
 
-vi.mock('@ethersproject/providers', () => {
+vi.mock('./static-json-rpc-batch-provider', () => {
   return {
-    JsonRpcProvider: vi.fn().mockImplementation(() => {
+    StaticJsonRpcBatchProvider: vi.fn().mockImplementation(() => {
       return {
         once: vi.fn(),
       };
@@ -13,23 +11,13 @@ vi.mock('@ethersproject/providers', () => {
   };
 });
 
-vi.mock('./static-json-rpc-batch-provider', () => {
-  return {
-    StaticJsonRpcBatchProvider: vi.fn().mockImplementation(() => {
-      return {};
-    }),
-  };
-});
-
 describe('RPC provider service', () => {
-  const MockedJsonRpcProvider = vi.mocked(JsonRpcProvider, true);
   const MockedStaticJsonRpcBatchProvider = vi.mocked(
     StaticJsonRpcBatchProvider,
     true
   );
 
   beforeEach(() => {
-    MockedJsonRpcProvider.mockClear();
     MockedStaticJsonRpcBatchProvider.mockClear();
   });
 
@@ -41,10 +29,5 @@ describe('RPC provider service', () => {
   it('Calls the JsonProvider constructor', () => {
     new RpcProviderService();
     expect(MockedStaticJsonRpcBatchProvider).toHaveBeenCalledTimes(1);
-  });
-
-  it('Calls the WebSocketProvider', () => {
-    new RpcProviderService().initBlockListener(() => ({}));
-    expect(MockedJsonRpcProvider).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/rpc-provider/rpc-provider.service.ts
+++ b/src/services/rpc-provider/rpc-provider.service.ts
@@ -15,8 +15,7 @@ export default class RpcProviderService {
   ) {}
 
   public initBlockListener(newBlockHandler: NewBlockHandler): void {
-    const blockProvider = new JsonRpcProvider(this.config.rpc);
-    blockProvider.once('block', newBlockNumber => {
+    this.jsonProvider.once('block', newBlockNumber => {
       let currentBlockNumber = newBlockNumber;
       newBlockHandler(currentBlockNumber);
       setInterval(() => {


### PR DESCRIPTION
# Description

Prevents two different json providers being initialized when it's not needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
