### PR TITLE
chore: Update APRs style and fix display

### DIFF
--- a/src/components/contextual/pages/pool/PoolStatCards.vue
+++ b/src/components/contextual/pages/pool/PoolStatCards.vue
@@ -14,6 +14,7 @@ import { Pool } from '@/services/pool/types';
 import { AprBreakdown } from '@balancer-labs/sdk';
 import { useCrossChainSync } from '@/providers/cross-chain-sync.provider';
 import useNetwork from '@/composables/useNetwork';
+import useWeb3 from '@/services/web3/useWeb3';
 
 /**
  * TYPES
@@ -41,6 +42,7 @@ const { fNum } = useNumbers();
 const { t } = useI18n();
 const { l2VeBalBalances } = useCrossChainSync();
 const { networkId } = useNetwork();
+const { isWalletReady } = useWeb3();
 
 /**
  * COMPUTED
@@ -49,7 +51,7 @@ const aprLabel = computed((): string => {
   const poolAPRs = props.poolApr;
   if (!poolAPRs) return '0';
 
-  return totalAprLabel(poolAPRs, props.pool?.boost);
+  return totalAprLabel(poolAPRs, props.pool?.boost, isWalletReady.value);
 });
 
 const syncVeBalTooltip = computed(() => {

--- a/src/components/tables/PoolsTable/PoolsTable.vue
+++ b/src/components/tables/PoolsTable/PoolsTable.vue
@@ -38,6 +38,7 @@ import { poolMetadata } from '@/lib/config/metadata';
 import PoolsTableExtraInfo from './PoolsTableExtraInfo.vue';
 import PoolsTableActionSelector from './PoolsTableActionSelector.vue';
 import { PoolAction } from '@/components/contextual/pages/pools/types';
+import useWeb3 from '@/services/web3/useWeb3';
 
 /**
  * TYPES
@@ -102,6 +103,7 @@ const { trackGoal, Goals } = useFathom();
 const { darkMode } = useDarkMode();
 const { upToLargeBreakpoint, upToSmallBreakpoint } = useBreakpoints();
 const { networkSlug } = useNetwork();
+const { isWalletReady } = useWeb3();
 
 const wideCompositionWidth = computed(() => {
   if (upToSmallBreakpoint.value) return 250;
@@ -271,7 +273,7 @@ function aprLabelFor(pool: Pool): string {
   const poolAPRs = pool?.apr;
   if (!poolAPRs) return '0';
 
-  return totalAprLabel(poolAPRs, boostFor(pool));
+  return totalAprLabel(poolAPRs, boostFor(pool), isWalletReady.value);
 }
 
 function lockedUntil(lockEndDate?: number) {

--- a/src/components/tooltips/APRTooltip/APRTooltip.spec.ts
+++ b/src/components/tooltips/APRTooltip/APRTooltip.spec.ts
@@ -104,7 +104,7 @@ describe('APRTooltip', () => {
         'Swap fees APR 0.00%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
-        'Min staking APR 0.44%'
+        'Staking APR 0.44% - 5.67%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
         'Min BAL APR 0.44%'
@@ -138,7 +138,7 @@ describe('APRTooltip', () => {
         'Swap fees APR 2.23%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
-        'Min staking APR 0.48%'
+        'Staking APR 0.48% - 5.55%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
         'Min BAL APR 0.48%'
@@ -272,7 +272,7 @@ describe('APRTooltip', () => {
       expect(yieldAprBreakdown.textContent).toContain('bb-a-USDC APR 0.04%');
       expect(yieldAprBreakdown.textContent).toContain('bb-a-DAI APR 0.12%');
       expect(getByTestId('staking-apr').textContent).toContain(
-        'Min staking APR 0.30%'
+        'Staking APR 0.30% - 0.75%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
         'Min BAL APR 0.30%'
@@ -311,7 +311,7 @@ describe('APRTooltip', () => {
         'Boosted APR 0.28%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
-        'Min staking APR 5.67%'
+        'Staking APR 5.67% - 14.18%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
         'Min BAL APR 5.67%'
@@ -377,7 +377,7 @@ describe('APRTooltip', () => {
         'Swap fees APR 0.00%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
-        'Min staking APR 1.67%'
+        'Staking APR 1.67% - 6.45%'
       );
       expect(getByTestId('staking-apr').textContent).toContain(
         'Min BAL APR 0.44%'

--- a/src/components/tooltips/APRTooltip/APRTooltip.spec.ts
+++ b/src/components/tooltips/APRTooltip/APRTooltip.spec.ts
@@ -47,7 +47,7 @@ describe('APRTooltip', () => {
       expect(getByTestId('total-apr').textContent).toBe('Total APR15.22%');
       expect(getByTestId('swap-fee-apr')).toBeTruthy();
       expect(getByTestId('swap-fee-apr').textContent).toBe(
-        '15.22% Swap fees APR'
+        'Swap fees APR 15.22%'
       );
     });
   });
@@ -75,7 +75,7 @@ describe('APRTooltip', () => {
         'Total APR0.78% - 1.95%'
       );
       expect(getByTestId('vebal-apr').textContent).toContain(
-        '1.17% Max locking/veBAL APR'
+        'Max locking/veBAL APR1.17%'
       );
     });
   });
@@ -101,19 +101,17 @@ describe('APRTooltip', () => {
         'Total APR0.44% - 5.67%'
       );
       expect(getByTestId('swap-fee-apr').textContent).toBe(
-        '0.00% Swap fees APR'
+        'Swap fees APR 0.00%'
       );
-      expect(
-        getByTestId('staking-apr').children[0].children[0].textContent
-      ).toBe('0.44% Min staking APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[0]
-          .textContent
-      ).toBe('0.44% Min BAL APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[1]
-          .textContent
-      ).toBe('5.67% Max BAL APR');
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min staking APR 0.44%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min BAL APR 0.44%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Max BAL APR 5.67%'
+      );
     });
 
     it('Should show swap fees and staking rewards', () => {
@@ -137,19 +135,17 @@ describe('APRTooltip', () => {
         'Total APR2.71% - 7.78%'
       );
       expect(getByTestId('swap-fee-apr').textContent).toBe(
-        '2.23% Swap fees APR'
+        'Swap fees APR 2.23%'
       );
-      expect(
-        getByTestId('staking-apr').children[0].children[0].textContent
-      ).toBe('0.48% Min staking APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[0]
-          .textContent
-      ).toBe('0.48% Min BAL APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[1]
-          .textContent
-      ).toBe('5.55% Max BAL APR');
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min staking APR 0.48%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min BAL APR 0.48%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Max BAL APR 5.55%'
+      );
     });
 
     it('Should show staking rewards as a single line item if min and max are the same', () => {
@@ -169,18 +165,18 @@ describe('APRTooltip', () => {
           poolApr: aprBreakdown,
         },
       });
-      expect(getByTestId('staking-apr').textContent).toBe('7.63% Staking APR');
+      expect(getByTestId('staking-apr').textContent).toBe('Staking APR 7.63%');
     });
   });
 
   describe('Token Aprs', () => {
-    it('Should show stETH token APRs', () => {
+    it('Should show WETH token APRs', () => {
       const aprBreakdown: AprBreakdown = {
         ...EmptyAprBreakdownMock,
         tokenAprs: {
           total: 166,
           breakdown: {
-            [configService.network.tokens.Addresses.wstETH || '']: 166,
+            [configService.network.tokens.Addresses.WETH || '']: 166,
           },
         },
         min: 166,
@@ -188,7 +184,7 @@ describe('APRTooltip', () => {
       };
       const poolMock: Pool = {
         ...EmptyPoolMock,
-        tokensList: [configService.network.tokens.Addresses.wstETH || ''],
+        tokensList: [configService.network.tokens.Addresses.WETH || ''],
       };
       const { getByTestId } = renderComponent(APRTooltip, {
         props: {
@@ -196,61 +192,8 @@ describe('APRTooltip', () => {
           poolApr: aprBreakdown,
         },
       });
-      expect(getByTestId('total-apr').textContent).toBe('Total APR1.66%');
-      expect(getByTestId('yield-apr').textContent).toBe('1.66% Token APR');
-    });
-
-    it('Should show stMATIC token APRs', () => {
-      const aprBreakdown: AprBreakdown = {
-        ...EmptyAprBreakdownMock,
-        tokenAprs: {
-          total: 153,
-          breakdown: {
-            '0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4': 153,
-          },
-        },
-        min: 153,
-        max: 153,
-      };
-      const poolMock: Pool = {
-        ...EmptyPoolMock,
-        tokensList: [configService.network.tokens.Addresses.stMATIC || ''],
-      };
-      const { getByTestId } = renderComponent(APRTooltip, {
-        props: {
-          pool: poolMock,
-          poolApr: aprBreakdown,
-        },
-      });
-      expect(getByTestId('total-apr').textContent).toBe('Total APR1.53%');
-      expect(getByTestId('yield-apr').textContent).toBe('1.53% stMATIC APR');
-    });
-
-    it('Should show rETH token APRs', () => {
-      const aprBreakdown: AprBreakdown = {
-        ...EmptyAprBreakdownMock,
-        swapFees: 29,
-        tokenAprs: {
-          total: 73,
-          breakdown: {
-            [configService.network.tokens.Addresses.rETH || '']: 73,
-          },
-        },
-        min: 102,
-        max: 102,
-      };
-      const poolMock: Pool = {
-        ...EmptyPoolMock,
-        tokensList: [configService.network.tokens.Addresses.rETH || ''],
-      };
-      const { getByTestId } = renderComponent(APRTooltip, {
-        props: {
-          pool: poolMock,
-          poolApr: aprBreakdown,
-        },
-      });
-      expect(getByTestId('total-apr').textContent).toBe('Total APR1.02%');
-      expect(getByTestId('yield-apr').textContent).toBe('0.73% Token APR');
+      expect(getByTestId('total-apr').textContent).toContain('Total APR1.66%');
+      expect(getByTestId('yield-apr').textContent).toContain('WETH APR 1.66%');
     });
 
     it('Should show multiple token APRs with a generic header', () => {
@@ -279,17 +222,11 @@ describe('APRTooltip', () => {
         },
       });
       expect(getByTestId('total-apr').textContent).toBe('Total APR1.02%');
-      const yieldAprBreakdown = getByTestId('yield-apr').children[0];
-      expect(yieldAprBreakdown.children[0].textContent).toBe('2.54% Token APR');
-      expect(yieldAprBreakdown.children[1].children[0].textContent).toBe(
-        '1.18% wstETH APR'
-      );
-      expect(yieldAprBreakdown.children[1].children[1].textContent).toBe(
-        '1.04% sfrxETH APR'
-      );
-      expect(yieldAprBreakdown.children[1].children[2].textContent).toBe(
-        '0.32% rETH APR'
-      );
+      const yieldAprBreakdown = getByTestId('yield-apr');
+      expect(yieldAprBreakdown.textContent).toContain('Boosted APR 2.54%');
+      expect(yieldAprBreakdown.textContent).toContain('wstETH APR 1.18%');
+      expect(yieldAprBreakdown.textContent).toContain('sfrxETH APR 1.04%');
+      expect(yieldAprBreakdown.textContent).toContain('rETH APR 0.32%');
     });
 
     it('Should show a breakdown of a boosted pools linear pool APRs and staking rewards', () => {
@@ -329,30 +266,20 @@ describe('APRTooltip', () => {
       expect(getByTestId('total-apr').textContent).toBe(
         'Total APR1.75% - 2.20%'
       );
-      const yieldAprBreakdown = getByTestId('yield-apr').children[0];
-      expect(yieldAprBreakdown.children[0].textContent).toBe(
-        '1.31% Boosted APR'
+      const yieldAprBreakdown = getByTestId('yield-apr');
+      expect(yieldAprBreakdown.textContent).toContain('Boosted APR 1.31%');
+      expect(yieldAprBreakdown.textContent).toContain('bb-a-USDT APR 1.15%');
+      expect(yieldAprBreakdown.textContent).toContain('bb-a-USDC APR 0.04%');
+      expect(yieldAprBreakdown.textContent).toContain('bb-a-DAI APR 0.12%');
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min staking APR 0.30%'
       );
-      expect(yieldAprBreakdown.children[1].children[0].textContent).toBe(
-        '1.15% bb-a-USDT APR'
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min BAL APR 0.30%'
       );
-      expect(yieldAprBreakdown.children[1].children[1].textContent).toBe(
-        '0.04% bb-a-USDC APR'
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Max BAL APR 0.75%'
       );
-      expect(yieldAprBreakdown.children[1].children[2].textContent).toBe(
-        '0.12% bb-a-DAI APR'
-      );
-      expect(
-        getByTestId('staking-apr').children[0].children[0].textContent
-      ).toBe('0.30% Min staking APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[0]
-          .textContent
-      ).toBe('0.30% Min BAL APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[1]
-          .textContent
-      ).toBe('0.75% Max BAL APR');
     });
 
     it('Should show boosted staking rewards as a line item for pools that contain a boosted pool', () => {
@@ -380,18 +307,18 @@ describe('APRTooltip', () => {
       expect(getByTestId('total-apr').textContent).toBe(
         'Total APR5.95% - 14.46%'
       );
-      expect(getByTestId('yield-apr').textContent).toBe('0.28% Boosted APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[0].textContent
-      ).toBe('5.67% Min staking APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[0]
-          .textContent
-      ).toBe('5.67% Min BAL APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[1]
-          .textContent
-      ).toBe('14.18% Max BAL APR');
+      expect(getByTestId('yield-apr').textContent).toContain(
+        'Boosted APR 0.28%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min staking APR 5.67%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min BAL APR 5.67%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Max BAL APR 14.18%'
+      );
     });
 
     it('Should show veBAL staking rewards as a line item for pools that contain the 80/20 veBAL pool', () => {
@@ -414,7 +341,9 @@ describe('APRTooltip', () => {
         },
       });
       expect(getByTestId('total-apr').textContent).toBe('Total APR0.17%');
-      expect(getByTestId('yield-apr').textContent).toBe('0.17% veBAL APR');
+      expect(getByTestId('yield-apr').textContent).toContain(
+        'Boosted APR 0.17%'
+      );
     });
   });
 
@@ -445,23 +374,20 @@ describe('APRTooltip', () => {
         'Total APR1.67% - 6.45%'
       );
       expect(getByTestId('swap-fee-apr').textContent).toBe(
-        '0.00% Swap fees APR'
+        'Swap fees APR 0.00%'
       );
-      expect(
-        getByTestId('staking-apr').children[0].children[0].textContent
-      ).toBe('1.67% Min staking APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[0]
-          .textContent
-      ).toBe('0.44% Min BAL APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[1]
-          .textContent
-      ).toBe('5.22% Max BAL APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[2]
-          .textContent
-      ).toBe('1.23% Rewards APR');
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min staking APR 1.67%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Min BAL APR 0.44%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Max BAL APR 5.22%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Rewards APR 1.23%'
+      );
     });
 
     it('Should show BAL + staking rewards as line items if staking APR is the same but there are rewards', () => {
@@ -486,17 +412,13 @@ describe('APRTooltip', () => {
           poolApr: aprBreakdown,
         },
       });
-      expect(
-        getByTestId('staking-apr').children[0].children[0].textContent
-      ).toBe('10.51% Staking APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[0]
-          .textContent
-      ).toBe('7.63% BAL APR');
-      expect(
-        getByTestId('staking-apr').children[0].children[1].children[1]
-          .textContent
-      ).toBe('2.88% Rewards APR');
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Staking APR 10.51%'
+      );
+      expect(getByTestId('staking-apr').textContent).toContain('BAL APR 7.63%');
+      expect(getByTestId('staking-apr').textContent).toContain(
+        'Rewards APR 2.88%'
+      );
     });
   });
 });

--- a/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
@@ -50,6 +50,13 @@ const hasRewardTokens = computed((): boolean =>
   bnum(rewardTokensAPR.value).gt(0)
 );
 
+const realMinAPR = computed((): number =>
+  bnum(minBalAPR.value).plus(rewardTokensAPR.value).toNumber()
+);
+const realMaxAPR = computed((): number =>
+  bnum(maxBalAPR.value).plus(rewardTokensAPR.value).toNumber()
+);
+
 /**
  * @summary The total APR if we have the user's boost.
  */
