### PR TITLE
fix: no gauge id error in checkpoint error

### DIFF
--- a/src/components/contextual/pages/vebal/cross-chain-boost/StakingCardSyncAlert.vue
+++ b/src/components/contextual/pages/vebal/cross-chain-boost/StakingCardSyncAlert.vue
@@ -39,7 +39,7 @@ const canShowSyncAlert = computed(() => {
   if (
     isAffectedBy(PoolWarning.PoolProtocolFeeVulnWarning) ||
     isAffectedBy(PoolWarning.CspPoolVulnWarning) ||
-    !gauge
+    !gauge?.gauge.id
   ) {
     return false;
   }


### PR DESCRIPTION
# Description
It shouldn't be possible to open checkpoint gauge modal if gauge id is not defined

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
