### PR TITLE
fix: veBAL balance loading state

### DIFF
--- a/src/components/contextual/pages/vebal/MyVebalInfo.vue
+++ b/src/components/contextual/pages/vebal/MyVebalInfo.vue
@@ -31,7 +31,7 @@ const { isLoadingLockPool, isLoadingLockInfo, lock } = useLock();
 const { fNum } = useNumbers();
 const router = useRouter();
 
-const { veBalBalance } = useVeBal();
+const { veBalBalance, isLoading: isLoadingVebalBalance } = useVeBal();
 const { t } = useI18n();
 const { isLoading, data: userHistoricalLocks } =
   useHistoricalLocksQuery(account);
@@ -58,7 +58,8 @@ const isLoadingData = computed(() => {
     isLoadingLockBoard.value ||
     isLoading.value ||
     isLoadingLockInfo.value ||
-    isLoadingLockPool.value
+    isLoadingLockPool.value ||
+    isLoadingVebalBalance.value
   );
 });
 

--- a/src/composables/useVeBAL.ts
+++ b/src/composables/useVeBAL.ts
@@ -80,7 +80,7 @@ export default function useVeBal() {
   /**
    * COMPOSABLES
    */
-  const { balanceFor, getToken } = useTokens();
+  const { balanceFor, getToken, balanceQueryLoading } = useTokens();
   const { networkConfig } = useConfig();
 
   /**
@@ -111,6 +111,7 @@ export default function useVeBal() {
     noVeBalBalance,
     lockablePoolId,
     showRedirectModal,
+    isLoading: balanceQueryLoading,
     // methods
     setShowRedirectModal,
   };


### PR DESCRIPTION
# Description

The veBAL page header wasn't waiting for the veBAL balance to be loaded before rendering which would result in a balance of 0.00 for a few seconds before balances were loaded. This PR just includes balance loading in the computed isLoading property so the whole header doesn't render until it's ready.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test veBAL balance on veBAL page never renders as 0.00 if you have a balance.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
