### PR TITLE
fix: Ensure single asset exits hidden for edge case

### DIFF
--- a/src/composables/usePoolHelpers.ts
+++ b/src/composables/usePoolHelpers.ts
@@ -612,12 +612,17 @@ export function isJoinsDisabled(id: string): boolean {
  * @param {Pool} pool - The pool to check
  */
 export function isRecoveryExitsOnly(pool: Pool): boolean {
-  return (
-    (!!pool.isInRecoveryMode && !!pool.isPaused) ||
-    (usePoolWarning(toRef(pool, 'id')).isAffectedBy(
+  const isInRecoveryAndPausedMode = !!pool.isInRecoveryMode && !!pool.isPaused;
+  const isVulnCsPoolAndInRecoveryMode =
+    usePoolWarning(toRef(pool, 'id')).isAffectedBy(
       PoolWarning.CspPoolVulnWarning
-    ) &&
-      !!pool.isInRecoveryMode)
+    ) && !!pool.isInRecoveryMode;
+  const isNotDeepAndCsV1 = !isDeep(pool) && isComposableStableV1(pool);
+
+  return (
+    isInRecoveryAndPausedMode ||
+    isVulnCsPoolAndInRecoveryMode ||
+    isNotDeepAndCsV1
   );
 }
 

--- a/src/providers/local/exit-pool.provider.ts
+++ b/src/providers/local/exit-pool.provider.ts
@@ -212,13 +212,8 @@ export const exitPoolProvider = (
       POOLS.ExitViaInternalBalance.includes(pool.value.id)
   );
 
-  // Should use recovery exits if:
-  // 1. The pool is paused AND in recovery mode, OR
-  // 2. The pool is a ComposableStableV1 pool and is not being treated as deep.
-  const shouldUseRecoveryExit = computed(
-    (): boolean =>
-      isRecoveryExitsOnly(pool.value) ||
-      (!isDeepPool.value && isComposableStableV1(pool.value))
+  const shouldUseRecoveryExit = computed((): boolean =>
+    isRecoveryExitsOnly(pool.value)
   );
 
   const exitHandlerType = computed((): ExitHandler => {


### PR DESCRIPTION
# Description

See title, moving all recovery exit logic into the recovery exit function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test withdrawals from this Polygon pool `0x8159462d255c1d24915cb51ec361f700174cd99400000000000000000000075d` it should only allow for proportional exits.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
