### PR TITLE
fix: Token filter removal

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -173,7 +173,7 @@ watch(poolTypeFilter, newPoolTypeFilter => {
                     :key="token"
                     :closeable="true"
                     class="mt-4"
-                    @closed="removeSelectedToken"
+                    @closed="removeSelectedToken(token)"
                   >
                     <BalAsset :address="token" :size="20" class="flex-auto" />
                     <span class="ml-2">{{ getToken(token)?.symbol }}</span>


### PR DESCRIPTION
# Description

On removing token filter tags, the address was not being passed so it would default to removing the last in the array. This fixes that.

Closes #4265

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
