### PR TITLE
chore: Add rate provider exception logic

### DIFF
--- a/src/components/contextual/pages/pool/PoolActionsCard.vue
+++ b/src/components/contextual/pages/pool/PoolActionsCard.vue
@@ -50,11 +50,22 @@ const { isAffectedBy } = usePoolWarning(computed(() => props.pool.id));
 const hasBpt = computed((): boolean =>
   bnum(balanceFor(props.pool.address)).gt(0)
 );
+
+const _hasNonApprovedRateProviders = computed(() => {
+  const nonApprovedRateProviderExceptions = [
+    '0x68e3266c9c8bbd44ad9dca5afbfe629022aee9fe000200000000000000000512',
+  ];
+  return (
+    hasNonApprovedRateProviders.value &&
+    !nonApprovedRateProviderExceptions.includes(props.pool.id)
+  );
+});
+
 const joinDisabled = computed(
   (): boolean =>
     !!deprecatedDetails(props.pool.id) ||
     isJoinsDisabled(props.pool.id) ||
-    hasNonApprovedRateProviders.value ||
+    _hasNonApprovedRateProviders.value ||
     isMigratablePool(props.pool) ||
     shouldDisableJoins.value
 );

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -731,7 +731,7 @@
   "noPriceImpact": "Best price",
   "noPriceImpactTip": "Adding tokens proportionally gets you the best price.",
   "noPriceInfo": "Price information is missing for this pool, since it contains a token not found by our price provider.",
-  "hasNonApprovedRateProviders": "One or more token rate providers associated with tokens in this pool have not been vetted. Investing has been disabled.",
+  "hasNonApprovedRateProviders": "One or more token rate providers associated with tokens in this pool have not been vetted.",
   "noRecentActivity": "Your recent activity will appear here…",
   "noResults": "No results",
   "noResultsTable": {


### PR DESCRIPTION
# Description

Adds logic that allows for exception when unvetted rate providers are blocking liquidity functions.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Test liquidity can be added to this pool on mainnet `0x68e3266c9c8bbd44ad9dca5afbfe629022aee9fe000200000000000000000512`

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
