### PR TITLE
feat: add default network filter on vebal table

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/GaugesFilters.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesFilters.vue
@@ -32,7 +32,7 @@ const networkFiltersArr = ref([...props.activeNetworkFilters]);
  * otherwise activeFiltersNum would change only after 500ms debounce which lead to poor UX
  */
 const isExpiredFilterActive = ref(false);
-const activeNetworksArr = ref<number[]>([]);
+const activeNetworksArr = ref<number[]>(props.activeNetworkFilters);
 
 /**
  * COMPUTED

--- a/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/LMVoting.vue
@@ -17,11 +17,20 @@ import useNumbers from '@/composables/useNumbers';
 import { isVotingCompleted, useVoting } from '../providers/voting.provider';
 
 /**
+ * COMPOSABLES
+ */
+const router = useRouter();
+
+/**
  * DATA
  */
+
 const tokenFilter = useDebouncedRef<string>('', 500);
 const showExpiredGauges = useDebouncedRef<boolean>(false, 500);
-const activeNetworkFilters = useDebouncedRef<Network[]>([], 500);
+const activeNetworkFilters = useDebouncedRef<Network[]>(
+  getDefaultActiveNetworkFilter(),
+  500
+);
 
 const networkFilters: Network[] = Object.entries(configs)
   .filter(details => {
@@ -51,7 +60,6 @@ const { isWalletReady } = useWeb3();
 
 const { hasVeBalBalance, noVeBalBalance } = useVeBal();
 const { fNum } = useNumbers();
-
 const {
   isLoading,
   isLoadingVotingPools,
@@ -143,6 +151,21 @@ function addIntersectionObserver(): void {
   observer = new IntersectionObserver(callback, options);
   observer.observe(intersectionSentinel.value);
 }
+
+function getDefaultActiveNetworkFilter() {
+  const param = router.currentRoute.value.query.chain;
+  if (!param || typeof param !== 'string') {
+    return [];
+  }
+
+  const networkToFilter = Network[param.toUpperCase()];
+  if (!networkToFilter) {
+    return [];
+  }
+
+  return [networkToFilter];
+}
+
 onMounted(() => {
   addIntersectionObserver();
 });


### PR DESCRIPTION
# Description
Adds default network filter on vebal table, which is taken from `chain` query param

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?
Add `chain` query param with desired network name and refresh page, vebal table will be filtered by it

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
