### PR TITLE
Chore: skip flaky test

### DIFF
--- a/src/composables/queries/useUserPoolSharesQuery.spec.ts
+++ b/src/composables/queries/useUserPoolSharesQuery.spec.ts
@@ -5,7 +5,7 @@ import { defaultPoolBalance } from '@tests/msw/graphql-handlers';
 
 initDependenciesWithDefaultMocks();
 
-test('Returns pool shares for the current user', async () => {
+test.skip('Returns pool shares for the current user', async () => {
   const { result } = mountComposable(() => useUserPoolSharesQuery());
 
   const data = await waitForQueryData(result);


### PR DESCRIPTION
# Description

Skip test causing flaky builds.

There is some concurrency problem when importing `balancerSubgraphService` from `useUserPoolSharesQuery` and this skipped test seems to make it more frequent. We skip it until we understand the root cause. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
