### PR TITLE
Update veBAL balance to include commas for large amounts

### DIFF
--- a/src/components/contextual/pages/vebal/MyVebalInfo.vue
+++ b/src/components/contextual/pages/vebal/MyVebalInfo.vue
@@ -277,7 +277,7 @@ function navigateToGetVeBAL() {
         <div v-else class="flex flex-col flex-1">
           <div class="mb-2 text-xl font-bold">My veBAL</div>
           <div class="mb-10 text-5xl font-black">
-            {{ Number(veBalBalance).toFixed(2) }}
+            {{ fNum(veBalBalance) }}
           </div>
 
           <div class="flex flex-col gap-2 mb-8">

--- a/src/components/contextual/pages/vebal/MyVebalInfo.vue
+++ b/src/components/contextual/pages/vebal/MyVebalInfo.vue
@@ -2,7 +2,7 @@
 import { useLock } from '@/composables/useLock';
 import { bnum } from '@/lib/utils';
 import useWeb3 from '@/services/web3/useWeb3';
-import useNumbers from '@/composables/useNumbers';
+import useNumbers, { FNumFormats } from '@/composables/useNumbers';
 import { differenceInDays, format } from 'date-fns';
 import { PRETTY_DATE_FORMAT } from '@/components/forms/lock_actions/constants';
 import rank from '@/assets/images/icons/rank.svg';
@@ -277,7 +277,7 @@ function navigateToGetVeBAL() {
         <div v-else class="flex flex-col flex-1">
           <div class="mb-2 text-xl font-bold">My veBAL</div>
           <div class="mb-10 text-5xl font-black">
-            {{ fNum(veBalBalance) }}
+            {{ fNum(veBalBalance, FNumFormats.token) }}
           </div>
 
           <div class="flex flex-col gap-2 mb-8">


### PR DESCRIPTION
# Description

Got a request to add a comma for large veBAL balances. Also happy to go with the default 3 decimals than the previous 2 here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Impersonated with address: 0x31e9fFCFfd0e400a9d6adF0c25369fB4D513254f

Before:

![cs 2023-12-12 at 09 05 07@2x](https://github.com/balancer/frontend-v2/assets/149399376/56845645-1dea-42a3-a649-5cca5cd48193)

After:

![cs 2023-12-12 at 09 04 12@2x](https://github.com/balancer/frontend-v2/assets/149399376/db364402-9427-4428-84e9-1f5b9334a090)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
