### PR TITLE
fix: Block joins page if unapproved rate provider

### DIFF
--- a/src/composables/contextual/add-liquidity/useDisabledJoinsGuard.spec.ts
+++ b/src/composables/contextual/add-liquidity/useDisabledJoinsGuard.spec.ts
@@ -43,6 +43,7 @@ async function mountTransferGuards(pool: Pool) {
 describe('When checking disabled pool joins', () => {
   it('does not redirect where no disabled joins', async () => {
     const veBalPool = aVeBalPool();
+    veBalPool.priceRateProviders = [];
 
     await mountTransferGuards(veBalPool);
 


### PR DESCRIPTION
# Description

See title.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Test that you cannot access the add-liquidity path if a rate provider is unapproved for a pool.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
