### PR TITLE
Hotfix swap input scaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.127.9",
+  "version": "1.127.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@balancer/frontend-v2",
-      "version": "1.127.9",
+      "version": "1.127.10",
       "license": "MIT",
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balancer/frontend-v2",
-  "version": "1.127.9",
+  "version": "1.127.10",
   "engines": {
     "node": "=16",
     "npm": ">=8"

--- a/src/composables/swap/useJoinExit.ts
+++ b/src/composables/swap/useJoinExit.ts
@@ -114,10 +114,9 @@ export default function useJoinExit({
       tokenInAddressInput.value,
       tokenOutAddressInput.value,
       exactIn.value ? SwapTypes.SwapExactIn : SwapTypes.SwapExactOut,
-      parseFixed(
-        tokenInAmountInput.value || tokenOutAmountInput.value || '0',
-        18
-      ),
+      exactIn.value
+        ? parseFixed(tokenInAmountInput.value || '0', tokenIn.value.decimals)
+        : parseFixed(tokenOutAmountInput.value || '0', tokenOut.value.decimals),
       undefined,
       true
     );


### PR DESCRIPTION
# Description

`getSwapInfo` function is using 18 decimals for scaling amount used in SOR/Swaps which causes issues when using something like USDC. Changed to use correct token decimals. This should also fixes token decimals for exact token out case which also seems to be broken.
I'm not 100% clear on how the swap logic is working on FE so should be double checked this doesn't lead to any knock-on effects.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Check USDC > wstEth on mainnet with a gas fee: Should now return a proper result compared to production.
Try a BAL > weth on mainnet with a gas fee and an amount for weth (e.g. exact out). Should now return a proper result compared to production.

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [X] I have commented my code where relevant, particularly in hard-to-understand areas
- [X] If package-lock.json has changes, it was intentional.
- [X] The base of this PR is `master` if hotfix, `develop` if not