@@ -66,15 +73,14 @@ const boostedTotalAPR = computed((): string => {
   return fNum(rewardTokensAPR.value, FNumFormats.bp);
 });
 
-/**
- * @summary The total APR if we have don't have the user's boost.
- */
-const unboostedTotalAPR = computed((): string =>
-  fNum(
-    bnum(minBalAPR.value).plus(rewardTokensAPR.value).toString(),
+const stakingAprRange = computed(() => {
+  if (isMinMaxSame.value) return fNum(realMinAPR.value, FNumFormats.bp);
+
+  return `${fNum(realMinAPR.value, FNumFormats.bp)} - ${fNum(
+    realMaxAPR.value,
     FNumFormats.bp
-  )
-);
+  )}`;
+});
 
 const breakdownItems = computed((): Array<any> => {
   const items: Array<any> = [];
@@ -111,22 +117,14 @@ const breakdownItems = computed((): Array<any> => {
   <div data-testid="staking-apr">
     <template v-if="hasBoost">
       <BalHStack justify="between" class="font-bold">
-        <span>
-          {{ $t('staking.stakingApr') }}
-        </span>
+        <span>Staking APR</span>
         {{ boostedTotalAPR }}
       </BalHStack>
     </template>
     <template v-else>
       <BalHStack justify="between" class="font-bold">
-        <span>
-          {{
-            isMinMaxSame
-              ? $t('staking.stakingApr')
-              : $t('staking.minimumStakingApr')
-          }}
-        </span>
-        {{ unboostedTotalAPR }}
+        <span>Staking APR</span>
+        {{ stakingAprRange }}
       </BalHStack>
       <BalVStack spacing="xs" class="mt-1">
         <BalHStack

--- a/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
@@ -6,7 +6,7 @@ import { bnum } from '@/lib/utils';
 import { Pool } from '@/services/pool/types';
 import { AprBreakdown } from '@balancer-labs/sdk';
 import { useTokens } from '@/providers/tokens.provider';
-import { hasBalEmissions, hasStakingRewards } from '@/composables/useAPR';
+import { hasBalEmissions } from '@/composables/useAPR';
 
 /**
  * TYPES
@@ -109,36 +109,36 @@ const breakdownItems = computed((): Array<any> => {
 
 <template>
   <div data-testid="staking-apr">
-    <div v-if="hasBoost">
-      <div class="flex items-center">
-        {{ boostedTotalAPR }}
-        <span class="ml-1 text-secondarytext-xs">
+    <template v-if="hasBoost">
+      <BalHStack justify="between" class="font-bold">
+        <span>
           {{ $t('staking.stakingApr') }}
         </span>
-      </div>
-    </div>
+        {{ boostedTotalAPR }}
+      </BalHStack>
+    </template>
     <template v-else>
-      <BalBreakdown
-        v-if="hasBalEmissions(apr) || hasStakingRewards(apr)"
-        :items="breakdownItems"
-      >
-        <div class="flex items-center">
-          {{ unboostedTotalAPR }}
-          <span class="ml-1 text-xs text-secondary">
-            {{
-              isMinMaxSame
-                ? $t('staking.stakingApr')
-                : $t('staking.minimumStakingApr')
-            }}
-          </span>
-        </div>
-        <template #item="{ item: [label, amount] }">
+      <BalHStack justify="between" class="font-bold">
+        <span>
+          {{
+            isMinMaxSame
+              ? $t('staking.stakingApr')
+              : $t('staking.minimumStakingApr')
+          }}
+        </span>
+        {{ unboostedTotalAPR }}
+      </BalHStack>
+      <BalVStack spacing="xs" class="mt-1">
+        <BalHStack
+          v-for="([label, amount], i) in breakdownItems"
+          :key="i"
+          justify="between"
+          class="text-gray-500"
+        >
+          <span class="ml-2">{{ label }} {{ $t('apr') }} </span>
           {{ fNum(amount, FNumFormats.bp) }}
-          <span class="ml-1 text-xs capitalize text-secondary">
-            {{ label }} {{ $t('apr') }}
-          </span>
-        </template>
-      </BalBreakdown>
+        </BalHStack>
+      </BalVStack>
     </template>
   </div>
 </template>

--- a/src/components/tooltips/APRTooltip/components/VeBalBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/VeBalBreakdown.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
-import { useI18n } from 'vue-i18n';
 
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 
@@ -20,31 +19,19 @@ const props = defineProps<Props>();
  * COMPOSABLES
  */
 const { fNum } = useNumbers();
-const { t } = useI18n();
 
 /**
  * COMPUTED
  */
 const aprLabel = computed((): string => fNum(props.apr, FNumFormats.bp));
-
-const items = computed((): string[] => [
-  t('tooltips.veBalApr.breakdown1'),
-  t('tooltips.veBalApr.breakdown2'),
-]);
 </script>
 
 <template>
-  <div data-testid="vebal-apr">
-    <BalBreakdown :items="items">
-      {{ aprLabel }}
-      <span class="ml-1 text-xs text-secondary">
-        {{ $t('tooltips.veBalApr.title') }}
-      </span>
-      <template #item="{ item }">
-        <div class="text-xs text-secondary">
-          {{ item }}
-        </div>
-      </template>
-    </BalBreakdown>
+  <div
+    data-testid="vebal-apr"
+    class="flex justify-between items-center text-sm font-bold"
+  >
+    <span>{{ $t('tooltips.veBalApr.title') }}</span>
+    <span>{{ aprLabel }}</span>
   </div>
 </template>

--- a/src/components/tooltips/APRTooltip/components/YieldBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/YieldBreakdown.vue
@@ -3,14 +3,8 @@ import { Pool } from '@/services/pool/types';
 import { AprBreakdown } from '@balancer-labs/sdk';
 import { getAddress } from '@ethersproject/address';
 import { computed } from 'vue';
-import { useI18n } from 'vue-i18n';
 
 import useNumbers, { FNumFormats } from '@/composables/useNumbers';
-import {
-  hasBoostedAPR,
-  isDeep,
-  isVeBalPoolAddress,
-} from '@/composables/usePoolHelpers';
 import { useTokens } from '@/providers/tokens.provider';
 
 /**
@@ -29,47 +23,14 @@ const props = defineProps<Props>();
 /**
  * COMPOSABLES
  */
-const { getToken, getTokens } = useTokens();
+const { getTokens } = useTokens();
 const { fNum } = useNumbers();
-const { t } = useI18n();
 
 /**
  * COMPUTED
  */
 const yieldAPRTokens = computed(() => {
   return getTokens(Object.keys(props.yieldAPR.breakdown));
-});
-
-const hasMultiRewardTokens = computed(
-  () => Object.keys(yieldAPRTokens.value).length > 1
-);
-
-const yieldAPRLabel = computed(() => {
-  const yieldTokensList = Object.keys(props.yieldAPR.breakdown);
-
-  if (isDeep(props.pool)) return t('yieldAprRewards.apr.boosted');
-
-  if (yieldTokensList.length > 1) {
-    return t('yieldAprRewards.apr.token');
-  }
-
-  if (yieldTokensList.length === 1) {
-    if (hasBoostedAPR(yieldTokensList[0]))
-      return t('yieldAprRewards.apr.boosted');
-    if (isVeBalPoolAddress(yieldTokensList[0]))
-      return t('yieldAprRewards.apr.veBAL');
-
-    const tokenAddress = getAddress(yieldTokensList[0]);
-    const token = getToken(tokenAddress);
-
-    if (!token) {
-      return t('yieldAprRewards.apr.token');
-    }
-
-    return `${token.symbol} ${t('apr')}`;
-  }
-
-  return '';
 });
 
 const yieldBreakdownItems = computed((): [string, number][] =>
@@ -79,20 +40,22 @@ const yieldBreakdownItems = computed((): [string, number][] =>
 
 <template>
   <div data-testid="yield-apr">
-    <BalBreakdown
-      :items="yieldBreakdownItems"
-      :hideItems="!hasMultiRewardTokens"
-    >
-      <div class="flex items-center">
-        {{ fNum(yieldAPR.total, FNumFormats.bp) }}
-        <span class="ml-1 text-xs text-secondary"> {{ yieldAPRLabel }} </span>
-      </div>
-      <template v-if="hasMultiRewardTokens" #item="{ item: [address, amount] }">
-        {{ fNum(amount, FNumFormats.bp) }}
-        <span class="ml-1 text-xs text-secondary">
+    <BalHStack justify="between" class="font-bold">
+      <span>{{ $t('yieldAprRewards.apr.boosted') }}</span>
+      {{ fNum(yieldAPR.total, FNumFormats.bp) }}
+    </BalHStack>
+    <BalVStack spacing="xs" class="mt-1">
+      <BalHStack
+        v-for="([address, amount], index) in yieldBreakdownItems"
+        :key="index"
+        justify="between"
+        class="text-gray-500"
+      >
+        <span class="ml-2">
           {{ yieldAPRTokens[getAddress(address)].symbol }} {{ $t('apr') }}
         </span>
-      </template>
-    </BalBreakdown>
+        {{ fNum(amount, FNumFormats.bp) }}
+      </BalHStack>
+    </BalVStack>
   </div>
 </template>

--- a/src/components/tooltips/APRTooltip/components/YieldBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/YieldBreakdown.vue
@@ -52,7 +52,7 @@ const yieldBreakdownItems = computed((): [string, number][] =>
         class="text-gray-500"
       >
         <span class="ml-2">
-          {{ yieldAPRTokens[getAddress(address)].symbol }} {{ $t('apr') }}
+          {{ yieldAPRTokens[getAddress(address)]?.symbol }} {{ $t('apr') }}
         </span>
         {{ fNum(amount, FNumFormats.bp) }}
       </BalHStack>

--- a/src/composables/usePoolHelpers.spec.ts
+++ b/src/composables/usePoolHelpers.spec.ts
@@ -601,7 +601,7 @@ test('generates APR label with boost', async () => {
     },
   });
 
-  expect(totalAprLabel(aprBreakdown, boost)).toBe('0.17%'); // swapFees + tokenAprsTotal + rewardAprsTotal
+  expect(totalAprLabel(aprBreakdown, boost, true)).toBe('0.17%'); // swapFees + tokenAprsTotal + rewardAprsTotal
 });
 
 test('generates APR label with boost', async () => {
@@ -634,7 +634,7 @@ test('generates APR label with boost', async () => {
   // (swapFees + tokenAprsTotal + rewardAprsTotal) = 10 + 5 + 2 = 17
   // (stakingAprMin * boost ) = 1.5 * 2.5 = 3.75
   // total = 17 + 3.75 = 20.75 --> 0.21%
-  expect(totalAprLabel(aprBreakdown, boost)).toBe('0.21%');
+  expect(totalAprLabel(aprBreakdown, boost, true)).toBe('0.21%');
 });
 
 test('generates absMaxApr when no boost', async () => {

--- a/src/composables/usePoolHelpers.ts
+++ b/src/composables/usePoolHelpers.ts
@@ -310,6 +310,7 @@ export function totalAprLabel(
     return '-';
   }
   if (boost && boost !== '1' && isConnected) {
+    console.log('boosted');
     return numF(absMaxApr(aprs, boost), FNumFormats.bp);
   }
   if (

--- a/src/composables/usePoolHelpers.ts
+++ b/src/composables/usePoolHelpers.ts
@@ -301,11 +301,15 @@ export function absMaxApr(aprs: AprBreakdown, boost?: string): string {
 /**
  * @summary Returns total APR label, whether range or single value.
  */
-export function totalAprLabel(aprs: AprBreakdown, boost?: string): string {
+export function totalAprLabel(
+  aprs: AprBreakdown,
+  boost?: string,
+  isConnected?: boolean
+): string {
   if (aprs.swapFees > APR_THRESHOLD) {
     return '-';
   }
-  if (boost) {
+  if (boost && boost !== '1' && isConnected) {
     return numF(absMaxApr(aprs, boost), FNumFormats.bp);
   }
   if (

--- a/src/dependencies/default-mocks.ts
+++ b/src/dependencies/default-mocks.ts
@@ -15,7 +15,6 @@ export function initDependenciesWithDefaultMocks() {
   initBalancerApiWithDefaultMocks();
   initBalancerSdkWithDefaultMocks();
   initRpcProviderServiceWithDefaultMocks();
-  //@ts-ignore
   initOldMulticallerWithDefaultMocks();
   initMulticallerWithDefaultMocks();
   initEthersContractWithDefaultMocks();

--- a/src/lib/config/avalanche/pools.ts
+++ b/src/lib/config/avalanche/pools.ts
@@ -10,7 +10,7 @@ const pools: Pools = {
     PerPool: 10,
     PerPoolInitial: 5,
   },
-  BoostsEnabled: false,
+  BoostsEnabled: true,
   DelegateOwner: '0xba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1b',
   ZeroAddress: '0x0000000000000000000000000000000000000000',
   DynamicFees: {

--- a/src/lib/config/base/pools.ts
+++ b/src/lib/config/base/pools.ts
@@ -7,7 +7,7 @@ const pools: Pools = {
     PerPool: 10,
     PerPoolInitial: 5,
   },
-  BoostsEnabled: false,
+  BoostsEnabled: true,
   DelegateOwner: '0xba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1ba1b',
   ZeroAddress: '0x0000000000000000000000000000000000000000',
   DynamicFees: {

--- a/src/lib/utils/styles.ts
+++ b/src/lib/utils/styles.ts
@@ -24,6 +24,7 @@ export const alignItemVariants = {
 
 export const ySpacingVariants = {
   none: 'space-y-0',
+  xs: 'space-y-1',
   sm: 'space-y-2',
   md: 'space-y-4',
   lg: 'space-y-8',

--- a/src/providers/local/pool-staking.provider.ts
+++ b/src/providers/local/pool-staking.provider.ts
@@ -92,7 +92,7 @@ export const poolStakingProvider = (_poolId?: string) => {
   const boost = computed((): string => {
     if (!boostsMap.value || !poolId.value) return '1';
 
-    return boostsMap[poolId.value];
+    return boostsMap[poolId.value] || '1';
   });
 
   // Addresses of all pool gauges.

--- a/tests/mount-helpers.ts
+++ b/tests/mount-helpers.ts
@@ -17,6 +17,7 @@ import { mount, MountResult } from './mount-composable-tester';
 import { registerTestPlugins } from './registerTestPlugins';
 import { DeepPartial } from './unit/types';
 import { Router } from 'vue-router';
+import { provideUserData } from '@/providers/user-data.provider';
 
 export const defaultStakedShares = '5';
 
@@ -37,6 +38,7 @@ export function mountComposable<R>(
   return mount<R>(callback, {
     provider: () => {
       provideWallets();
+      provideUserData();
       provideUserSettings();
       provideTokenLists();
       provideFakePoolStaking();


### PR DESCRIPTION
# Description

- Updates style of APR tooltip
- Fixes display of range or single value depending on if wallet is connected and if they have a boost > 1
- Introduces staking range APRs on Base and Avalance (should have been added when cross-chain syncing was enabled)

## Type of change

- [x] Code refactor / cleanup

## Visual context

<img width="387" alt="Screenshot 2023-10-11 at 16 43 31" src="https://github.com/balancer/frontend-v2/assets/2406506/c9ee3cf3-7489-46a8-9234-a1c815fb6020">

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
