### PR TITLE
Chore/vetted mev eth

### DIFF
--- a/src/lib/config/arbitrum/rateProviders.ts
+++ b/src/lib/config/arbitrum/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -15,4 +16,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/avalanche/rateProviders.ts
+++ b/src/lib/config/avalanche/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -6,4 +7,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/base/rateProviders.ts
+++ b/src/lib/config/base/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -6,4 +7,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/gnosis-chain/rateProviders.ts
+++ b/src/lib/config/gnosis-chain/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -6,4 +7,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/goerli/rateProviders.ts
+++ b/src/lib/config/goerli/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -30,4 +31,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/mainnet/rateProviders.ts
+++ b/src/lib/config/mainnet/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -18,4 +19,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/mainnet/rateProviders.ts
+++ b/src/lib/config/mainnet/rateProviders.ts
@@ -13,8 +13,8 @@ const rateProviders: RateProviders = {
   '0xa13a9247ea42d743238089903570127dda72fe44': {
     '0xa13a9247ea42d743238089903570127dda72fe44': true,
   },
-  '0x24Ae2dA0f361AA4BE46b48EB19C91e02c5e4f27E': {
-    '0xf518f2EbeA5df8Ca2B5E9C7996a2A25e8010014b': true,
+  '0x24ae2da0f361aa4be46b48eb19c91e02c5e4f27e': {
+    '0xf518f2ebea5df8ca2b5e9c7996a2a25e8010014b': true,
   },
 };
 

--- a/src/lib/config/optimism/rateProviders.ts
+++ b/src/lib/config/optimism/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -9,4 +10,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/polygon/rateProviders.ts
+++ b/src/lib/config/polygon/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -12,4 +13,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/sepolia/rateProviders.ts
+++ b/src/lib/config/sepolia/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -6,4 +7,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/config/zkevm/rateProviders.ts
+++ b/src/lib/config/zkevm/rateProviders.ts
@@ -1,3 +1,4 @@
+import { convertKeysToLowerCase } from '@/lib/utils/objects';
 import { RateProviders } from '../types';
 
 const rateProviders: RateProviders = {
@@ -6,4 +7,4 @@ const rateProviders: RateProviders = {
   },
 };
 
-export default rateProviders;
+export default convertKeysToLowerCase(rateProviders);

--- a/src/lib/utils/objects.spec.ts
+++ b/src/lib/utils/objects.spec.ts
@@ -1,0 +1,7 @@
+import { convertKeysToLowerCase } from './objects';
+
+it('convertKeysToLowerCase', () => {
+  expect(convertKeysToLowerCase({ Address1: { ADDRESS2: true } })).toEqual({
+    address1: { address2: true },
+  });
+});

--- a/src/lib/utils/objects.ts
+++ b/src/lib/utils/objects.ts
@@ -1,0 +1,30 @@
+/**
+ * Given an object like:
+ *
+ *    const obj = { Address1: { ADDRESS2: true } }
+ *
+ * converts all its keys to lowercase:
+ *
+ *    { address1: { address2: true } }
+ *
+ * User by config files to enable non-case-sensitive lookups.
+ */
+export function convertKeysToLowerCase(obj: any): any {
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => convertKeysToLowerCase(item));
+  }
+
+  const newObj: { [key: string]: any } = {};
+  for (const key in obj) {
+    // eslint-disable-next-line no-prototype-builtins
+    if (obj.hasOwnProperty(key)) {
+      const newKey = key.toLowerCase();
+      newObj[newKey] = convertKeysToLowerCase(obj[key]);
+    }
+  }
+  return newObj;
+}


### PR DESCRIPTION
# Description

The rate provider setup of [this pool](https://app.balancer.fi/#/ethereum/pool/0x58b645fa247b60f2cb896991fd8956146c9fcb4a00020000000000000000061d) was added in [this PR](https://github.com/balancer/frontend-v2/pull/4538) but the addresses had upper case letters so [this code](https://github.com/balancer/frontend-v2/blob/chore/vetted-mevETH/src/composables/usePoolHelpers.ts#L799) did not find them. 

This PR fixes the root cause by converting rateProvider's address keys so that the lookup becomes non case sensitive.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

The issue is fixed in the preview url: 

https://beta-app-v2-git-chore-vetted-meveth-balancer.vercel.app/#/ethereum/pool/0x58b645fa247b60f2cb896991fd8956146c9fcb4a00020000000000000000061d

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
