### PR TITLE
fix: bug with lockable amount

### DIFF
--- a/src/components/forms/lock_actions/LockForm/components/VeBalForm/VeBalForm.vue
+++ b/src/components/forms/lock_actions/LockForm/components/VeBalForm/VeBalForm.vue
@@ -69,12 +69,19 @@ const submissionDisabled = computed(() => {
     return true;
   }
 
+  const lockableAmount = bnum(lockablePoolBptBalance.value || '0');
+  const toLockAmount = bnum(lockAmount.value || '0');
+
+  if (toLockAmount.isGreaterThan(lockableAmount)) {
+    return true;
+  }
+
   if (props.veBalLockInfo?.hasExistingLock && !props.veBalLockInfo?.isExpired) {
     return !isIncreasedLockAmount.value && !isExtendedLockEndDate.value;
   }
 
   return (
-    !bnum(lockablePoolBptBalance.value).gt(0) ||
+    !lockableAmount.gt(0) ||
     !isValidLockAmount.value ||
     !isValidLockEndDate.value
   );


### PR DESCRIPTION
# Description
There is a bug in lock flow when preview btn is not disabled when user inputs lock amount greater than lockable

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?
Try to lock/extend in veBAL form, preview btn should be disabled if entered lock amount is greater than lockable

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
