### PR TITLE
update subgraphs to studio

### DIFF
--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -25,17 +25,15 @@ const config: Config = {
   publicRpc: 'https://arb1.arbitrum.io/rpc',
   explorer: 'https://arbiscan.io',
   explorerName: 'Arbiscan',
-  subgraph:
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2',
+  subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/98cQDy6tufTJtshDCuhh9z2kWXsQWBHVh2bqnLHsGAeS`,
   balancerApi: 'https://api.balancer.fi',
   poolsUrlV2: '',
   subgraphs: {
     main: [
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2',
+      `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/98cQDy6tufTJtshDCuhh9z2kWXsQWBHVh2bqnLHsGAeS`,
     ],
     aave: '',
-    gauge:
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-arbitrum',
+    gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/Bb1hVjJZ52kL23chZyyGWJKrGEg3S6euuNa1YA6XRU4J`,
     blocks:
       'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
   },

--- a/src/lib/config/arbitrum/index.ts
+++ b/src/lib/config/arbitrum/index.ts
@@ -34,8 +34,7 @@ const config: Config = {
     ],
     aave: '',
     gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/Bb1hVjJZ52kL23chZyyGWJKrGEg3S6euuNa1YA6XRU4J`,
-    blocks:
-      'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
+    blocks: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/5jebsN6RBioFWQX7LP2N8r55nL4QPAyeKc6GzDA1Pt5H`,
   },
   bridgeUrl: 'https://bridge.arbitrum.io/',
   supportsEIP1559: false,

--- a/src/lib/config/avalanche/index.ts
+++ b/src/lib/config/avalanche/index.ts
@@ -25,17 +25,15 @@ const config: Config = {
   publicRpc: 'https://avalanche.public-rpc.com',
   explorer: 'https://snowtrace.io',
   explorerName: 'Snowtrace',
-  subgraph:
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-avalanche-v2',
+  subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/7asfmtQA1KYu6CP7YVm5kv4bGxVyfAHEiptt2HMFgkHu`,
   balancerApi: 'https://api.balancer.fi',
   poolsUrlV2: '',
   subgraphs: {
     main: [
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-avalanche-v2',
+      `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/7asfmtQA1KYu6CP7YVm5kv4bGxVyfAHEiptt2HMFgkHu`,
     ],
     aave: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v2-avalanche',
-    gauge:
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-avalanche',
+    gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/GzGBUh1X4Cq9RBdyKoCrPLhYW1saBYHwFBgcTsARPYUG`,
     blocks:
       'https://api.thegraph.com/subgraphs/name/iliaazhel/avalanche-blocks',
   },

--- a/src/lib/config/avalanche/index.ts
+++ b/src/lib/config/avalanche/index.ts
@@ -34,8 +34,7 @@ const config: Config = {
     ],
     aave: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/EZvK18pMhwiCjxwesRLTg81fP33WnR6BnZe5Cvma3H1C`,
     gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/GzGBUh1X4Cq9RBdyKoCrPLhYW1saBYHwFBgcTsARPYUG`,
