### PR TITLE
fix: Avax explorer links

### DIFF
--- a/src/lib/config/avalanche/index.ts
+++ b/src/lib/config/avalanche/index.ts
@@ -23,7 +23,7 @@ const config: Config = {
   rpc: `https://avalanche-mainnet.infura.io/v3/${keys.infura}`,
   ws: `wss://api.avax.network/ext/bc/C/ws`,
   publicRpc: 'https://avalanche.public-rpc.com',
-  explorer: 'https://snowtrace.io/',
+  explorer: 'https://snowtrace.io',
   explorerName: 'Snowtrace',
   subgraph:
     'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-avalanche-v2',


### PR DESCRIPTION
# Description

We had an additional slash injected into explorer links.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
