### PR TITLE
fix: Overfetching sor pools

### DIFF
--- a/src/composables/swap/useSor.ts
+++ b/src/composables/swap/useSor.ts
@@ -149,6 +149,12 @@ export function calcPriceImpact(
   return priceImpact;
 }
 
+const sorManager = new SorManager(
+  rpcProviderService.jsonProvider,
+  BigNumber.from(GAS_PRICE),
+  Number(MAX_POOLS)
+);
+
 export default function useSor({
   exactIn,
   tokenInAddressInput,
@@ -166,7 +172,6 @@ export default function useSor({
   slippageBufferRate,
   isCowswapSwap,
 }: Props) {
-  let sorManager: SorManager | undefined = undefined;
   const pools = ref<SubgraphPoolBase[]>([]);
   const sorReturn = ref<SorReturn>({
     hasSwaps: false,
@@ -214,7 +219,7 @@ export default function useSor({
       unknownAssets.push(tokenOutAddressInput.value);
     }
     await injectTokens(unknownAssets);
-    await initSor();
+    await fetchPools();
     await handleAmountChange();
   });
 
@@ -223,16 +228,6 @@ export default function useSor({
     state.validationErrors.noSwaps = false;
 
     state.submissionError = null;
-  }
-
-  async function initSor(): Promise<void> {
-    sorManager = new SorManager(
-      rpcProviderService.jsonProvider,
-      BigNumber.from(GAS_PRICE),
-      Number(MAX_POOLS)
-    );
-
-    fetchPools();
   }
 
   async function fetchPools(): Promise<void> {
@@ -829,7 +824,6 @@ export default function useSor({
     sorManager,
     sorReturn,
     pools,
-    initSor,
     handleAmountChange,
     exactIn,
     swap,

--- a/src/lib/balancer.sdk.ts
+++ b/src/lib/balancer.sdk.ts
@@ -2,7 +2,7 @@ import { BalancerSDK } from '@balancer-labs/sdk';
 import { Network } from '@/lib/config/types';
 import { configService } from '@/services/config/config.service';
 import { ref } from 'vue';
-import { isTestMode } from '@/plugins/modes';
+// import { isTestMode } from '@/plugins/modes';
 
 export const balancer = new BalancerSDK({
   network: configService.network.chainId as Network,
@@ -21,4 +21,4 @@ export async function fetchPoolsForSor() {
   console.timeEnd('fetchPoolsForSor');
 }
 
-if (!isTestMode()) fetchPoolsForSor();
+// if (!isTestMode()) fetchPoolsForSor();


### PR DESCRIPTION
# Description

We were loading SOR pools on page load and whenever you visited the swap page. The swap page was also fetching every time you revised the page which is unnecessary.

- Prevents initial global fetch, this was for swap join/exit flows to speed up the flows, but it now seems to be affecting the global UX. The handlers themselves trigger a fetch if it hasn't been loaded globally so this won't break anything.
- Moves instantiation of SorManager outside of useSor so fetching is not retriggered every time you visit the swap page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Click around the app on Polygon an notice if anything is laggy. Try again on Production and see if there is a difference. In particular click in and out of the swap page.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