-    blocks:
-      'https://api.thegraph.com/subgraphs/name/iliaazhel/avalanche-blocks',
+    blocks: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/97YH6dMhGcXoTvVwDAML6GxYm9hBh7PCz6WPscUkrFhv`,
   },
   bridgeUrl: 'https://core.app/bridge/',
   supportsEIP1559: false,

--- a/src/lib/config/avalanche/index.ts
+++ b/src/lib/config/avalanche/index.ts
@@ -32,7 +32,7 @@ const config: Config = {
     main: [
       `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/7asfmtQA1KYu6CP7YVm5kv4bGxVyfAHEiptt2HMFgkHu`,
     ],
-    aave: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v2-avalanche',
+    aave: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/EZvK18pMhwiCjxwesRLTg81fP33WnR6BnZe5Cvma3H1C`,
     gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/GzGBUh1X4Cq9RBdyKoCrPLhYW1saBYHwFBgcTsARPYUG`,
     blocks:
       'https://api.thegraph.com/subgraphs/name/iliaazhel/avalanche-blocks',

--- a/src/lib/config/avalanche/keys.ts
+++ b/src/lib/config/avalanche/keys.ts
@@ -4,6 +4,7 @@ const keys: Keys = {
   infura: 'daaa68ec242643719749dd1caba2fc66',
   alchemy: 'UrVAqAyukeLVl8hhc29tLtegSoWL9Iuy',
   balancerApi: 'da2-7a3ukmnw7bexndpx5x522uafui',
+  graph: 'a84caa9e5c322a2faec24ad89ccb9d28',
 };
 
 export default keys;

--- a/src/lib/config/gnosis-chain/index.ts
+++ b/src/lib/config/gnosis-chain/index.ts
@@ -1,4 +1,5 @@
 import { Config } from '../types';
+import keys from './keys';
 import contracts from './contracts';
 import pools from './pools';
 import tokenlists from './tokenlists';
@@ -26,16 +27,14 @@ const config: Config = {
   explorer: 'https://gnosisscan.io',
   explorerName: 'Gnosisscan',
   balancerApi: 'https://api.balancer.fi',
-  subgraph:
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gnosis-chain-v2',
+  subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/EJezH1Cp31QkKPaBDerhVPRWsKVZLrDfzjrLqpmv6cGg`,
   poolsUrlV2: '',
   subgraphs: {
     main: [
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gnosis-chain-v2',
+      `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/EJezH1Cp31QkKPaBDerhVPRWsKVZLrDfzjrLqpmv6cGg`,
     ],
     aave: '',
-    gauge:
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-gnosis-chain',
+    gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/HW5XpZBi2iYDLBqqEEMiRJFx8ZJAQak9uu5TzyH9BBxy`,
     blocks: '',
   },
   bridgeUrl: 'https://bridge.gnosischain.com/',

--- a/src/lib/config/gnosis-chain/keys.ts
+++ b/src/lib/config/gnosis-chain/keys.ts
@@ -1,8 +1,6 @@
 import { Keys } from '../types';
 
 const keys: Keys = {
-  infura: 'daaa68ec242643719749dd1caba2fc66',
-  alchemy: '',
   graph: 'a84caa9e5c322a2faec24ad89ccb9d28',
 };
 

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -33,8 +33,7 @@ const config: Config = {
     ],
     aave: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/8wR23o1zkS4gpLqLNU4kG3JHYVucqGyopL5utGxP2q1N`,
     gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/4sESujoqmztX6pbichs4wZ1XXyYrkooMuHA8sKkYxpTn`,
-    blocks:
-      'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
+    blocks: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/236pc6mnPH2EdGJxR5wunibyGsagq1JsSx5e2hx5tdoE`,
   },
   bridgeUrl: '',
   supportsEIP1559: true,

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -23,18 +23,16 @@ const config: Config = {
   ws: ``,
   explorer: 'https://etherscan.io',
   explorerName: 'Etherscan',
-  subgraph: 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2',
+  subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/C4ayEZP2yTXRAB8vSaTrgN4m9anTe9Mdm2ViyiAuV9TV`,
   balancerApi: 'https://api.balancer.fi',
   poolsUrlV2:
     'https://storageapi.fleek.co/johngrantuk-team-bucket/poolsV2.json',
   subgraphs: {
     main: [
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2',
-      `https://gateway.thegraph.com/api/${keys.graph}/subgraphs/id/GAWNgiGrA9eRce5gha9tWc7q5DPvN3fs5rSJ6tEULFNM`,
+      `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/C4ayEZP2yTXRAB8vSaTrgN4m9anTe9Mdm2ViyiAuV9TV`,
     ],
     aave: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v2',
-    gauge:
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges',
+    gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/4sESujoqmztX6pbichs4wZ1XXyYrkooMuHA8sKkYxpTn`,
     blocks:
       'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
   },

--- a/src/lib/config/mainnet/index.ts
+++ b/src/lib/config/mainnet/index.ts
@@ -31,7 +31,7 @@ const config: Config = {
     main: [
       `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/C4ayEZP2yTXRAB8vSaTrgN4m9anTe9Mdm2ViyiAuV9TV`,
     ],
-    aave: 'https://api.thegraph.com/subgraphs/name/aave/protocol-v2',
+    aave: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/8wR23o1zkS4gpLqLNU4kG3JHYVucqGyopL5utGxP2q1N`,
     gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/4sESujoqmztX6pbichs4wZ1XXyYrkooMuHA8sKkYxpTn`,
     blocks:
       'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',

--- a/src/lib/config/mainnet/keys.ts
+++ b/src/lib/config/mainnet/keys.ts
@@ -3,7 +3,7 @@ import { Keys } from '../types';
 const keys: Keys = {
   infura: 'daaa68ec242643719749dd1caba2fc66',
   alchemy: '',
-  graph: '7c7b4c36244b0b86171a3931eaf9bb23',
+  graph: 'a84caa9e5c322a2faec24ad89ccb9d28',
   balancerApi: 'da2-7a3ukmnw7bexndpx5x522uafui',
 };
 

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -34,8 +34,7 @@ const config: Config = {
     ],
     aave: '',
     gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/CbLt7GqU7sypjRaCfwissEBkFeCw3dUz2emrvBNJ7dZu`,
