### PR TITLE
Fix typo in pool liquidity add form

### DIFF
--- a/src/components/forms/pool_actions/AddLiquidityForm/components/AddLiquidityTotals.vue
+++ b/src/components/forms/pool_actions/AddLiquidityForm/components/AddLiquidityTotals.vue
@@ -73,7 +73,7 @@ const {
           <BalLoadingBlock v-else class="w-10" />
 
           <BalTooltip
-            :text="`LP tokens you are expected to recieve, not
+            :text="`LP tokens you are expected to receive, not
           including possible slippage (${fNum(slippage, FNumFormats.percent)})`"
           >
             <template #activator>


### PR DESCRIPTION
Just fixing a typo I found while using the frontend :heart: 