### PR TITLE
fix: APR tooltip staking range

### DIFF
--- a/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
+++ b/src/components/tooltips/APRTooltip/components/StakingBreakdown.vue
@@ -7,6 +7,7 @@ import { Pool } from '@/services/pool/types';
 import { AprBreakdown } from '@balancer-labs/sdk';
 import { useTokens } from '@/providers/tokens.provider';
 import { hasBalEmissions } from '@/composables/useAPR';
+import useWeb3 from '@/services/web3/useWeb3';
 
 /**
  * TYPES
@@ -26,6 +27,7 @@ const props = defineProps<Props>();
  */
 const { fNum } = useNumbers();
 const { getToken } = useTokens();
+const { isWalletReady } = useWeb3();
 
 /**
  * COMPUTED
@@ -34,7 +36,9 @@ const { getToken } = useTokens();
 const apr = computed(() => props.pool?.apr || props.poolApr);
 
 const boost = computed((): string => props.pool?.boost || '');
-const hasBoost = computed((): boolean => !!boost.value);
+const hasBoost = computed(
+  (): boolean => !!boost.value && boost.value !== '1' && isWalletReady.value
+);
 const stakingAPR = computed(
   (): AprBreakdown['stakingApr'] | undefined => apr.value?.stakingApr
 );


### PR DESCRIPTION
# Description

Fixes staking APR in tooltip on pool pages when user's wallet is not connected or the boost value is 1.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
