### PR TITLE
Fix/reset vote selection

### DIFF
--- a/src/components/contextual/pages/vebal/providers/voting.provider.ts
+++ b/src/components/contextual/pages/vebal/providers/voting.provider.ts
@@ -39,7 +39,8 @@ export function votingProvider() {
   const {
     votingPools,
     votingGaugeAddresses,
-    isLoading: isLoadingVotingPools,
+    isLoadingVotingPools,
+    isRefetchingVotingPools,
   } = useVotingPools();
   const { data: expiredGauges, isLoading: isLoadingExpiredGauges } =
     useExpiredGaugesQuery(votingGaugeAddresses);
@@ -222,6 +223,7 @@ export function votingProvider() {
     isLoading,
     isLoadingExpiredGauges,
     isLoadingVotingPools,
+    isRefetchingVotingPools,
     totalAllocatedWeight,
     isRequestingTooMuchWeight,
     isVotingRequestValid,
@@ -233,6 +235,7 @@ export function votingProvider() {
     hasAllVotingPowerTimeLocked,
     hasTimeLockedPools,
     confirmedVotingRequest,
+    isVotingRequestLoaded,
     getIsGaugeExpired,
     toggleSelection,
     isSelected,

--- a/src/composables/useVotingPools.ts
+++ b/src/composables/useVotingPools.ts
@@ -93,7 +93,7 @@ export default function useVotingPools() {
 
   return {
     totalVotes,
-    isLoading,
+    isLoadingVotingPools: isLoading,
     isRefetchingVotingPools: votingPoolsQuery.isRefetching,
     votingPools,
     votingGauges,
@@ -103,5 +103,6 @@ export default function useVotingPools() {
     votingPeriodLastHour,
     votingPoolsQuery,
     refetchVotingPools: votingPoolsQuery.refetch,
+    resetVotingPools: votingPoolsQuery.remove,
   };
 }


### PR DESCRIPTION
# Description

The multivoting request was not being recreated when the on user account change.

The underlying code is probably too complex.

The main idea is that the first time we load the voting list decorated with votes, we also load an in memory votingRequest that is shared across the voting pages (list and forms) to store the current selection (pools + votes) of the user.
The issue was that, once the user account was changed the vue-queries were being reloaded but the votingRequest didn’t. We need watchers to know how to reset/update that votingRequest and that’s the complex part but I made them work in all scenarios.

If I had more time I would try to simplify the logic around this watchers but I think it is ok like it is now.

The key is that when [we detect that the user account changed](https://github.com/balancer/frontend-v2/pull/4480/files#diff-a1d6ae4ed6ef224aa4909fe06cb8dbeed56837acc510735a8fb2e8d8aa11bbfdR139), we reset the voting list query and the votingRequest to trigger a complete reload.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

https://github.com/balancer/frontend-v2/assets/1316240/32c9a90b-2e52-4ccc-b6e6-c4f54bfe78d6


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
