### PR TITLE
Fix: take old weights into account when ordering weights for multivote

### DIFF
--- a/src/components/contextual/pages/vebal/providers/voting.provider.spec.ts
+++ b/src/components/contextual/pages/vebal/providers/voting.provider.spec.ts
@@ -181,7 +181,7 @@ describe('Returns confirmedVotingRequest', () => {
     votingRequest.value[gaugeAddress2] = '50';
 
     /*
-     gaugeAddress1 wight is the smallest (20%) but
+     gaugeAddress1 weight is the smallest (20%) but
      gaugeAddress2 vote must come first because weight is updating from 100% to 50%
     */
     expect(confirmedVotingRequest.value).toEqual([

--- a/src/components/contextual/pages/vebal/providers/voting.provider.ts
+++ b/src/components/contextual/pages/vebal/providers/voting.provider.ts
@@ -65,15 +65,22 @@ export function votingProvider() {
   );
 
   /***
-   * Order by vote weight (from smallest to largest)
-   * to avoid going above max voting power when multi-voting in the contract
+   * Order by weight increment (from smallest to largest)
+   * to avoid going above max voting power when multi-voting in the contract,
+   * where weight increment for a given pool is the difference between the old exiting weight and the new requested weight
    */
   const unlockedSelectedPoolsOrderedByWeight = computed(() =>
-    unlockedSelectedPools.value.sort(
-      (a, b) =>
-        parseFloat(votingRequest.value[a.gauge.address]) -
-        parseFloat(votingRequest.value[b.gauge.address])
-    )
+    unlockedSelectedPools.value.sort((a, b) => {
+      const oldWeightA = Number(bpsToShares(a.userVotes));
+      const newWeightA = parseFloat(votingRequest.value[a.gauge.address]);
+      const weightIncrementA = newWeightA - oldWeightA;
+
+      const oldWeightB = Number(bpsToShares(b.userVotes));
+      const newWeightB = parseFloat(votingRequest.value[b.gauge.address]);
+      const weightIncrementB = newWeightB - oldWeightB;
+
+      return weightIncrementA - weightIncrementB;
+    })
   );
 
   const confirmedVotingRequest = computed(


### PR DESCRIPTION
# Description

Fixes an ordering issue when sending parameters to `vote_for_many_gauge_weights` call.

Example: 

The user had 100% allocated to gaugeA

Now they want to allocate: 
50% to gaugeA
50% to gaugeB

If we sent gaugeB parameters before gaugeA parameters, there was an error: `Used to much power`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [ ] The base of this PR is `master` if hotfix, `develop` if not
