### PR TITLE
chore: Remove pool allowlisting

### DIFF
--- a/src/components/pool/PoolPageHeader.vue
+++ b/src/components/pool/PoolPageHeader.vue
@@ -310,24 +310,12 @@ function symbolFor(titleTokenIndex: number): string {
   </BalAlert>
 
   <BalAlert
-    v-if="
-      disableJoinsReason.requiresAllowListing ||
-      disableJoinsReason.nonAllowedWeightedPoolAfterTimestamp
-    "
-    type="warning"
-    :title="$t('requiresAllowListing1')"
+    v-if="disableJoinsReason.isBlocked"
+    type="error"
+    :title="$t('blockedPool')"
     class="mt-2"
     block
-  >
-    {{ $t('Click') }}
-    <a
-      href="https://github.com/balancer/frontend-v2/wiki/How-tos#add-a-new-pool"
-      target="_blank"
-      class="underline"
-      >{{ $t('here') }}</a
-    >
-    {{ $t('requiresAllowListing2') }}
-  </BalAlert>
+  />
 </template>
 <style scoped>
 .pool-title {

--- a/src/composables/useDisabledJoinPool.spec.ts
+++ b/src/composables/useDisabledJoinPool.spec.ts
@@ -63,40 +63,6 @@ it('allows joins for pools on test networks with non vetted tokens', async () =>
   expect(shouldDisableJoins.value).toBeFalse();
 });
 
-it('disables joins for weighted pools created after timestamp (2023-03-29) that are not in the weighted allow list', async () => {
-  const { networkId } = useNetwork();
-  networkId.value = 1;
-
-  const pool = aBoostedPool();
-  pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
-  pool.poolType = PoolType.Weighted;
-  const { disableJoinsReason, shouldDisableJoins } =
-    await mountVettedTokensInPool(pool);
-
-  pool.tokens[0].address = randomAddress();
-
-  expect(shouldDisableJoins.value).toBeTrue();
-  expect(
-    disableJoinsReason.value.nonAllowedWeightedPoolAfterTimestamp
-  ).toBeTrue();
-});
-
-it('allows joins for weighted pools on test networks created after timestamp (2023-03-29) that are not in the weighted allow list', async () => {
-  const { networkId } = useNetwork();
-  networkId.value = 5;
-
-  const pool = aBoostedPool();
-  pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
-  pool.poolType = PoolType.Weighted;
-  const { disableJoinsReason } = await mountVettedTokensInPool(pool);
-
-  pool.tokens[0].address = randomAddress();
-
-  expect(
-    disableJoinsReason.value.nonAllowedWeightedPoolAfterTimestamp
-  ).toBeFalse();
-});
-
 it('does not disables joins for pools created before 29 march', async () => {
   const pool = aBoostedPool();
   pool.createTime = dateToUnixTimestamp('2023-03-28'); //Created before 29 March
@@ -126,7 +92,6 @@ it('disabled joins for pools FX pool', async () => {
   const { shouldDisableJoins, disableJoinsReason } =
     await mountVettedTokensInPool(pool);
 
-  expect(disableJoinsReason.value.requiresAllowListing).toBeTrue();
   expect(shouldDisableJoins.value).toBeTrue();
   expect(disableJoinsReason.value.nonVettedTokensAfterTimestamp).toBeFalse();
   expect(disableJoinsReason.value.notInitialLiquidity).toBeFalse();

--- a/src/composables/useDisabledJoinPool.spec.ts
+++ b/src/composables/useDisabledJoinPool.spec.ts
@@ -1,14 +1,8 @@
-import { initDependenciesWithDefaultMocks } from '@/dependencies/default-mocks';
-import { Pool, PoolType } from '@/services/pool/types';
 import { aBoostedPool } from '@/__mocks__/boosted-pool';
-import { aPoolToken } from '@/__mocks__/weighted-pool';
+import { initDependenciesWithDefaultMocks } from '@/dependencies/default-mocks';
+import { Pool } from '@/services/pool/types';
 import { mountComposableWithFakeTokensProvider as mountComposable } from '@tests/mount-helpers';
-import {
-  balAddress,
-  daiAddress,
-  randomAddress,
-} from '@tests/unit/builders/address';
-import { aPool } from '@tests/unit/builders/pool.builders';
+import { randomAddress } from '@tests/unit/builders/address';
 import { useDisabledJoinPool } from './useDisabledJoinPool';
 import useNetwork from './useNetwork';
 import { dateToUnixTimestamp } from './useTime';
@@ -43,27 +37,4 @@ it('allows joins for pools on test networks with non vetted tokens', async () =>
 
   console.log('Reason: ', disableJoinsReason.value);
   expect(shouldDisableJoins.value).toBeFalse();
-});
-
-it('disabled joins for pools FX pool', async () => {
-  const pool = aPool({
-    totalShares: '100',
-    createTime: dateToUnixTimestamp('2023-03-28'),
-    owner: randomAddress(),
-    poolType: PoolType.Investment, // Requires Allow listing
-    tokens: [
-      aPoolToken({ address: daiAddress, symbol: 'DAI' }),
-      aPoolToken({ address: balAddress, symbol: 'BAL' }),
-    ],
-  });
-
-  const { networkId } = useNetwork();
-  networkId.value = 1;
-
-  const { shouldDisableJoins, disableJoinsReason } =
-    await mountVettedTokensInPool(pool);
-
-  expect(shouldDisableJoins.value).toBeTrue();
-  expect(disableJoinsReason.value.nonVettedTokensAfterTimestamp).toBeFalse();
-  expect(disableJoinsReason.value.notInitialLiquidity).toBeFalse();
 });

--- a/src/composables/useDisabledJoinPool.spec.ts
+++ b/src/composables/useDisabledJoinPool.spec.ts
@@ -30,24 +30,6 @@ it('disables joins for pools with no initial liquidity', async () => {
   expect(disableJoinsReason.value.notInitialLiquidity).toBeTrue();
 });
 
-it('disables joins for pools created after timestamp (2023-03-29) with non vetted tokens', async () => {
-  const { networkId } = useNetwork();
-  networkId.value = 1;
-
-  const pool = aBoostedPool();
-  pool.createTime = dateToUnixTimestamp('2023-03-30'); //Created after 29 March
-  const { disableJoinsReason, shouldDisableJoins, nonAllowedSymbols } =
-    await mountVettedTokensInPool(pool);
-
-  pool.tokens[0].address = randomAddress();
-
-  expect(shouldDisableJoins.value).toBeTrue();
-  expect(disableJoinsReason.value.nonVettedTokensAfterTimestamp).toBeTrue();
-  expect(nonAllowedSymbols.value).toMatchInlineSnapshot(
-    '"bb-a-USDT,USDT,bb-a-USDC,USDC,bb-a-DAI,DAI"'
-  );
-});
-
 it('allows joins for pools on test networks with non vetted tokens', async () => {
   const { networkId } = useNetwork();
   networkId.value = 5;
@@ -60,17 +42,6 @@ it('allows joins for pools on test networks with non vetted tokens', async () =>
   pool.tokens[0].address = randomAddress();
 
   console.log('Reason: ', disableJoinsReason.value);
-  expect(shouldDisableJoins.value).toBeFalse();
-});
-
-it('does not disables joins for pools created before 29 march', async () => {
-  const pool = aBoostedPool();
-  pool.createTime = dateToUnixTimestamp('2023-03-28'); //Created before 29 March
-  pool.totalShares = '100';
-  const { shouldDisableJoins, disableJoinsReason } =
-    await mountVettedTokensInPool(pool);
-
-  expect(disableJoinsReason.value.nonVettedTokensAfterTimestamp).toBeFalse();
   expect(shouldDisableJoins.value).toBeFalse();
 });
 

--- a/src/lib/config/arbitrum/pools.ts
+++ b/src/lib/config/arbitrum/pools.ts
@@ -96,8 +96,7 @@ const pools: Pools = {
     AllowList: [''],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [
       '0xd449efa0a587f2cb6be3ae577bc167a7745258100001000000000000000003f4',
       '0xce34c867d7053befb3421d6adabcb5ce55ff777b00010000000000000000041b', // crv/wbtc/wsteth/gdai/uni/link

--- a/src/lib/config/avalanche/pools.ts
+++ b/src/lib/config/avalanche/pools.ts
@@ -47,8 +47,7 @@ const pools: Pools = {
     AllowList: [''],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [
       '0xe4a4565ad31a3af8286bc6e6dbb20ba76752557700010000000000000000000b',
       '0x3bde1563903ebb564ca37d5736afbb850929cfd7000200000000000000000017', // ankrAVAX-ankrETH

--- a/src/lib/config/base/pools.ts
+++ b/src/lib/config/base/pools.ts
@@ -43,8 +43,7 @@ const pools: Pools = {
     AllowList: [],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [
       '0xcde67b70e8144d7d2772de59845b3a67266c2ca7000200000000000000000009', // BAL/DAI
       '0x868f0efc81a6c1df16298dcc82f7926b9099946b00020000000000000000000b', // Bald/weth

--- a/src/lib/config/gnosis-chain/pools.ts
+++ b/src/lib/config/gnosis-chain/pools.ts
@@ -47,8 +47,7 @@ const pools: Pools = {
     AllowList: [],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [
       '0x915938ff0a2b54e575068ff1a95007cafba7d27700020000000000000000008a', // 80REG-20WXDAI
       '0xa99fd9950b5d5dceeaf4939e221dca8ca9b938ab000100000000000000000025', // 25WETH-25BAL-25GNO-25wxDAI

--- a/src/lib/config/goerli/pools.ts
+++ b/src/lib/config/goerli/pools.ts
@@ -71,8 +71,7 @@ const pools: Pools = {
     AllowList: [],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [
       '0xbb372d299cc1afa14d5b8691ced1486fa0216f74000200000000000000000757', // DVT /WETH
       '0x4dc5ef9b11fd462d78e197f8a98089933174b2c5000200000000000000000836', //tkn1/tkn2

--- a/src/lib/config/mainnet/pools.ts
+++ b/src/lib/config/mainnet/pools.ts
@@ -184,8 +184,7 @@ const pools: Pools = {
     ],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [
       '0x8e6c196e201942246cef85718c5d3a5622518053000200000000000000000582', // 80LE/20WETH
       '0x67f117350eab45983374f4f83d275d8a5d62b1bf0001000000000000000004f2', // GRAIN/OATH/USDC/WETH

--- a/src/lib/config/polygon/pools.ts
+++ b/src/lib/config/polygon/pools.ts
@@ -125,8 +125,7 @@ const pools: Pools = {
     AllowList: [''],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [
       '0x7104ad560c1d74aabc108bc51114db121b927a9d000200000000000000000b2a', // 80XES/20USDC
       '0x3efb91c4f9b103ee45885695c67794591916f34e000200000000000000000b43', // bb-am-usd/2brl

--- a/src/lib/config/sepolia/pools.ts
+++ b/src/lib/config/sepolia/pools.ts
@@ -38,8 +38,7 @@ const pools: Pools = {
     AllowList: [],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [],
   },
   Factories: {},

--- a/src/lib/config/zkevm/pools.ts
+++ b/src/lib/config/zkevm/pools.ts
@@ -45,8 +45,7 @@ const pools: Pools = {
     AllowList: [],
   },
   Weighted: {
-    // Only effective after given timestamp here: usePool.ts#createdAfterTimestamp
-    // see useDisabledJoinPool.ts#nonAllowedWeightedPoolAfterTimestamp for logic.
+    // Deprecated list, no longer in use
     AllowList: [
       '0x5480b5f610fa0e11e66b42b977e06703c07bc5cf000200000000000000000008',
       '0xa7f602cfaf75a566cb0ed110993ee81c27fa3f53000200000000000000000009',

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -116,6 +116,7 @@
   "buy": "Buy",
   "build": "Build",
   "blog": "Blog",
+  "blockedPool": "This pool has been blocked in the UI.",
   "boostedPool": "Balancer Boosted pool",
   "byConnectingWallet": "By connecting a wallet, I agree to Balancer Foundation’s",
   "brandedRedirect": {


### PR DESCRIPTION
Since allowlisting is really controlled by the tokenlist we are reverting to a reactive approach to pool blocking in the UI. 