### PR TITLE
chore: Bump SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@aave/protocol-js": "^4.3.0",
         "@balancer-labs/assets": "github:balancer-labs/assets#master",
-        "@balancer-labs/sdk": "^1.1.6-beta.4",
+        "@balancer-labs/sdk": "^1.1.6-beta.7",
         "@balancer-labs/typechain": "^1.0.0",
         "@balancer-labs/v2-deployments": "^3.2.0",
         "@cowprotocol/contracts": "^1.3.1",
@@ -1602,9 +1602,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.1.6-beta.4",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.1.6-beta.4.tgz",
-      "integrity": "sha512-UDnx/vkuYzXIEOEeCaBS9Bj9w/kHRhwSfEmLTVeAQI+aEj97MMJITnVU3wTHGJl1Oo6m+AjAep8afgmtffZz5Q==",
+      "version": "1.1.6-beta.7",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.1.6-beta.7.tgz",
+      "integrity": "sha512-ndQYTEPWQicF0xvxkESZK2yXakUixzziU1uqKqkCpxxPC57fDlk1jT9xptTD1+5CvqyDgMLR7ToXBgnaEVJoqQ==",
       "dev": true,
       "dependencies": {
         "@balancer-labs/sor": "^4.1.1-beta.16",
@@ -29783,9 +29783,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.1.6-beta.4",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.1.6-beta.4.tgz",
-      "integrity": "sha512-UDnx/vkuYzXIEOEeCaBS9Bj9w/kHRhwSfEmLTVeAQI+aEj97MMJITnVU3wTHGJl1Oo6m+AjAep8afgmtffZz5Q==",
+      "version": "1.1.6-beta.7",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.1.6-beta.7.tgz",
+      "integrity": "sha512-ndQYTEPWQicF0xvxkESZK2yXakUixzziU1uqKqkCpxxPC57fDlk1jT9xptTD1+5CvqyDgMLR7ToXBgnaEVJoqQ==",
       "dev": true,
       "requires": {
         "@balancer-labs/sor": "^4.1.1-beta.16",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@aave/protocol-js": "^4.3.0",
     "@balancer-labs/assets": "github:balancer-labs/assets#master",
-    "@balancer-labs/sdk": "^1.1.6-beta.4",
+    "@balancer-labs/sdk": "^1.1.6-beta.7",
     "@balancer-labs/typechain": "^1.0.0",
     "@balancer-labs/v2-deployments": "^3.2.0",
     "@cowprotocol/contracts": "^1.3.1",


### PR DESCRIPTION
# Description

From SDK team:

> We received a [report](https://github.com/balancer/balancer-sdk/issues/553) saying that the FE/SOR was not finding a route between WXDAI and crvUSD last week and we just published a new SDK version ([v1.1.6-beta.7](https://www.npmjs.com/package/@balancer-labs/sdk/v/1.1.6-beta.7)) that fixes this by adding a new tri hop pool to the gnosis chain config.
It’s a small change that should not break anything

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
