### PR TITLE
chore: Add OP blocks subgraph to config

### DIFF
--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -35,7 +35,8 @@ const config: Config = {
     aave: '',
     gauge:
       'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-optimism',
-    blocks: 'https://api.thegraph.com/subgraphs/name/iliaazhel/optimism-blocklytics',
+    blocks: 
+      'https://api.thegraph.com/subgraphs/name/iliaazhel/optimism-blocklytics',
   },
   bridgeUrl: '',
   supportsEIP1559: false,

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -35,7 +35,7 @@ const config: Config = {
     aave: '',
     gauge:
       'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-optimism',
-    blocks: '',
+    blocks: 'https://api.thegraph.com/subgraphs/name/iliaazhel/optimism-blocklytics',
   },
   bridgeUrl: '',
   supportsEIP1559: false,

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -35,7 +35,7 @@ const config: Config = {
     aave: '',
     gauge:
       'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-optimism',
-    blocks: 
+    blocks:
       'https://api.thegraph.com/subgraphs/name/iliaazhel/optimism-blocklytics',
   },
   bridgeUrl: '',


### PR DESCRIPTION
# Description

Add missing op block subgraph.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Verify that you can query block/timestamp data on Optimism

## Visual context

Please provide any relevant visual context for UI changes or additions. This could be static screenshots or a loom screencast.

## Checklist:

- [x ] I have performed a self-review of my own code
- [ x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas
- [ ] If package-lock.json has changes, it was intentional.
- [x ] The base of this PR is `master` if hotfix, `develop` if not