-    blocks:
-      'https://api.thegraph.com/subgraphs/name/iliaazhel/optimism-blocklytics',
+    blocks: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/HsWM1oAXHGWdkH8bK98UrW38PvyPx6Q4waRow2LT8mcp`,
   },
   bridgeUrl: '',
   supportsEIP1559: false,

--- a/src/lib/config/optimism/index.ts
+++ b/src/lib/config/optimism/index.ts
@@ -1,4 +1,5 @@
 import { Config } from '../types';
+import keys from './keys';
 import contracts from './contracts';
 import pools from './pools';
 import tokenlists from './tokenlists';
@@ -24,17 +25,15 @@ const config: Config = {
   blockTime: 13,
   explorer: 'https://optimistic.etherscan.io/',
   explorerName: 'The Optimism Explorer',
-  subgraph:
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-optimism-v2',
+  subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/FsmdxmvBJLGjUQPxKMRtcWKzuCNpomKuMTbSbtRtggZ7`,
   balancerApi: 'https://api.balancer.fi',
   poolsUrlV2: '',
   subgraphs: {
     main: [
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-optimism-v2',
+      `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/FsmdxmvBJLGjUQPxKMRtcWKzuCNpomKuMTbSbtRtggZ7`,
     ],
     aave: '',
-    gauge:
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-optimism',
+    gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/CbLt7GqU7sypjRaCfwissEBkFeCw3dUz2emrvBNJ7dZu`,
     blocks:
       'https://api.thegraph.com/subgraphs/name/iliaazhel/optimism-blocklytics',
   },

--- a/src/lib/config/optimism/keys.ts
+++ b/src/lib/config/optimism/keys.ts
@@ -1,8 +1,6 @@
 import { Keys } from '../types';
 
 const keys: Keys = {
-  infura: 'daaa68ec242643719749dd1caba2fc66',
-  alchemy: '',
   graph: 'a84caa9e5c322a2faec24ad89ccb9d28',
 };
 

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -25,17 +25,15 @@ const config: Config = {
   publicRpc: 'https://polygon-rpc.com',
   explorer: 'https://polygonscan.com',
   explorerName: 'Polygonscan',
-  subgraph:
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2',
+  subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/H9oPAbXnobBRq1cB3HDmbZ1E8MWQyJYQjT1QDJMrdbNp`,
   balancerApi: 'https://api.balancer.fi',
   poolsUrlV2: '',
   subgraphs: {
     main: [
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2',
+      `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/H9oPAbXnobBRq1cB3HDmbZ1E8MWQyJYQjT1QDJMrdbNp`,
     ],
     aave: 'https://api.thegraph.com/subgraphs/name/aave/aave-v2-matic',
-    gauge:
-      'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gauges-polygon',
+    gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/FxSLKXiieSqBCjDGPbqayhqbxyNtwaEC5M3rxr6hUa8h`,
     blocks: 'https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks',
   },
   bridgeUrl: 'https://wallet.polygon.technology/polygon/bridge',

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -32,7 +32,7 @@ const config: Config = {
     main: [
       `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/H9oPAbXnobBRq1cB3HDmbZ1E8MWQyJYQjT1QDJMrdbNp`,
     ],
-    aave: 'https://api.thegraph.com/subgraphs/name/aave/aave-v2-matic',
+    aave: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/H1Et77RZh3XEf27vkAmJyzgCME2RSFLtDS2f4PPW6CGp`,
     gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/FxSLKXiieSqBCjDGPbqayhqbxyNtwaEC5M3rxr6hUa8h`,
     blocks: 'https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks',
   },

--- a/src/lib/config/polygon/index.ts
+++ b/src/lib/config/polygon/index.ts
@@ -34,7 +34,7 @@ const config: Config = {
     ],
     aave: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/H1Et77RZh3XEf27vkAmJyzgCME2RSFLtDS2f4PPW6CGp`,
     gauge: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/FxSLKXiieSqBCjDGPbqayhqbxyNtwaEC5M3rxr6hUa8h`,
-    blocks: 'https://api.thegraph.com/subgraphs/name/ianlapham/polygon-blocks',
+    blocks: `https://gateway-arbitrum.network.thegraph.com/api/${keys.graph}/subgraphs/id/HHpzhtyGrTNSbhtjgZyYG4aG538fKpV21dsCBshLnKDg`,
   },
   bridgeUrl: 'https://wallet.polygon.technology/polygon/bridge',
   supportsEIP1559: true,

--- a/src/lib/config/polygon/keys.ts
+++ b/src/lib/config/polygon/keys.ts
@@ -3,6 +3,7 @@ import { Keys } from '../types';
 const keys: Keys = {
   infura: 'daaa68ec242643719749dd1caba2fc66',
   alchemy: '',
+  graph: 'a84caa9e5c322a2faec24ad89ccb9d28',
 };
 
 export default keys;

--- a/src/providers/cross-chain-sync.provider.spec.ts
+++ b/src/providers/cross-chain-sync.provider.spec.ts
@@ -93,10 +93,10 @@ describe('Returns correct Sync state by network', () => {
 
     expect(networksBySyncState.value).toMatchInlineSnapshot(`
       {
-        "synced": [],
-        "syncing": [
+        "synced": [
           42161,
         ],
+        "syncing": [],
         "unsynced": [
           10,
           100,


### PR DESCRIPTION
# Description

TheGraph is deprecating the hosted service so this PR migrates all relevant endpoints to Studio. API key is public but I've allowlisted only `*.balancer.fi` to use it.

All endpoints are available at https://docs.balancer.fi/reference/subgraph

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [x] I've double-checked the URLs match what we have on docs
- [x] I've accessed every network and clicked on a few pools
- [x] I've verified snapshots load for pools on every network

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas
- [x] If package-lock.json has changes, it was intentional.
- [x] The base of this PR is `master` if hotfix, `develop` if not
