### PR TITLE
fix: hide rank if no vebal balance

### DIFF
--- a/src/components/contextual/pages/vebal/MyVebalInfo.vue
+++ b/src/components/contextual/pages/vebal/MyVebalInfo.vue
@@ -168,8 +168,8 @@ const userRank = computed(() => {
 
 const vebalInfo = computed(() => {
   const arr: { icon: any; value: string }[] = [];
-
-  if (bnum(veBalBalance.value).isGreaterThan(0)) {
+  const hasVebalBalance = bnum(veBalBalance.value).isGreaterThan(0);
+  if (hasVebalBalance) {
     arr.push({
       icon: share,
       value: t('veBAL.myVeBAL.cards.myVeBAL.secondaryText', [
@@ -186,7 +186,7 @@ const vebalInfo = computed(() => {
     });
   }
 
-  if (userRank.value) {
+  if (hasVebalBalance && userRank.value) {
     arr.unshift({
       icon: rank,
       value: `Rank ${userRank.value}`,


### PR DESCRIPTION
# Description
Hide user rank if no veBal balance

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context
![Screenshot 2024-01-08 at 11 26 13](https://github.com/balancer/frontend-v2/assets/46521087/93c0f71b-3056-4435-95b7-af38bfc8c9c6)


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
