### PR TITLE
fix pools composition on vebal page

### DIFF
--- a/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
+++ b/src/components/contextual/pages/vebal/LMVoting/GaugesTable.vue
@@ -252,7 +252,7 @@ function getPickedTokens(tokens: VotingPool['tokens']) {
       </template>
       <template #poolCompositionCell="pool: VotingPool">
         <div v-if="!isLoading" class="flex items-center py-4 px-6">
-          <div v-if="poolMetadata(pool.id)" class="text-left">
+          <div v-if="poolMetadata(pool.id)?.name" class="text-left">
             {{ poolMetadata(pool.id)?.name }}
           </div>
           <TokenPills


### PR DESCRIPTION
# Description

Fix condition for showing pool name from metadata. We have some pools that have metadata (points) but not a name set up so previous if-condition broke the composition.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] Go to veBAL page and verify all pools have composition rendered as expected

## Visual context

BEFORE FIX:

<img width="1013" alt="image" src="https://github.com/balancer/frontend-v2/assets/43360747/4a74a0ff-93a1-4bba-95c3-aadb1fb5c416">

AFTER FIX:

<img width="961" alt="image" src="https://github.com/balancer/frontend-v2/assets/43360747/ca28a22f-cabc-40c7-abd8-c2ede248fdb6">


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
